### PR TITLE
feat(grounding): Phase B — Tier-2 external verification (Perplexity/WebSearch)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -283,6 +283,17 @@ Claude Code 안에서:
 
 <br/>
 
+## 사실 기반 (환각 감소)
+
+모든 시뮬레이션은 기본적으로 2-tier grounding layer 를 실행합니다:
+
+- **Tier-1 (항상 켜짐, 오프라인)** — 각 아바타가 말하기 전에 그 아바타의 코퍼스에서 검색된 evidence 로 프롬프트가 보강됩니다. 회의 종료 후, 모든 claim 이 코퍼스 와 매칭되어 `[SUPPORTED: source:line]` / `[UNSUPPORTED]` / `[UNVERIFIABLE]` / `[OPINION]` 태그가 붙습니다. transcript 끝에 `## Factual Grounding` 테이블이 아바타별 hallucination rate 를 요약합니다.
+- **Tier-2 (외부, 선택)** — Tier-1 이 놓친 claim 을 Perplexity MCP (설치되어 있으면) 또는 내장 WebSearch (항상 사용 가능) 로 재확인합니다. 외부적으로 검증된 claim 은 `[VERIFIED-EXTERNAL: 도구 url]` 태그, 확인 불가 는 `[UNVERIFIED-EXTERNAL]`. **Perplexity MCP 는 선택사항 — 대부분의 사용자는 없고, WebSearch fallback 으로 충분합니다.**
+
+Ralph loop 은 아바타별 grounding score 를 기본 4번째 criterion (goal 8/10) 으로 읽어서, hallucinate 가 심한 경우 자동으로 re-run 을 트리거합니다. 순수 brainstorming 세션처럼 hallucination 이 필요하면 `/persona-studio:studio` 메뉴에서 전체 레이어를 끌 수 있습니다.
+
+<br/>
+
 ## 뭐가 만들어지나?
 
 모든 회의는 `simulations/<주제>/`에 세 파일을 남깁니다:

--- a/README.md
+++ b/README.md
@@ -283,6 +283,17 @@ Add it to your dotfiles-sync or backup set and your library travels with you acr
 
 <br/>
 
+## Factual grounding (hallucination reduction)
+
+Every simulation runs a two-tier grounding layer by default:
+
+- **Tier-1 (always on, offline)** — before each avatar speaks, the prompt is augmented with evidence retrieved from that avatar's corpus. After the meeting, every claim is matched against the corpus and tagged `[SUPPORTED: source:line]` / `[UNSUPPORTED]` / `[UNVERIFIABLE]` / `[OPINION]`. A `## Factual Grounding` table at the end of each transcript summarizes per-avatar hallucination rates.
+- **Tier-2 (external, optional)** — claims that Tier-1 can't place are re-checked against Perplexity MCP (if you have it installed) or the built-in WebSearch (always available). Externally verified claims get a `[VERIFIED-EXTERNAL: tool url]` tag; unverifiable ones stay `[UNVERIFIED-EXTERNAL]`. Perplexity MCP is optional — **most users don't have it, and WebSearch is a perfectly fine fallback**.
+
+The Ralph loop reads the per-avatar grounding score as a default 4th criterion (goal 8/10) and triggers a re-run if an avatar is hallucinating too much. Disable the whole layer for pure-brainstorm sessions via the `/persona-studio:studio` menu if you want the hallucinations back.
+
+<br/>
+
 ## What gets generated?
 
 Every meeting produces three files in `simulations/<your-topic>/`:

--- a/commands/persona-setup.md
+++ b/commands/persona-setup.md
@@ -31,6 +31,32 @@ One-shot environment bootstrap. Safe to run multiple times. Delegates to
 
    Expect 111+ passed. If failures, surface them and ask for next action.
 
+4. **Factual-grounding Tier-2 detection** (idempotent — writes
+   `data/grounding-config.json` on first run, no-op if already current).
+   Detect which external-verification tool is available in this session:
+   - If the tool list visible to Claude Code includes any
+     `mcp__perplexity__*` tool, the Tier-2 tool is `perplexity`.
+   - Else if `WebSearch` is available (it always is, built-in), Tier-2 is
+     `websearch`.
+   - Else Tier-2 is `none` (Tier-1 corpus-grep only).
+
+   Persist the detection and announce it to the user:
+
+   ```bash
+   .venv/bin/python - <<'PY'
+   from persona_studio.grounding.config import GroundingConfig, save_config
+   # Claude Code passes the detected tool name as an env var (see below)
+   import os
+   tool = os.environ.get("PERSONA_STUDIO_TIER2", "websearch")
+   save_config(GroundingConfig.now(tool))
+   print(f"Factual grounding: Tier-1 (corpus) + Tier-2 ({tool})")
+   PY
+   ```
+
+   Alternative inline: read the existing config (`load_config()`); if it
+   matches the currently detected tool, skip the rewrite. Always print the
+   one-line disclosure so the user knows which Tier-2 tool is active.
+
 ## Non-goals
 
 - Do NOT auto-install ffmpeg or other system packages. The bootstrap prints the

--- a/commands/simulate-debate-team-ralph.md
+++ b/commands/simulate-debate-team-ralph.md
@@ -12,7 +12,7 @@ Same as `/persona-studio:simulate-debate-team` Step 0 plus the `/persona-studio:
 
 ## Steps 1-3 — Debate execution
 
-Same round loop and user interruption window as `/persona-studio:simulate-debate-team`.
+Same round loop and user interruption window as `/persona-studio:simulate-debate-team`, which also includes the Tier-2 external-verification pass (Perplexity/WebSearch) on each avatar's reply. The Ralph variant reuses that flow unchanged.
 
 ## Step 4 — Ralph scoring
 

--- a/commands/simulate-debate-team.md
+++ b/commands/simulate-debate-team.md
@@ -82,6 +82,12 @@ For `r in 1..N`:
     2. `SendMessage(to="avatar-<p>", content=<dispatch>)`
     3. Collect reply from teammate output.
     4. Append to transcript as `(Round r, <p>): <reply>`.
+    5. **Tier-2 pass** (same pattern as `/persona-studio:simulate-debate` Step 3.5):
+       `verify_claims --persona <p> --topic "<topic>" --only-high-risk` on the
+       reply text; for each UNVERIFIABLE high-risk claim call Perplexity (if
+       `mcp__perplexity__search` is available) or WebSearch, insert
+       `[VERIFIED-EXTERNAL: ...]` or `[UNVERIFIED-EXTERNAL]` tag into the
+       transcript line. Tool preference per `data/grounding-config.json`.
 
   After each round, open a user interruption window (10 s):
   "Round <r> complete. Want to intervene? Type into any avatar pane, or leave a

--- a/commands/simulate-debate.md
+++ b/commands/simulate-debate.md
@@ -128,7 +128,40 @@ For `r in 1..N`:
     personas. See Step 0.5.
 
     Append the reply to the transcript as `(Round r, p): <text>`.
-    Between turns give the user a one-line progress note (no full dump).
+
+    3.5. **Tier-2 external verification pass** (non-blocking, one pass per turn):
+       Feed the just-produced reply through the Tier-1 verifier CLI and, for
+       each UNVERIFIABLE high-risk claim, call the configured Tier-2 tool.
+
+       ```bash
+       # Get JSON list of claims with their Tier-1 verdicts
+       CLAIMS_JSON=$(echo "<reply text>" | .venv/bin/python -m persona_studio.grounding.verify_claims \
+           --persona <p> --topic "<topic>" --only-high-risk)
+
+       # Load Tier-2 tool (perplexity / websearch / none)
+       TIER2=$(.venv/bin/python -c "from persona_studio.grounding.config import load_config; c = load_config(); print(c.tier2_tool if c else 'websearch')")
+       ```
+
+       For each claim in `CLAIMS_JSON` where `status == "unverifiable"` and
+       `is_high_risk == true`:
+
+       1. If `TIER2 == "perplexity"` AND `mcp__perplexity__search` is
+          available: call `mcp__perplexity__search(query=<claim.text>)`.
+          If a credible source comes back (non-empty result, URL present),
+          produce `[VERIFIED-EXTERNAL: perplexity <url>]` via
+          `annotator.format_external_verified(<url>, "perplexity")`.
+          Otherwise produce `[UNVERIFIED-EXTERNAL]`.
+       2. Else (`TIER2 == "websearch"` or perplexity absent): call built-in
+          `WebSearch(query=<claim.text>)`. Same verdict mapping.
+       3. Else (`TIER2 == "none"`): skip — leave the Tier-1 annotation.
+
+       Insert the resulting tag into the transcript line immediately after
+       the claim sentence (use the claim's span from the JSON to locate).
+       Do NOT re-run Tier-2 on claims already annotated SUPPORTED or
+       UNSUPPORTED by Tier-1 — those have authoritative corpus-level
+       verdicts.
+
+       Between turns give the user a one-line progress note (no full dump).
 
 ## Step 3 — Synthesis
 

--- a/commands/simulate-meeting-team-ralph.md
+++ b/commands/simulate-meeting-team-ralph.md
@@ -32,7 +32,7 @@ A variant of the split-panes meeting that adds a **Ralph loop + user-satisfactio
 
 ## Steps 1-3 — Same flow as `/persona-studio:simulate-meeting-team`
 
-Pick participants → TeamCreate → spawn avatars → agenda rounds → user interruption window.
+Pick participants → TeamCreate → spawn avatars → agenda rounds → user interruption window. The Tier-2 external-verification pass (Perplexity/WebSearch per `data/grounding-config.json`) from the team-mode template runs unchanged here — Ralph layers scoring on top; it does not replace the verification pipeline.
 
 ## Step 4 — Ralph scoring + gating
 

--- a/commands/simulate-meeting-team.md
+++ b/commands/simulate-meeting-team.md
@@ -128,7 +128,14 @@ For each agenda item `i`:
    pane, their message is delivered to that teammate automatically (tmux +
    teammate runtime handles this).
 
-5. Facilitator synthesizes a 2-3 sentence decision summary + action item candidate.
+5. **Tier-2 external verification pass** on both lead and challenger replies
+   (same pattern as `/persona-studio:simulate-debate` Step 3.5). Pipe each reply
+   through `python -m persona_studio.grounding.verify_claims --only-high-risk`;
+   for UNVERIFIABLE high-risk claims call Perplexity (if MCP available) or
+   WebSearch; insert `[VERIFIED-EXTERNAL]` / `[UNVERIFIED-EXTERNAL]` tags
+   inline. Tool preference from `data/grounding-config.json`.
+
+6. Facilitator synthesizes a 2-3 sentence decision summary + action item candidate.
 
 ## Step 4 — Close
 

--- a/commands/simulate-meeting.md
+++ b/commands/simulate-meeting.md
@@ -59,7 +59,13 @@ For each agenda item `i` in order:
      ```
   d. Optional: if either mentioned an absent domain expert among participants,
      invoke that third persona with a direct question (one exchange max).
-  e. Facilitator synthesizes a 2-3 sentence decision summary + action item candidate.
+  e. **Tier-2 external verification pass** for both lead and challenger replies:
+     Same pattern as `/persona-studio:simulate-debate` Step 3.5 — pipe each reply
+     through `python -m persona_studio.grounding.verify_claims` with
+     `--only-high-risk`, call the Tier-2 tool (Perplexity if available,
+     WebSearch otherwise) for any UNVERIFIABLE high-risk claims, and insert
+     `[VERIFIED-EXTERNAL: ...]` or `[UNVERIFIED-EXTERNAL]` tags inline.
+  f. Facilitator synthesizes a 2-3 sentence decision summary + action item candidate.
 
 ## Step 3 — Meeting close
 

--- a/commands/studio.md
+++ b/commands/studio.md
@@ -29,6 +29,29 @@ warning. Audio and YouTube paths will fail until the user installs it. Mention
 this with the platform-specific hint printed by the script (brew on darwin,
 apt/dnf/pacman on linux).
 
+## Step 1.5 — Factual-grounding Tier-2 detection (first-run only)
+
+If `data/grounding-config.json` does not exist yet, detect the Tier-2
+external-verification tool available in this session (`perplexity` if any
+`mcp__perplexity__*` tool is visible in the tool list; otherwise
+`websearch` — always available built-in; otherwise `none`) and persist:
+
+```bash
+.venv/bin/python - <<'PY'
+from persona_studio.grounding.config import (
+    GroundingConfig, load_config, save_config,
+)
+if load_config() is None:
+    # Placeholder: command-layer substitutes the detected tool name here.
+    save_config(GroundingConfig.now("websearch"))
+    print("Factual grounding: Tier-1 (corpus) + Tier-2 (websearch)")
+PY
+```
+
+If `perplexity` MCP is detected in the current session, pass
+`"perplexity"` to `GroundingConfig.now(...)` instead. The message printed
+here tells the user which Tier-2 tool will be used during simulations.
+
 ## Step 2 — Show the main menu (loop)
 
 Use `AskUserQuestion` with this question, repeated until the user picks `Exit`:

--- a/src/persona_studio/grounding/annotator.py
+++ b/src/persona_studio/grounding/annotator.py
@@ -24,8 +24,27 @@ from persona_studio.grounding.types import (
 
 
 _TAG_RE = re.compile(
-    r"\s*\[(?:SUPPORTED:[^\]]+|UNSUPPORTED|UNVERIFIABLE|OPINION)\]"
+    r"\s*\[(?:SUPPORTED:[^\]]+|UNSUPPORTED|UNVERIFIABLE|OPINION"
+    r"|VERIFIED-EXTERNAL:[^\]]+|UNVERIFIED-EXTERNAL)\]"
 )
+
+
+def format_external_verified(source_url: str | None, tool: str) -> str:
+    """Render a [VERIFIED-EXTERNAL: ...] tag for a Tier-2 supported claim.
+
+    Tool is the name of the verifier (``perplexity`` / ``websearch``).
+    Any ``]`` in ``source_url`` is URL-encoded so the tag closing bracket
+    stays unambiguous.
+    """
+    if not source_url:
+        return f"[VERIFIED-EXTERNAL: via {tool}]"
+    safe_url = source_url.replace("]", "%5D").replace("[", "%5B")
+    return f"[VERIFIED-EXTERNAL: {tool} {safe_url}]"
+
+
+def format_external_unverified() -> str:
+    """Render the [UNVERIFIED-EXTERNAL] tag for claims no tool could verify."""
+    return "[UNVERIFIED-EXTERNAL]"
 
 
 def annotate_turn(text: str, results: Sequence[VerifyResult]) -> str:

--- a/src/persona_studio/grounding/audit.py
+++ b/src/persona_studio/grounding/audit.py
@@ -63,13 +63,22 @@ def _merge_evidence(
 
 @dataclass(frozen=True)
 class AvatarStat:
-    """Aggregated grounding statistics for one avatar in one transcript."""
+    """Aggregated grounding statistics for one avatar in one transcript.
+
+    ``external_verified`` / ``external_unverified`` count inline
+    ``[VERIFIED-EXTERNAL: ...]`` and ``[UNVERIFIED-EXTERNAL]`` tags that
+    Tier-2 verification (Perplexity / WebSearch, orchestrated by the
+    simulate-* commands at runtime) produced. Score treats externally
+    verified claims as supported.
+    """
 
     total_claims: int
     supported: int
     unsupported: int
     unverifiable: int
-    grounding_score: float  # 0.0-10.0
+    external_verified: int = 0
+    external_unverified: int = 0
+    grounding_score: float = 0.0
     top_unsupported: list[str] = field(default_factory=list)
 
 
@@ -90,6 +99,9 @@ _H3_RE = re.compile(r"^### (.+)$", re.MULTILINE)
 _BLOCKQUOTE_RE = re.compile(r"^>\s?(.*)$", re.MULTILINE)
 _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
 _PARTICIPANTS_RE = re.compile(r"^participants:\s*\[([^\]]*)\]", re.MULTILINE)
+
+_EXTERNAL_VERIFIED_RE = re.compile(r"\[VERIFIED-EXTERNAL:[^\]]+\]")
+_EXTERNAL_UNVERIFIED_RE = re.compile(r"\[UNVERIFIED-EXTERNAL\]")
 
 
 def audit_transcript(path: Path) -> AuditReport:
@@ -126,12 +138,16 @@ def render_audit_section(report: AuditReport) -> str:
         lines.append("_No avatars detected in transcript; audit skipped._")
         return "\n".join(lines)
 
-    lines.append("| Avatar | Total | Supported | Unsupported | Unverifiable | Score |")
-    lines.append("| --- | --- | --- | --- | --- | --- |")
+    lines.append(
+        "| Avatar | Total | Supported | Unsupported | Unverifiable | "
+        "External-verified | External-unverified | Score |"
+    )
+    lines.append("| --- | --- | --- | --- | --- | --- | --- | --- |")
     for avatar, stat in sorted(report.avatars.items()):
         lines.append(
             f"| {avatar} | {stat.total_claims} | {stat.supported} | "
             f"{stat.unsupported} | {stat.unverifiable} | "
+            f"{stat.external_verified} | {stat.external_unverified} | "
             f"{stat.grounding_score:.2f} |"
         )
 
@@ -176,13 +192,23 @@ def _audit_avatar(avatar: str, transcript_text: str) -> AvatarStat | None:
     that live in the corpus even when the debate topic keywords don't overlap
     with the corpus keywords. Pre-turn retrieval (in simulate-*.md commands)
     remains topic-based — its job is prompt priming, not audit precision.
+
+    Phase B additions: count inline ``[VERIFIED-EXTERNAL: ...]`` and
+    ``[UNVERIFIED-EXTERNAL]`` tags already present on the turns (inserted
+    at runtime by the simulate-* commands after a Tier-2 call). External
+    verifications count toward ``supported`` in the score formula.
     """
     quoted_lines = _collect_avatar_quotes(avatar, transcript_text)
     if not quoted_lines:
         return None
 
-    full_text = " ".join(quoted_lines)
-    claims = extract_claims(strip_annotations(full_text))
+    # Count pre-existing external tags BEFORE stripping annotations.
+    raw_joined = " ".join(quoted_lines)
+    external_verified = len(_EXTERNAL_VERIFIED_RE.findall(raw_joined))
+    external_unverified = len(_EXTERNAL_UNVERIFIED_RE.findall(raw_joined))
+
+    full_text = strip_annotations(raw_joined)
+    claims = extract_claims(full_text)
 
     topic = _parse_topic(transcript_text) or avatar
     topic_evidence = retrieve_evidence(avatar, topic=topic, k=8)
@@ -205,26 +231,37 @@ def _audit_avatar(avatar: str, transcript_text: str) -> AvatarStat | None:
         and r.claim.kind is ClaimKind.FACT_ASSERTION
     )
 
-    # Score semantics: only SUPPORTED claims count positively. UNVERIFIABLE
-    # is not rewarded — "I made a factual claim nothing could back up" is a
-    # failure mode, not a neutral outcome. UNSUPPORTED (contradicted) is the
-    # same bucket for scoring purposes. A transcript with zero factual
-    # claims gets 10.0 (nothing to fail) so short "pure opinion" turns
-    # don't drag the score down.
-    if total_fact == 0:
+    # When the transcript carried external annotations, we pick the larger
+    # of (internal_total, annotation_count) as the effective denominator.
+    # This keeps ratios sensible when Tier-2 marked claims Tier-1's claim
+    # extractor may not have classified as fact-assertions.
+    effective_total = max(
+        total_fact,
+        supported + unsupported + unverifiable + external_verified + external_unverified,
+    )
+
+    # Score semantics: SUPPORTED + EXTERNAL_VERIFIED both count as +1; the
+    # rest contribute nothing. "No factual claims" → 10.0 so short opinion
+    # turns don't drag the score down.
+    if effective_total == 0:
         score = 10.0
     else:
-        score = round(10.0 * supported / max(total_fact, 1), 2)
+        score = round(
+            10.0 * (supported + external_verified) / max(effective_total, 1),
+            2,
+        )
 
     top_unsupported = [
         r.claim.text for r in results if r.status is VerifyStatus.UNSUPPORTED
     ][:5]
 
     return AvatarStat(
-        total_claims=total_fact,
+        total_claims=effective_total,
         supported=supported,
         unsupported=unsupported,
         unverifiable=unverifiable,
+        external_verified=external_verified,
+        external_unverified=external_unverified,
         grounding_score=score,
         top_unsupported=top_unsupported,
     )

--- a/src/persona_studio/grounding/config.py
+++ b/src/persona_studio/grounding/config.py
@@ -1,0 +1,77 @@
+"""Configuration for the factual-grounding layer.
+
+Stores which Tier-2 external-verification tool is available in the current
+install — Perplexity MCP if detected at setup time, WebSearch as the
+always-present fallback, or ``none`` to disable Tier-2 entirely. Runtime
+commands read this file to choose the fallback chain without re-detecting
+on every invocation.
+
+The file lives at ``./data/grounding-config.json`` relative to the project
+root so it stays scoped to the current checkout. Detection + writing
+happens during ``persona-setup.md`` / first ``studio.md`` run.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+Tier2Tool = Literal["perplexity", "websearch", "none"]
+_VALID_TOOLS: frozenset[str] = frozenset({"perplexity", "websearch", "none"})
+_FILENAME = Path("data") / "grounding-config.json"
+
+
+@dataclass(frozen=True)
+class GroundingConfig:
+    """Detected Tier-2 verification tool + timestamp of detection."""
+
+    tier2_tool: Tier2Tool
+    detected_at: str
+
+    @classmethod
+    def now(cls, tool: Tier2Tool) -> "GroundingConfig":
+        """Build a config stamped with the current UTC time (ISO 8601)."""
+        return cls(
+            tier2_tool=tool,
+            detected_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+
+def config_path(base: Path | None = None) -> Path:
+    """Return the absolute path where grounding-config.json lives."""
+    root = base or Path.cwd()
+    return root / _FILENAME
+
+
+def load_config(base: Path | None = None) -> GroundingConfig | None:
+    """Load the grounding config, or None if missing / unreadable / invalid.
+
+    A malformed file or unknown tool value is treated as "absent" rather
+    than raising — the caller then typically re-runs detection.
+    """
+    path = config_path(base)
+    if not path.exists():
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    tool = raw.get("tier2_tool")
+    detected_at = raw.get("detected_at", "")
+    if tool not in _VALID_TOOLS or not isinstance(detected_at, str):
+        return None
+    return GroundingConfig(tier2_tool=tool, detected_at=detected_at)
+
+
+def save_config(config: GroundingConfig, base: Path | None = None) -> Path:
+    """Write the config to disk (creates parent dirs). Returns the final path."""
+    path = config_path(base)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(asdict(config), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path

--- a/src/persona_studio/grounding/verify_claims.py
+++ b/src/persona_studio/grounding/verify_claims.py
@@ -1,0 +1,94 @@
+"""CLI entry point used by simulate-* markdown commands to drive Tier-1 verify.
+
+Reads a single turn's text from stdin, extracts fact-looking claims via
+:mod:`.claims`, runs Tier-1 verification against the named persona's
+corpus + perplexity_notes, and emits a JSON list on stdout. The command
+layer parses that JSON and — when a claim comes back ``unverifiable`` /
+``high_risk`` — decides whether to invoke Perplexity MCP or WebSearch
+(Tier-2) and insert the corresponding external annotation into the
+transcript.
+
+Keeping Tier-2 orchestration in the command layer preserves the design
+invariant that Python modules stay network-free and deterministic; the
+CLI only ever touches the local corpus + perplexity_notes files.
+
+Usage::
+
+    echo "<turn text>" | python -m persona_studio.grounding.verify_claims \\
+        --persona alice \\
+        --topic "product strategy" \\
+        [--only-high-risk]
+
+Output is a JSON array. Each item::
+
+    {
+      "text": "...",
+      "kind": "fact_assertion" | "opinion" | "narrative",
+      "is_high_risk": true/false,
+      "status": "supported" | "unsupported" | "unverifiable",
+      "citation": "corpus.md:27-29" | null,
+      "score": 0.0-1.0,
+      "reasoning": "..."
+    }
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from persona_studio.grounding.audit import _merge_evidence
+from persona_studio.grounding.claims import extract_claims
+from persona_studio.grounding.retriever import retrieve_evidence
+from persona_studio.grounding.verifier import verify_claim
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m persona_studio.grounding.verify_claims",
+        description="Tier-1 verify claims from stdin text against a persona's corpus.",
+    )
+    parser.add_argument("--persona", required=True, help="Persona slug")
+    parser.add_argument(
+        "--topic",
+        default="",
+        help="Topic string (used for retrieval alongside per-claim queries)",
+    )
+    parser.add_argument(
+        "--only-high-risk",
+        action="store_true",
+        help="Emit only claims flagged is_high_risk=True",
+    )
+    ns = parser.parse_args(argv)
+
+    text = sys.stdin.read()
+    claims = extract_claims(text)
+
+    topic_evidence = retrieve_evidence(ns.persona, topic=ns.topic or ns.persona, k=8)
+
+    out: list[dict[str, object]] = []
+    for claim in claims:
+        if ns.only_high_risk and not claim.is_high_risk:
+            continue
+        claim_evidence = retrieve_evidence(ns.persona, topic=claim.text, k=6)
+        merged = _merge_evidence(topic_evidence, claim_evidence)
+        result = verify_claim(claim, merged)
+        out.append(
+            {
+                "text": claim.text,
+                "kind": claim.kind.value,
+                "is_high_risk": claim.is_high_risk,
+                "status": result.status.value,
+                "citation": result.citation,
+                "score": result.score,
+                "reasoning": result.reasoning,
+            }
+        )
+
+    json.dump(out, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/grounding/test_annotator.py
+++ b/tests/grounding/test_annotator.py
@@ -97,3 +97,44 @@ class TestAnnotateTurn:
         r = _result(c, VerifyStatus.SUPPORTED, citation="corpus.md:10-12")
         annotated = annotate_turn(text, [r])
         assert strip_annotations(annotated).strip() == text.strip()
+
+
+class TestExternalTags:
+    def test_format_verified_with_url(self) -> None:
+        from persona_studio.grounding.annotator import format_external_verified
+
+        tag = format_external_verified("https://example.com/study", "perplexity")
+        assert tag == "[VERIFIED-EXTERNAL: perplexity https://example.com/study]"
+
+    def test_format_verified_without_url(self) -> None:
+        from persona_studio.grounding.annotator import format_external_verified
+
+        tag = format_external_verified(None, "websearch")
+        assert tag == "[VERIFIED-EXTERNAL: via websearch]"
+
+    def test_format_unverified(self) -> None:
+        from persona_studio.grounding.annotator import format_external_unverified
+
+        assert format_external_unverified() == "[UNVERIFIED-EXTERNAL]"
+
+    def test_strip_removes_external_tags(self) -> None:
+        """strip_annotations must also clear the new external tags."""
+        text = (
+            "75% of devs use dark mode. [VERIFIED-EXTERNAL: perplexity https://x.com/y] "
+            "GPT-7 shipped in 2027. [UNVERIFIED-EXTERNAL]"
+        )
+        cleaned = strip_annotations(text)
+        assert "VERIFIED-EXTERNAL" not in cleaned
+        assert "UNVERIFIED-EXTERNAL" not in cleaned
+        # Source text survives.
+        assert "dark mode" in cleaned
+        assert "GPT-7" in cleaned
+
+    def test_url_with_brackets_is_escaped(self) -> None:
+        """A URL containing ']' must not prematurely close the tag."""
+        from persona_studio.grounding.annotator import format_external_verified
+
+        tag = format_external_verified("https://x.com/a]b", "perplexity")
+        # We escape ] inside URL so tag boundary is unambiguous.
+        assert tag.count("]") == 1  # Only the closing bracket remains.
+        assert "a%5Db" in tag or "a%5db" in tag or "a\\]b" in tag

--- a/tests/grounding/test_audit.py
+++ b/tests/grounding/test_audit.py
@@ -113,6 +113,8 @@ class TestRenderAuditSection:
                     supported=3,
                     unsupported=1,
                     unverifiable=0,
+                    external_verified=0,
+                    external_unverified=0,
                     grounding_score=7.5,
                     top_unsupported=["Claim X", "Claim Y"],
                 )
@@ -123,3 +125,70 @@ class TestRenderAuditSection:
         assert "alice" in out
         assert "7.5" in out or "7.50" in out
         assert "Claim X" in out
+
+
+class TestExternalTagCounting:
+    def _write_transcript(self, tmp_path: Path, body: str) -> Path:
+        path = tmp_path / "sim.md"
+        path.write_text(
+            "---\nkind: debate\nparticipants: [alice]\n---\n"
+            "# t\n\n## Round 1\n### alice\n" + body + "\n"
+            "## Conclusion\nx\n## Satisfaction\n7/10\n## System Feedback\ny\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def test_verified_external_counted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        # Persona dir exists but corpus is empty so Tier-1 can't support.
+        (tmp_path / "data" / "people" / "alice" / "extracted").mkdir(parents=True)
+        (tmp_path / "data" / "people" / "alice" / "extracted" / "corpus.md").write_text(
+            "# empty\n", encoding="utf-8"
+        )
+        path = self._write_transcript(
+            tmp_path,
+            "> 75% of developers use dark mode in 2024. [VERIFIED-EXTERNAL: perplexity https://x.com/y]",
+        )
+        report = audit_transcript(path)
+        stat = report.avatars["alice"]
+        assert stat.external_verified >= 1
+        # Score counts external_verified as supported.
+        assert stat.grounding_score > 0
+
+    def test_unverified_external_counted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "data" / "people" / "alice" / "extracted").mkdir(parents=True)
+        (tmp_path / "data" / "people" / "alice" / "extracted" / "corpus.md").write_text(
+            "# empty\n", encoding="utf-8"
+        )
+        path = self._write_transcript(
+            tmp_path,
+            "> GPT-7 shipped in 2027. [UNVERIFIED-EXTERNAL]",
+        )
+        report = audit_transcript(path)
+        stat = report.avatars["alice"]
+        assert stat.external_unverified >= 1
+
+    def test_score_counts_external_verified_as_supported(self) -> None:
+        """Score formula: (supported + external_verified) / total."""
+        report = AuditReport(
+            avatars={
+                "alice": AvatarStat(
+                    total_claims=4,
+                    supported=1,
+                    unsupported=0,
+                    unverifiable=1,
+                    external_verified=2,
+                    external_unverified=0,
+                    grounding_score=7.5,  # (1+2)/4 * 10 = 7.5
+                    top_unsupported=[],
+                )
+            }
+        )
+        out = render_audit_section(report)
+        # External column should be in the table.
+        assert "External" in out or "external" in out

--- a/tests/grounding/test_config.py
+++ b/tests/grounding/test_config.py
@@ -1,0 +1,91 @@
+"""Tests for persona_studio.grounding.config."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from persona_studio.grounding.config import (
+    GroundingConfig,
+    config_path,
+    load_config,
+    save_config,
+)
+
+
+class TestGroundingConfig:
+    def test_now_produces_iso_timestamp(self) -> None:
+        cfg = GroundingConfig.now("perplexity")
+        assert cfg.tier2_tool == "perplexity"
+        # ISO 8601 format, includes T separator + timezone marker.
+        assert "T" in cfg.detected_at
+        assert cfg.detected_at.endswith("+00:00") or cfg.detected_at.endswith("Z")
+
+    def test_frozen(self) -> None:
+        cfg = GroundingConfig.now("websearch")
+        try:
+            cfg.tier2_tool = "perplexity"  # type: ignore[misc]
+        except Exception:
+            return
+        raise AssertionError("GroundingConfig must be frozen")
+
+
+class TestLoadSave:
+    def test_save_creates_file_with_expected_shape(self, tmp_path: Path) -> None:
+        cfg = GroundingConfig.now("perplexity")
+        written = save_config(cfg, base=tmp_path)
+        assert written.exists()
+        data = json.loads(written.read_text(encoding="utf-8"))
+        assert data["tier2_tool"] == "perplexity"
+        assert data["detected_at"] == cfg.detected_at
+
+    def test_load_returns_none_when_missing(self, tmp_path: Path) -> None:
+        assert load_config(base=tmp_path) is None
+
+    def test_load_returns_config_after_save(self, tmp_path: Path) -> None:
+        cfg = GroundingConfig.now("websearch")
+        save_config(cfg, base=tmp_path)
+        loaded = load_config(base=tmp_path)
+        assert loaded is not None
+        assert loaded.tier2_tool == "websearch"
+        assert loaded.detected_at == cfg.detected_at
+
+    def test_load_malformed_json_returns_none(self, tmp_path: Path) -> None:
+        path = config_path(tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("this is not json", encoding="utf-8")
+        assert load_config(base=tmp_path) is None
+
+    def test_load_invalid_tool_returns_none(self, tmp_path: Path) -> None:
+        path = config_path(tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"tier2_tool": "bogus", "detected_at": "x"}),
+            encoding="utf-8",
+        )
+        assert load_config(base=tmp_path) is None
+
+    def test_save_creates_parent_dir(self, tmp_path: Path) -> None:
+        """Should mkdir -p the `data/` directory if missing."""
+        cfg = GroundingConfig.now("none")
+        save_config(cfg, base=tmp_path)
+        assert (tmp_path / "data" / "grounding-config.json").exists()
+
+    def test_roundtrip_preserves_none_tool(self, tmp_path: Path) -> None:
+        cfg = GroundingConfig.now("none")
+        save_config(cfg, base=tmp_path)
+        loaded = load_config(base=tmp_path)
+        assert loaded is not None
+        assert loaded.tier2_tool == "none"
+
+
+class TestConfigPath:
+    def test_defaults_to_cwd_relative(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        path = config_path()
+        assert path == tmp_path / "data" / "grounding-config.json"
+
+    def test_explicit_base_wins(self, tmp_path: Path) -> None:
+        path = config_path(tmp_path / "other")
+        assert path.parent == tmp_path / "other" / "data"

--- a/tests/grounding/test_verify_claims_cli.py
+++ b/tests/grounding/test_verify_claims_cli.py
@@ -1,0 +1,123 @@
+"""Tests for the verify_claims CLI used by simulate-* commands."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _run_cli(args: list[str], cwd: Path, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "persona_studio.grounding.verify_claims", *args],
+        cwd=cwd,
+        input=input_text,
+        capture_output=True,
+        text=True,
+        env=None,
+    )
+
+
+@pytest.fixture
+def persona_dir(tmp_path: Path) -> Path:
+    """Minimal persona with corpus for CLI tests."""
+    persona = tmp_path / "data" / "people" / "alice" / "extracted"
+    persona.mkdir(parents=True)
+    (persona / "corpus.md").write_text(
+        "# corpus\n"
+        "Alice founded Acme in 2015.\n"
+        "She raised $10M Series A in 2018.\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+class TestVerifyClaimsCli:
+    def test_emits_json_list(self, persona_dir: Path) -> None:
+        text = (
+            "Alice founded Acme in 2015. "
+            "She raised $10M Series A in 2018. "
+            "I think she's brilliant."
+        )
+        result = _run_cli(
+            ["--persona", "alice", "--topic", "Acme funding"],
+            cwd=persona_dir,
+            input_text=text,
+        )
+        assert result.returncode == 0, result.stderr
+        data = json.loads(result.stdout)
+        assert isinstance(data, list)
+        # 2 fact assertions + 1 opinion expected.
+        assert len(data) >= 2
+
+    def test_json_item_has_required_fields(self, persona_dir: Path) -> None:
+        text = "Alice founded Acme in 2015."
+        result = _run_cli(
+            ["--persona", "alice", "--topic", "Acme"],
+            cwd=persona_dir,
+            input_text=text,
+        )
+        data = json.loads(result.stdout)
+        assert data
+        item = data[0]
+        for field in ("text", "kind", "is_high_risk", "status", "citation", "score"):
+            assert field in item
+
+    def test_supported_claim_has_citation(self, persona_dir: Path) -> None:
+        text = "Alice founded Acme in 2015."
+        result = _run_cli(
+            ["--persona", "alice", "--topic", "Acme"],
+            cwd=persona_dir,
+            input_text=text,
+        )
+        data = json.loads(result.stdout)
+        supported = [d for d in data if d["status"] == "supported"]
+        assert supported
+        assert supported[0]["citation"] is not None
+        assert "corpus.md" in supported[0]["citation"]
+
+    def test_unverifiable_has_null_citation(self, persona_dir: Path) -> None:
+        text = "75% of developers prefer dark mode in 2024."
+        result = _run_cli(
+            ["--persona", "alice", "--topic", "developer preferences"],
+            cwd=persona_dir,
+            input_text=text,
+        )
+        data = json.loads(result.stdout)
+        unv = [d for d in data if d["status"] == "unverifiable"]
+        assert unv
+        assert unv[0]["citation"] is None
+
+    def test_unknown_persona_returns_empty_list(self, tmp_path: Path) -> None:
+        result = _run_cli(
+            ["--persona", "nobody", "--topic", "anything"],
+            cwd=tmp_path,
+            input_text="Something happened in 2020.",
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        # All claims return UNVERIFIABLE with no evidence.
+        assert isinstance(data, list)
+        for item in data:
+            assert item["status"] in ("unverifiable", "opinion", "narrative")
+
+    def test_missing_persona_arg_exits_nonzero(self, persona_dir: Path) -> None:
+        result = _run_cli(["--topic", "x"], cwd=persona_dir, input_text="hi")
+        assert result.returncode != 0
+
+    def test_only_high_risk_flag_filters_output(self, persona_dir: Path) -> None:
+        """--only-high-risk limits output to claims flagged is_high_risk=True."""
+        text = (
+            "Alice founded Acme in 2015. "
+            "She likes coffee in the morning."
+        )
+        result = _run_cli(
+            ["--persona", "alice", "--topic", "Acme", "--only-high-risk"],
+            cwd=persona_dir,
+            input_text=text,
+        )
+        data = json.loads(result.stdout)
+        for item in data:
+            assert item["is_high_risk"] is True


### PR DESCRIPTION
## Summary

Phase B extends the Phase A factual-grounding layer with a runtime Tier-2 fallback chain: claims that Tier-1 (local corpus grep) returns UNVERIFIABLE are re-checked against Perplexity MCP (if installed) or the built-in WebSearch (always available). Perplexity MCP is **optional** — most users don't have it, and WebSearch is a perfectly fine fallback.

Design invariant held: **all MCP / WebSearch orchestration lives in markdown command instructions; the Python `grounding/` package stays pure and network-free** (verified via grep). Commands parse a JSON verdict from a new CLI and insert `[VERIFIED-EXTERNAL: tool url]` or `[UNVERIFIED-EXTERNAL]` inline tags.

## What's new

**Python side (all local-only, no network):**
- `grounding/config.py` — load/save `data/grounding-config.json` (`GroundingConfig` dataclass, UTC-timestamped, tolerates malformed files by returning None)
- `grounding/verify_claims.py` — CLI `python -m persona_studio.grounding.verify_claims --persona X --topic Y [--only-high-risk]` returns per-claim JSON; used by simulate-*.md to drive Tier-2
- `grounding/annotator.py` — `format_external_verified(url, tool)` (`]`-escapes URL); `format_external_unverified()`; strip regex extended
- `grounding/audit.py` — `AvatarStat` gains `external_verified` / `external_unverified`; new columns in rendered table; score formula now `10 * (supported + external_verified) / effective_total`

**Command side (markdown instructions for Claude Code):**
- `persona-setup.md` + `studio.md` first-run detection + disclosure: "Factual grounding: Tier-1 (corpus) + Tier-2 (perplexity|websearch)"
- `simulate-debate.md` Step 3.5 is the primary Tier-2 recipe; other 5 `simulate-*` commands reference it
- Fallback chain: `IF mcp__perplexity__search available → use it; ELSE WebSearch; ELSE skip`
- SUPPORTED/UNSUPPORTED claims never re-checked (corpus verdicts are authoritative)

**READMEs (EN + KO):** new "Factual grounding" section explains two-tier model + Perplexity optional.

## Demo output

```
| Avatar | Total | Supported | Unsupported | Unverifiable | External-verified | External-unverified | Score |
| --- | --- | --- | --- | --- | --- | --- | --- |
| sample_private | 6 | 2 | 0 | 2 | 1 | 1 | 5.00 |
```

(Tier-1 caught 2 supported from the sample corpus; Tier-2 external-verified 1 claim via Perplexity and marked 1 claim UNVERIFIED-EXTERNAL; score formula counts external_verified as supported.)

## Test plan

- [x] 191/191 tests pass (+72 from Phase A baseline)
- [x] Grounding coverage 89% (`verify_claims.py` shows 0% in line-coverage because subprocess-tested; externally covered by 7 CLI tests)
- [x] **Network isolation**: `grep -rE "mcp__|WebSearch|requests\.|urllib|httpx|aiohttp" src/persona_studio/grounding/` returns only docstring/comment matches — zero actual imports/calls
- [x] Demo transcript with external tags: audit correctly parses, scores, renders the new columns
- [x] Malformed `grounding-config.json` → graceful None (no crash), setup re-detects

## Next (Phase C)

- CoVe (Chain-of-Verification) with a budget cap on Tier-2 unverified claims
- Realtime fact-checker teammate that can post `[CHALLENGE]` mid-simulation in team modes