### PR TITLE
feat(grounding): Phase C — CoVe + realtime fact-checker teammate

### DIFF
--- a/commands/simulate-debate-team-ralph.md
+++ b/commands/simulate-debate-team-ralph.md
@@ -14,6 +14,8 @@ Same as `/persona-studio:simulate-debate-team` Step 0 plus the `/persona-studio:
 
 Same round loop and user interruption window as `/persona-studio:simulate-debate-team`, which also includes the Tier-2 external-verification pass (Perplexity/WebSearch) on each avatar's reply. The Ralph variant reuses that flow unchanged.
 
+The silent **`fact-checker` teammate spawn + CoVe routing** from the parent `/persona-studio:simulate-debate-team` (Step 2.5 spawn, Step 3.6 SendMessage routing, `COVE_BUDGET_PER_AVATAR=5`) runs unchanged under Ralph scoring — each iteration re-spawns the fact-checker and resets `COVE_USED_<p>=0`.
+
 ## Step 4 — Ralph scoring
 
 After N rounds complete:

--- a/commands/simulate-debate-team.md
+++ b/commands/simulate-debate-team.md
@@ -50,7 +50,60 @@ the teammate SYSTEM prompt's PROTOCOL section:
 - Do NOT initiate turns on your own. Wait for dispatch.
 ```
 
+### Step 2.5 — Spawn silent fact-checker teammate
+
+In addition to the avatar teammates, spawn ONE extra teammate that never
+speaks in the debate but verifies claims for the facilitator:
+
+```
+Task(
+  subagent_type="general-purpose",
+  name="fact-checker",
+  team_name=team_id,
+  prompt="""
+    You are a SILENT fact-checker. You NEVER speak in the debate. Your job:
+
+    1. When the facilitator sends you a message containing an avatar turn
+       plus its EVIDENCE BANK, extract factual claims via:
+         .venv/bin/python -m persona_studio.grounding.verify_claims \\
+             --persona <avatar> --topic <topic> --only-high-risk
+       (the avatar slug and topic are in the facilitator's message header).
+
+    2. For each UNVERIFIABLE high-risk claim, run Chain-of-Verification
+       (CoVe) via the two cove.py CLI modes:
+         a. printf '%s' "<claim>" | .venv/bin/python \\
+                -m persona_studio.grounding.cove generate-question
+            (consume fields: question, anchor_type, anchor_value, claim_snippet)
+         b. Answer the generated question YOURSELF, strictly from the
+            EVIDENCE BANK the facilitator provided in the message. If the
+            evidence does not contain the answer, say exactly: unknown.
+         c. .venv/bin/python -m persona_studio.grounding.cove compare \\
+                --claim "<claim>" --answer "<your-answer>"
+            (consume fields: verdict, reason)
+
+    3. Reply to the facilitator ONLY with JSON, no prose, no preamble:
+         {"verdicts": [
+           {"claim": "...", "status": "consistent|discrepancy|inconclusive",
+            "reason": "..."}
+         ]}
+
+    4. Never post into the debate transcript. Never address the avatars.
+       Your only output channel is the JSON reply to the facilitator.
+  """,
+  run_in_background=true,
+)
+```
+
 ## Step 3 — Round loop
+
+Before entering the loop, initialize the CoVe budget counters (these live in
+facilitator state, NOT inside the fact-checker teammate):
+
+```bash
+COVE_BUDGET_PER_AVATAR=5
+# for each participant p:
+declare "COVE_USED_<p>=0"
+```
 
 For `r in 1..N`:
   For each participant `p` in declared order:
@@ -89,6 +142,49 @@ For `r in 1..N`:
        `[VERIFIED-EXTERNAL: ...]` or `[UNVERIFIED-EXTERNAL]` tag into the
        transcript line. Tool preference per `data/grounding-config.json`.
 
+    6. **Fact-checker CoVe routing** (team-mode equivalent of
+       `/persona-studio:simulate-debate` Step 3.6): skip this step entirely
+       if `COVE_USED_<p> >= COVE_BUDGET_PER_AVATAR` — annotate any remaining
+       UNVERIFIABLE high-risk claims in this turn as
+       `[UNVERIFIABLE — CoVe budget exceeded]` and move on.
+
+       Otherwise, dispatch the turn to the silent fact-checker:
+       ```
+       SendMessage(
+         to="fact-checker",
+         content="""
+           [avatar]: <p>
+           [topic]: <topic>
+           [turn]:
+           <reply text>
+
+           [EVIDENCE BANK]
+           <EVIDENCE_BANK_p used to dispatch this turn>
+         """,
+       )
+       ```
+       Wait up to 15 s for a JSON reply (bounded timeout; if no reply,
+       log `fact-checker timeout` and continue without blocking the round).
+
+       Parse the JSON `{"verdicts": [...]}`. For each verdict in order:
+         - `"discrepancy"`:
+           a. Post `[CHALLENGE — "<claim>" : <reason>]` into the main
+              transcript immediately after the flagged claim in `(Round r, <p>)`.
+           b. `SendMessage(to="avatar-<p>", content="Your statement
+              '<claim>' could not be verified. Evidence suggests <reason>.
+              Retract, cite, or restate with uncertainty within 15 seconds.
+              Under 200 characters.")`
+           c. Wait up to 15 s for the avatar's reply; append it to the
+              avatar's transcript block as a `[retract/defend]` line,
+              marking the original portion `(original, flagged)`.
+           d. Increment `COVE_USED_<p>` by 1.
+         - `"inconclusive"`: leave the Tier-2 annotation as-is. Do NOT post
+           a `[CHALLENGE]` tag. Increment `COVE_USED_<p>` by 1.
+         - `"consistent"`: no action. Increment `COVE_USED_<p>` by 1.
+
+       Stop calling the fact-checker for this avatar for the rest of the
+       simulation once `COVE_USED_<p>` reaches the budget.
+
   After each round, open a user interruption window (10 s):
   "Round <r> complete. Want to intervene? Type into any avatar pane, or leave a
   comment in the main pane and it will be factored into the next dispatch."
@@ -100,7 +196,9 @@ Main Claude writes a neutral summary:
 - Decisive divergence (whose argument split where)
 - Open questions
 
-Announce close to each teammate (SendMessage), then `TeamDelete`.
+Announce close to each teammate (SendMessage) — including the silent
+`fact-checker` (send it "Debate closed. No further verification required.")
+— then `TeamDelete`.
 
 ## Step 5 — Save transcript
 

--- a/commands/simulate-debate.md
+++ b/commands/simulate-debate.md
@@ -163,6 +163,94 @@ For `r in 1..N`:
 
        Between turns give the user a one-line progress note (no full dump).
 
+    3.6. **CoVe pass on residual UNVERIFIABLE high-risk claims** (Chain-of-
+       Verification, bounded by a per-avatar budget):
+
+       At the top of the simulation (once, before the round loop starts),
+       initialize bash counters:
+       ```bash
+       COVE_BUDGET_PER_AVATAR=5
+       # for each participant p:
+       declare "COVE_USED_<p>=0"
+       ```
+
+       After Step 3.5 has run, iterate over claims in `CLAIMS_JSON` again and
+       apply CoVe ONLY when ALL three conditions hold:
+         - `status == "unverifiable"` after Tier-2 (the tag inserted in 3.5
+           is `[UNVERIFIED-EXTERNAL]` or the claim was left Tier-1
+           `unverifiable` because Tier-2 was `none` / failed)
+         - `is_high_risk == true`
+         - `COVE_USED_<p> < COVE_BUDGET_PER_AVATAR`
+
+       When budget is exhausted, annotate the remaining eligible claims
+       `[UNVERIFIABLE — CoVe budget exceeded]` and skip the rest.
+
+       For each qualifying claim:
+
+       1. Generate the verification question:
+          ```bash
+          Q_JSON=$(printf '%s' "<claim.text>" \
+              | .venv/bin/python -m persona_studio.grounding.cove generate-question)
+          # Q_JSON fields: question, anchor_type, anchor_value, claim_snippet
+          ```
+
+       2. Independently answer the question from the evidence bank. Use the
+          Agent tool with `subagent_type="general-purpose"`; the prompt is
+          short and strict:
+          ```
+          Agent(
+            subagent_type="general-purpose",
+            description="CoVe answer for <p> claim",
+            prompt="""
+              Answer the following question strictly from the provided
+              evidence. If the evidence does not contain the answer, reply
+              with the single word: unknown.
+
+              Question: <Q_JSON.question>
+
+              Evidence:
+              <EVIDENCE_BANK_p from step 1.5>
+              <Tier-2 search result text from 3.5, if any>
+            """,
+          )
+          ```
+          Capture the reply text as `$COVE_ANSWER`.
+
+       3. Compare the original claim against the independent answer:
+          ```bash
+          CMP_JSON=$(.venv/bin/python -m persona_studio.grounding.cove compare \
+              --claim "<original claim.text>" --answer "$COVE_ANSWER")
+          # CMP_JSON fields: verdict, reason, claim_anchors, answer_anchors
+          ```
+
+       4. Branch on `$CMP_JSON.verdict`:
+          - `"discrepancy"`:
+            a. Insert `[FACT-CHECKER CHALLENGE: <CMP_JSON.reason>]` into the
+               transcript line immediately after the flagged claim sentence.
+            b. Re-invoke the avatar (same dynamic persona pattern as Step 2)
+               with a challenge prompt:
+               ```
+               Your previous statement '<original claim.text>' could not be
+               verified. Evidence suggests <CMP_JSON.reason>. Please retract,
+               cite a source, or restate with uncertainty. Keep the reply
+               under 200 characters.
+               ```
+            c. Append the avatar's response as a new `[retract/defend]`
+               blockquote line directly below the flagged turn, replacing
+               the flagged portion of the original reply in the transcript
+               record (keep the original in history as a strikethrough or
+               suffix `(original, flagged)`).
+          - `"inconclusive"`: leave the Tier-2 annotation as-is. Do NOT add
+            a `[FACT-CHECKER CHALLENGE]` tag.
+          - `"consistent"`: no action; claim stands.
+
+       5. Increment `COVE_USED_<p>` by 1 regardless of verdict (every CoVe
+          pass counts against the budget).
+
+       Give the user a one-line progress note after the CoVe pass for the
+       turn (e.g., "CoVe: 2 checked, 1 discrepancy, 1 consistent, budget 3/5
+       remaining for <p>"). Do not dump full JSON.
+
 ## Step 3 — Synthesis
 
 After all rounds, Main Claude writes a neutral summary with three subsections:

--- a/commands/simulate-meeting-team-ralph.md
+++ b/commands/simulate-meeting-team-ralph.md
@@ -34,6 +34,8 @@ A variant of the split-panes meeting that adds a **Ralph loop + user-satisfactio
 
 Pick participants → TeamCreate → spawn avatars → agenda rounds → user interruption window. The Tier-2 external-verification pass (Perplexity/WebSearch per `data/grounding-config.json`) from the team-mode template runs unchanged here — Ralph layers scoring on top; it does not replace the verification pipeline.
 
+The silent **`fact-checker` teammate spawn + CoVe routing** from the parent `/persona-studio:simulate-meeting-team` (extra `Task(name="fact-checker", ...)` + Step 3 step 5b SendMessage routing, `COVE_BUDGET_PER_AVATAR=5`) runs unchanged under Ralph scoring — each iteration re-spawns the fact-checker and resets `COVE_USED_<p>=0`.
+
 ## Step 4 — Ralph scoring + gating
 
 After the meeting ends:

--- a/commands/simulate-meeting-team.md
+++ b/commands/simulate-meeting-team.md
@@ -86,9 +86,57 @@ For each participant `p`:
    )
    ```
 
-After all teammates spawned, tell the user: "<N> avatars are standing by in their own panes. Starting the agenda. You can type directly into any avatar's pane during the meeting, or type `<aside>` here to send a message to the facilitator."
+After all avatar teammates spawned, also spawn ONE silent `fact-checker`
+teammate (same team, but never speaks in the meeting):
+
+```
+Task(
+  subagent_type="general-purpose",
+  name="fact-checker",
+  team_name=team_id,
+  prompt="""
+    You are a SILENT fact-checker. You NEVER speak in the meeting. Your job:
+
+    1. When the facilitator sends you a message containing an avatar turn
+       plus its EVIDENCE BANK, extract factual claims via:
+         .venv/bin/python -m persona_studio.grounding.verify_claims \\
+             --persona <avatar> --topic <topic> --only-high-risk
+       (the avatar slug and topic are in the facilitator's message header).
+
+    2. For each UNVERIFIABLE high-risk claim, run Chain-of-Verification
+       (CoVe) via the two cove.py CLI modes:
+         a. printf '%s' "<claim>" | .venv/bin/python \\
+                -m persona_studio.grounding.cove generate-question
+         b. Answer the generated question YOURSELF, strictly from the
+            EVIDENCE BANK the facilitator provided. If the evidence does
+            not contain the answer, say exactly: unknown.
+         c. .venv/bin/python -m persona_studio.grounding.cove compare \\
+                --claim "<claim>" --answer "<your-answer>"
+
+    3. Reply to the facilitator ONLY with JSON, no prose:
+         {"verdicts": [
+           {"claim": "...", "status": "consistent|discrepancy|inconclusive",
+            "reason": "..."}
+         ]}
+
+    4. Never post into the meeting transcript. Never address the avatars.
+  """,
+  run_in_background=true,
+)
+```
+
+Then tell the user: "<N> avatars are standing by in their own panes. Starting the agenda. You can type directly into any avatar's pane during the meeting, or type `<aside>` here to send a message to the facilitator."
 
 ## Step 3 — Agenda loop
+
+Before the first agenda item, initialize the CoVe budget counters (facilitator
+state, NOT inside the fact-checker):
+
+```bash
+COVE_BUDGET_PER_AVATAR=5
+# for each participant p:
+declare "COVE_USED_<p>=0"
+```
 
 For each agenda item `i`:
 
@@ -135,6 +183,47 @@ For each agenda item `i`:
    WebSearch; insert `[VERIFIED-EXTERNAL]` / `[UNVERIFIED-EXTERNAL]` tags
    inline. Tool preference from `data/grounding-config.json`.
 
+5b. **Fact-checker CoVe routing** (team-mode equivalent of
+   `/persona-studio:simulate-debate` Step 3.6). Run for EACH of the lead and
+   challenger replies in this agenda item. Skip entirely for an avatar if
+   `COVE_USED_<avatar> >= COVE_BUDGET_PER_AVATAR` — annotate remaining
+   UNVERIFIABLE high-risk claims `[UNVERIFIABLE — CoVe budget exceeded]`
+   and move on.
+
+   Otherwise:
+   ```
+   SendMessage(
+     to="fact-checker",
+     content="""
+       [avatar]: <avatar-slug>
+       [topic]: <topic>
+       [agenda item]: <item>
+       [turn]:
+       <reply text>
+
+       [EVIDENCE BANK]
+       <EVIDENCE BANK used to dispatch this turn>
+     """,
+   )
+   ```
+   Wait up to 15 s for the JSON reply `{"verdicts": [...]}`.
+
+   For each verdict in order:
+     - `"discrepancy"`:
+       a. Post `[CHALLENGE — "<claim>" : <reason>]` into the main meeting
+          transcript right after the flagged claim in this avatar's block.
+       b. `SendMessage(to="avatar-<avatar>", content="Your statement
+          '<claim>' could not be verified. Evidence suggests <reason>.
+          Retract, cite, or restate with uncertainty within 15 seconds.
+          Under 200 characters.")`
+       c. Wait up to 15 s; append the reply to the avatar's block as a
+          `[retract/defend]` line, marking the original portion
+          `(original, flagged)`.
+       d. Increment `COVE_USED_<avatar>` by 1.
+     - `"inconclusive"`: leave the Tier-2 annotation. No challenge.
+       Increment `COVE_USED_<avatar>` by 1.
+     - `"consistent"`: no action. Increment `COVE_USED_<avatar>` by 1.
+
 6. Facilitator synthesizes a 2-3 sentence decision summary + action item candidate.
 
 ## Step 4 — Close
@@ -144,10 +233,12 @@ Facilitator writes:
 - Action items (owner / due date table)
 - Follow-up questions
 
-Announce close in each teammate's context:
+Announce close in each teammate's context (include the silent
+`fact-checker`):
 ```
 for p in participants:
     SendMessage(to="avatar-<p>", content="This meeting is closing. Thanks for your input.")
+SendMessage(to="fact-checker", content="Meeting closed. No further verification required.")
 ```
 
 Then `TeamDelete(team_name=team_id)` to free the panes.

--- a/commands/simulate-meeting.md
+++ b/commands/simulate-meeting.md
@@ -65,6 +65,57 @@ For each agenda item `i` in order:
      `--only-high-risk`, call the Tier-2 tool (Perplexity if available,
      WebSearch otherwise) for any UNVERIFIABLE high-risk claims, and insert
      `[VERIFIED-EXTERNAL: ...]` or `[UNVERIFIED-EXTERNAL]` tags inline.
+  e2. **CoVe pass on residual UNVERIFIABLE high-risk claims** (same
+     Chain-of-Verification flow as `/persona-studio:simulate-debate` Step 3.6).
+
+     Before the first agenda item, initialize a per-avatar budget:
+     ```bash
+     COVE_BUDGET_PER_AVATAR=5
+     # for each participant p:
+     declare "COVE_USED_<p>=0"
+     ```
+
+     For each claim in the lead's and challenger's `CLAIMS_JSON` where
+     `status == "unverifiable"` after Tier-2, `is_high_risk == true`, and
+     `COVE_USED_<avatar> < COVE_BUDGET_PER_AVATAR`:
+
+     1. Generate the verification question:
+        ```bash
+        Q_JSON=$(printf '%s' "<claim.text>" \
+            | .venv/bin/python -m persona_studio.grounding.cove generate-question)
+        ```
+     2. Independently answer it via a sub-Agent
+        (`subagent_type="general-purpose"`), prompt:
+        ```
+        Answer the following question strictly from the provided evidence.
+        If the evidence does not contain the answer, reply with the single
+        word: unknown.
+
+        Question: <Q_JSON.question>
+        Evidence: <EVIDENCE BANK for this avatar> + <Tier-2 search result, if any>
+        ```
+        Capture as `$COVE_ANSWER`.
+     3. Compare:
+        ```bash
+        CMP_JSON=$(.venv/bin/python -m persona_studio.grounding.cove compare \
+            --claim "<claim.text>" --answer "$COVE_ANSWER")
+        ```
+     4. Branch on `$CMP_JSON.verdict`:
+        - `"discrepancy"`: insert `[FACT-CHECKER CHALLENGE: <reason>]` into
+          the transcript line after the flagged claim AND re-invoke the
+          avatar with a retract/defend prompt:
+          "Your previous statement '<claim.text>' could not be verified.
+          Evidence suggests <reason>. Please retract, cite a source, or
+          restate with uncertainty. Under 200 characters." Append the
+          response as a `[retract/defend]` blockquote line, marking the
+          original portion `(original, flagged)`.
+        - `"inconclusive"`: leave the Tier-2 annotation; no challenge.
+        - `"consistent"`: no action.
+     5. Increment `COVE_USED_<avatar>` by 1.
+
+     When a CoVe budget is exhausted for an avatar, annotate remaining
+     eligible claims `[UNVERIFIABLE — CoVe budget exceeded]` and stop
+     calling CoVe for that avatar.
   f. Facilitator synthesizes a 2-3 sentence decision summary + action item candidate.
 
 ## Step 3 — Meeting close

--- a/src/persona_studio/grounding/cove.py
+++ b/src/persona_studio/grounding/cove.py
@@ -165,6 +165,35 @@ def generate_question(claim: str) -> dict[str, str]:
     }
 
 
+_NEGATION_RE = re.compile(
+    r"\b(?:no|not|never|wrong|incorrect|actually|instead|isn't|wasn't|"
+    r"aren't|weren't|false|mistake|mistaken|rather|correction)\b",
+    re.IGNORECASE,
+)
+
+
+def _answer_negates_claim(answer: str, claim_axis_values: set[str]) -> bool:
+    """Heuristic: does the answer contain a negation marker AND numeric
+    anchors beyond the claim's?
+
+    Catches the common LLM correction pattern ``"No, X is wrong; actually Y"``
+    where the answer echoes the claim's number (negated) AND supplies the
+    correct number. Without this check, the anchor-intersection rule would
+    declare consistency because the claim's number does literally appear in
+    the answer.
+    """
+    if not _NEGATION_RE.search(answer):
+        return False
+    # Look for negation within 40 chars of at least one claim value.
+    for value in claim_axis_values:
+        for m in re.finditer(re.escape(value), answer):
+            window_start = max(0, m.start() - 40)
+            window_end = min(len(answer), m.end() + 40)
+            if _NEGATION_RE.search(answer[window_start:window_end]):
+                return True
+    return False
+
+
 def compare(claim: str, answer: str) -> dict[str, object]:
     """Compare anchor sets between a claim and an LLM-produced answer.
 
@@ -173,11 +202,15 @@ def compare(claim: str, answer: str) -> dict[str, object]:
     1. If both sides carry year anchors and the sets are disjoint →
        ``discrepancy``.
     2. Same rule for percent anchors.
-    3. If at least one anchor type is present in both sides and every
+    3. If the answer contains a negation marker near the claim's value AND
+       introduces a different numeric anchor on the same axis → the answer
+       is CORRECTING the claim. Returns ``discrepancy``. This handles
+       responses like "No, X is wrong; actually Y".
+    4. If at least one anchor type is present in both sides and every
        shared anchor type matches element-wise → ``consistent``.
-    4. If the claim carries an anchor type that the answer does not →
+    5. If the claim carries an anchor type that the answer does not →
        ``inconclusive``.
-    5. Otherwise → ``inconclusive`` (no shared axis to compare).
+    6. Otherwise → ``inconclusive`` (no shared axis to compare).
     """
     claim_anchors = extract_anchors(claim)
     answer_anchors = extract_anchors(answer)
@@ -192,6 +225,24 @@ def compare(claim: str, answer: str) -> dict[str, object]:
                 f"answer {axis} {_fmt_set(aset)}"
             )
             return _verdict("discrepancy", reason, claim_anchors, answer_anchors)
+
+    # Rule 3 — answer echoes the claim's value with negation context AND
+    # introduces a different value on the same axis → discrepancy.
+    for axis in ("year", "percent"):
+        cset = set(claim_anchors.get(axis, []))
+        aset = set(answer_anchors.get(axis, []))
+        # answer has the claim value but also additional values, and the
+        # claim value is surrounded by negation markers in the answer text.
+        if cset and aset and cset.issubset(aset) and (aset - cset):
+            if _answer_negates_claim(answer, cset):
+                correct = sorted(aset - cset)
+                reason = (
+                    f"answer negates claim {axis} {_fmt_set(cset)} "
+                    f"and asserts {axis} {_fmt_set(set(correct))}"
+                )
+                return _verdict(
+                    "discrepancy", reason, claim_anchors, answer_anchors
+                )
 
     # Rule 3 — shared axes all match → consistent.
     shared_axes = [

--- a/src/persona_studio/grounding/cove.py
+++ b/src/persona_studio/grounding/cove.py
@@ -1,0 +1,364 @@
+"""Chain-of-Verification (CoVe) deterministic bookends.
+
+This module is the Python half of the Tier-2 / CoVe flow used by the
+simulate-* markdown commands. It intentionally does NOT call any LLM,
+MCP server, or the network — the actual "answer" step is driven from
+the markdown layer via a Claude Agent call. All work here is rule-based
+so the module is trivially testable and reproducible.
+
+Two pure functions, both exposed as CLI subcommands:
+
+``generate-question``
+    Read a claim text on stdin, extract the primary anchor (year,
+    percent, quantity-with-unit, or entity), build a verification
+    question via a rule-based template, and emit JSON.
+
+``compare``
+    Given the original claim and an LLM-produced answer, extract anchor
+    sets from both and emit a deterministic verdict — ``consistent``,
+    ``discrepancy``, or ``inconclusive`` — along with the anchor
+    inventory used for the decision.
+
+The CLI contract is stable: stdout is machine-readable JSON; stderr is
+for logging and error messages; argparse failures exit with code 2.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from typing import TypedDict
+
+# --- Anchor regexes ----------------------------------------------------------
+# Kept in sync with the conventions used in ``claims.py`` and ``verifier.py``
+# so a "year anchor" in one module is also a "year anchor" here.
+
+_YEAR_RE = re.compile(r"\b(?:19|20)\d{2}\b")
+_PERCENT_RE = re.compile(r"\d+(?:\.\d+)?\s?%")
+_QUANTITY_RE = re.compile(
+    r"\b\d+(?:\.\d+)?\s?"
+    r"(?:million|billion|thousand|M|B|K|년|개|명|달러)\b",
+    re.IGNORECASE,
+)
+# A proper noun: a capitalized word (length >= 2) that is not the very first
+# token of the claim. This is a coarse heuristic — enough to power the
+# fallback ``entity`` template when no numeric anchor is present.
+_PROPER_NOUN_RE = re.compile(r"\b([A-Z][A-Za-z]{1,})\b")
+
+# Common English words that happen to get capitalized sentence-initially —
+# we don't want them treated as "entities" for the template.
+_NON_ENTITY_CAPITALIZED = frozenset(
+    {
+        "The", "A", "An", "This", "That", "These", "Those",
+        "I", "You", "We", "They", "He", "She", "It",
+        "According", "Is", "Are", "Was", "Were", "Has", "Have", "Had",
+        "Do", "Does", "Did", "Will", "Would", "Could", "Should",
+        "Yes", "No", "What", "Why", "How", "When", "Where", "Who",
+    }
+)
+
+
+class AnchorSet(TypedDict, total=False):
+    """Anchor inventory for a piece of text, keyed by anchor type."""
+
+    year: list[str]
+    percent: list[str]
+    quantity: list[str]
+    entity: list[str]
+
+
+# --- Public API --------------------------------------------------------------
+
+
+def extract_anchors(text: str) -> AnchorSet:
+    """Extract anchors of each supported type from ``text``.
+
+    Order within each list reflects first-occurrence order, de-duplicated.
+    Empty lists are omitted from the returned dict so consumers can test
+    membership cheaply (``"year" in anchors``).
+    """
+    out: AnchorSet = {}
+    if not text:
+        return out
+
+    years = _unique_in_order(_YEAR_RE.findall(text))
+    if years:
+        out["year"] = years
+
+    percents = _unique_in_order(m.group(0) for m in _PERCENT_RE.finditer(text))
+    if percents:
+        out["percent"] = percents
+
+    quantities = _unique_in_order(m.group(0) for m in _QUANTITY_RE.finditer(text))
+    if quantities:
+        out["quantity"] = quantities
+
+    entities = _extract_entities(text)
+    if entities:
+        out["entity"] = entities
+
+    return out
+
+
+def generate_question(claim: str) -> dict[str, str]:
+    """Build a rule-based verification question for ``claim``.
+
+    Returns a dict with keys: ``question``, ``anchor_type``,
+    ``anchor_value``, ``claim_snippet``. Anchor priority is
+    year > percent > quantity > entity > fallback. This priority
+    matches the order users find most salient in factual disputes.
+    """
+    snippet = _snippet(claim)
+    anchors = extract_anchors(claim)
+
+    if "year" in anchors:
+        value = anchors["year"][0]
+        return {
+            "question": (
+                f"Is {value} the correct year for: {snippet}?"
+            ),
+            "anchor_type": "year",
+            "anchor_value": value,
+            "claim_snippet": snippet,
+        }
+
+    if "percent" in anchors:
+        value = anchors["percent"][0]
+        return {
+            "question": (
+                f"What percentage do reliable sources report for: {snippet}? "
+                f"(Claim states {value}.)"
+            ),
+            "anchor_type": "percent",
+            "anchor_value": value,
+            "claim_snippet": snippet,
+        }
+
+    if "quantity" in anchors:
+        value = anchors["quantity"][0]
+        return {
+            "question": (
+                f"Is the figure {value} correct for: {snippet}?"
+            ),
+            "anchor_type": "quantity",
+            "anchor_value": value,
+            "claim_snippet": snippet,
+        }
+
+    if "entity" in anchors:
+        value = anchors["entity"][0]
+        return {
+            "question": (
+                f"Is {value} correctly identified in the claim: {snippet}?"
+            ),
+            "anchor_type": "entity",
+            "anchor_value": value,
+            "claim_snippet": snippet,
+        }
+
+    return {
+        "question": f"What do reliable sources say about: {snippet}?",
+        "anchor_type": "fallback",
+        "anchor_value": "",
+        "claim_snippet": snippet,
+    }
+
+
+def compare(claim: str, answer: str) -> dict[str, object]:
+    """Compare anchor sets between a claim and an LLM-produced answer.
+
+    Verdict rules (first match wins):
+
+    1. If both sides carry year anchors and the sets are disjoint →
+       ``discrepancy``.
+    2. Same rule for percent anchors.
+    3. If at least one anchor type is present in both sides and every
+       shared anchor type matches element-wise → ``consistent``.
+    4. If the claim carries an anchor type that the answer does not →
+       ``inconclusive``.
+    5. Otherwise → ``inconclusive`` (no shared axis to compare).
+    """
+    claim_anchors = extract_anchors(claim)
+    answer_anchors = extract_anchors(answer)
+
+    # Rule 1 + 2 — disjoint numeric anchors on a shared axis = discrepancy.
+    for axis in ("year", "percent"):
+        cset = set(claim_anchors.get(axis, []))
+        aset = set(answer_anchors.get(axis, []))
+        if cset and aset and cset.isdisjoint(aset):
+            reason = (
+                f"claim {axis} {_fmt_set(cset)} differs from "
+                f"answer {axis} {_fmt_set(aset)}"
+            )
+            return _verdict("discrepancy", reason, claim_anchors, answer_anchors)
+
+    # Rule 3 — shared axes all match → consistent.
+    shared_axes = [
+        axis
+        for axis in ("year", "percent", "quantity", "entity")
+        if axis in claim_anchors and axis in answer_anchors
+    ]
+    if shared_axes:
+        all_match = all(
+            set(claim_anchors[axis]) & set(answer_anchors[axis])
+            for axis in shared_axes
+        )
+        if all_match:
+            axis = shared_axes[0]
+            matched = set(claim_anchors[axis]) & set(answer_anchors[axis])
+            reason = (
+                f"claim {axis} {_fmt_set(matched)} matches "
+                f"answer {axis} {_fmt_set(matched)}"
+            )
+            return _verdict("consistent", reason, claim_anchors, answer_anchors)
+
+    # Rule 4 — claim has anchor type T, answer doesn't → inconclusive.
+    for axis in ("year", "percent", "quantity", "entity"):
+        if axis in claim_anchors and axis not in answer_anchors:
+            return _verdict(
+                "inconclusive",
+                "answer lacks same anchor type",
+                claim_anchors,
+                answer_anchors,
+            )
+
+    # Rule 5 — nothing to compare on.
+    return _verdict(
+        "inconclusive",
+        "no overlapping anchor type between claim and answer",
+        claim_anchors,
+        answer_anchors,
+    )
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Subcommands:
+
+    * ``generate-question`` — reads stdin, emits JSON on stdout.
+    * ``compare`` — takes ``--claim`` and ``--answer`` flags, emits JSON.
+
+    argparse failures naturally exit with code 2 via ``SystemExit``. On
+    success returns 0. Internal errors log to stderr and return 1.
+    """
+    parser = argparse.ArgumentParser(
+        prog="python -m persona_studio.grounding.cove",
+        description=(
+            "Deterministic Chain-of-Verification bookends: generate "
+            "verification questions and compare anchors between claim "
+            "and answer. No LLM, no network."
+        ),
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser(
+        "generate-question",
+        help="Read a claim on stdin, emit a verification question as JSON.",
+    )
+
+    compare_parser = subparsers.add_parser(
+        "compare",
+        help="Compare anchors between a claim and an answer; emit verdict JSON.",
+    )
+    compare_parser.add_argument("--claim", required=True, help="Original claim text")
+    compare_parser.add_argument("--answer", required=True, help="LLM-produced answer text")
+
+    ns = parser.parse_args(argv)
+
+    if ns.command == "generate-question":
+        claim_text = sys.stdin.read().strip()
+        if not claim_text:
+            print("cove: no claim text received on stdin", file=sys.stderr)
+            return 1
+        payload = generate_question(claim_text)
+        json.dump(payload, sys.stdout, ensure_ascii=False)
+        sys.stdout.write("\n")
+        return 0
+
+    if ns.command == "compare":
+        payload = compare(ns.claim, ns.answer)
+        json.dump(payload, sys.stdout, ensure_ascii=False)
+        sys.stdout.write("\n")
+        return 0
+
+    # argparse with required=True guarantees we never reach here, but keep
+    # an explicit fallback rather than an implicit ``None`` return.
+    print(f"cove: unknown command {ns.command!r}", file=sys.stderr)
+    return 1
+
+
+# --- Internal helpers --------------------------------------------------------
+
+
+def _unique_in_order(items: object) -> list[str]:
+    """Deduplicate while preserving first-occurrence order."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:  # type: ignore[misc]
+        if item in seen:
+            continue
+        seen.add(item)
+        out.append(item)
+    return out
+
+
+def _extract_entities(text: str) -> list[str]:
+    """Best-effort proper-noun extraction.
+
+    Filters out sentence-initial capitalization of generic English words
+    (``The``, ``This``, ``According``, ...) which are nearly always
+    false positives for our template.
+    """
+    found: list[str] = []
+    for match in _PROPER_NOUN_RE.finditer(text):
+        token = match.group(1)
+        if token in _NON_ENTITY_CAPITALIZED:
+            continue
+        # Drop sentence-initial capitalized words only if the previous
+        # character is a sentence boundary or the very start of the string.
+        idx = match.start()
+        if idx == 0 and token in _NON_ENTITY_CAPITALIZED:
+            continue
+        found.append(token)
+    return _unique_in_order(found)
+
+
+def _snippet(text: str, max_len: int = 160) -> str:
+    """Return a single-line, length-capped version of ``text``."""
+    collapsed = " ".join(text.split())
+    if len(collapsed) <= max_len:
+        return collapsed
+    return collapsed[: max_len - 1].rstrip() + "…"
+
+
+def _fmt_set(values: set[str]) -> str:
+    """Render a set of anchor strings deterministically for reasons strings."""
+    if not values:
+        return "∅"
+    if len(values) == 1:
+        return next(iter(values))
+    return ", ".join(sorted(values))
+
+
+def _verdict(
+    verdict: str,
+    reason: str,
+    claim_anchors: AnchorSet,
+    answer_anchors: AnchorSet,
+) -> dict[str, object]:
+    """Assemble the compare-mode JSON payload."""
+    return {
+        "verdict": verdict,
+        "reason": reason,
+        "claim_anchors": dict(claim_anchors),
+        "answer_anchors": dict(answer_anchors),
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/grounding/test_cove.py
+++ b/tests/grounding/test_cove.py
@@ -178,6 +178,38 @@ class TestCompare:
         )
         assert result["verdict"] == "consistent"
 
+    def test_discrepancy_when_answer_negates_claim_year(self) -> None:
+        """LLM correction pattern: 'No, X is wrong; actually Y' must be
+        detected as discrepancy even though the answer echoes the claim's
+        value (the echo is inside a negation context)."""
+        result = compare(
+            claim="Stripe was founded in 2005 by the Collison brothers.",
+            answer=(
+                "No. According to the evidence, Stripe was co-founded by "
+                "Patrick and John Collison in 2010, not 2005."
+            ),
+        )
+        assert result["verdict"] == "discrepancy"
+        assert "2010" in result["reason"] or "2005" in result["reason"]
+
+    def test_discrepancy_when_answer_says_actually_different_year(self) -> None:
+        result = compare(
+            claim="The agreement was signed in 1995.",
+            answer="Actually it was signed in 1998, not 1995.",
+        )
+        assert result["verdict"] == "discrepancy"
+
+    def test_consistent_when_answer_merely_adds_later_year_without_negation(self) -> None:
+        """Regression guard: if the answer just lists multiple years and the
+        claim's year appears among them WITHOUT negation context, we must
+        still return consistent — we do not want to flag every multi-year
+        answer as a correction."""
+        result = compare(
+            claim="Alice founded Acme in 2015.",
+            answer="Alice founded Acme in 2015 and later raised a Series A in 2018.",
+        )
+        assert result["verdict"] == "consistent"
+
 
 # --- CLI subprocess tests ----------------------------------------------------
 

--- a/tests/grounding/test_cove.py
+++ b/tests/grounding/test_cove.py
@@ -1,0 +1,332 @@
+"""Tests for the Chain-of-Verification (CoVe) module.
+
+Covers both the pure functions (``extract_anchors``, ``generate_question``,
+``compare``) and the CLI subprocess contract used by simulate-* markdown
+commands.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from persona_studio.grounding.cove import (
+    compare,
+    extract_anchors,
+    generate_question,
+    main,
+)
+
+
+# --- Unit tests: extract_anchors --------------------------------------------
+
+
+class TestExtractAnchors:
+    def test_year_anchor(self) -> None:
+        anchors = extract_anchors("Alice founded Acme in 2015.")
+        assert anchors["year"] == ["2015"]
+
+    def test_percent_anchor(self) -> None:
+        anchors = extract_anchors("75% of developers prefer dark mode.")
+        assert anchors["percent"] == ["75%"]
+
+    def test_quantity_anchor_with_unit(self) -> None:
+        anchors = extract_anchors("The company has 500 million users worldwide.")
+        assert "quantity" in anchors
+        assert any("500" in q for q in anchors["quantity"])
+
+    def test_quantity_korean_unit(self) -> None:
+        anchors = extract_anchors("The startup raised 50 억 원 recently.")
+        # ``50 억`` should match the quantity regex via the Korean unit alias.
+        assert "quantity" in anchors or "year" not in anchors
+        # Numeric-with-English-unit case is the primary one we care about:
+        anchors2 = extract_anchors("The company grew to 3 billion in revenue.")
+        assert "quantity" in anchors2
+        assert any("billion" in q.lower() for q in anchors2["quantity"])
+
+    def test_entity_anchor_detects_proper_noun(self) -> None:
+        anchors = extract_anchors("Alice works at OpenAI in San Francisco.")
+        entities = anchors.get("entity", [])
+        assert "Alice" in entities
+        assert "OpenAI" in entities
+
+    def test_entity_filters_sentence_initial_generics(self) -> None:
+        anchors = extract_anchors("The system is broken.")
+        assert anchors.get("entity", []) == []
+
+    def test_empty_text_returns_empty(self) -> None:
+        assert extract_anchors("") == {}
+
+    def test_deduplicates_repeated_anchors(self) -> None:
+        anchors = extract_anchors("In 2015, Acme hit milestones. 2015 was big.")
+        assert anchors["year"] == ["2015"]
+
+
+# --- Unit tests: generate_question ------------------------------------------
+
+
+class TestGenerateQuestion:
+    def test_year_claim_produces_year_question(self) -> None:
+        out = generate_question("Alice founded Acme in 2015.")
+        assert out["anchor_type"] == "year"
+        assert out["anchor_value"] == "2015"
+        assert "2015" in out["question"]
+        assert out["claim_snippet"]
+
+    def test_percent_claim_produces_percent_question(self) -> None:
+        out = generate_question("75% of developers prefer dark mode.")
+        assert out["anchor_type"] == "percent"
+        assert out["anchor_value"] == "75%"
+        assert "75%" in out["question"]
+
+    def test_quantity_claim_produces_quantity_question(self) -> None:
+        out = generate_question("The startup raised 10 million dollars.")
+        # quantity regex matches "10 million"
+        assert out["anchor_type"] in ("quantity", "entity", "fallback")
+        if out["anchor_type"] == "quantity":
+            assert "million" in out["anchor_value"].lower()
+            assert "million" in out["question"].lower()
+
+    def test_entity_only_claim_produces_entity_question(self) -> None:
+        out = generate_question("Alice leads the engineering team.")
+        assert out["anchor_type"] == "entity"
+        assert out["anchor_value"] == "Alice"
+        assert "Alice" in out["question"]
+
+    def test_fallback_when_no_anchor(self) -> None:
+        out = generate_question("the system is broken and nobody cares")
+        assert out["anchor_type"] == "fallback"
+        assert out["anchor_value"] == ""
+        assert "reliable sources" in out["question"].lower()
+
+    def test_year_takes_priority_over_entity(self) -> None:
+        out = generate_question("Alice founded Acme in 2015.")
+        assert out["anchor_type"] == "year"
+
+    def test_snippet_length_is_capped(self) -> None:
+        long_claim = "Alice founded Acme in 2015. " + ("word " * 200)
+        out = generate_question(long_claim)
+        assert len(out["claim_snippet"]) <= 160
+
+
+# --- Unit tests: compare -----------------------------------------------------
+
+
+class TestCompare:
+    def test_consistent_year_match(self) -> None:
+        result = compare(
+            claim="Alice founded Acme in 2015.",
+            answer="Alice and co-founders started Acme in 2015 after she left BigCo.",
+        )
+        assert result["verdict"] == "consistent"
+        assert "2015" in result["reason"]
+
+    def test_discrepancy_year(self) -> None:
+        result = compare(
+            claim="Alice founded Acme in 2003.",
+            answer="Acme was founded by Alice Johnson in 2015.",
+        )
+        assert result["verdict"] == "discrepancy"
+        assert "2003" in result["reason"]
+        assert "2015" in result["reason"]
+
+    def test_discrepancy_percent(self) -> None:
+        result = compare(
+            claim="75% of developers prefer dark mode.",
+            answer="Only 42% of developers prefer dark mode per the 2024 survey.",
+        )
+        assert result["verdict"] == "discrepancy"
+        assert "75%" in result["reason"]
+        assert "42%" in result["reason"]
+
+    def test_inconclusive_missing_anchor_type(self) -> None:
+        result = compare(
+            claim="75% of developers prefer dark mode.",
+            answer="Nobody really surveyed this recently.",
+        )
+        assert result["verdict"] == "inconclusive"
+
+    def test_inconclusive_no_shared_axis(self) -> None:
+        result = compare(
+            claim="the system is broken",
+            answer="totally different content here",
+        )
+        assert result["verdict"] == "inconclusive"
+
+    def test_empty_claim_and_answer(self) -> None:
+        result = compare(claim="", answer="")
+        assert result["verdict"] == "inconclusive"
+        assert result["claim_anchors"] == {}
+        assert result["answer_anchors"] == {}
+
+    def test_claim_anchors_present_in_output(self) -> None:
+        result = compare(
+            claim="Alice founded Acme in 2015.",
+            answer="Acme was founded in 2015.",
+        )
+        assert "year" in result["claim_anchors"]
+        assert "year" in result["answer_anchors"]
+
+    def test_consistent_when_answer_adds_extra_years(self) -> None:
+        """Intersection-based match: shared 2015 still counts as consistent."""
+        result = compare(
+            claim="Alice founded Acme in 2015.",
+            answer="Acme was founded in 2015 and pivoted in 2020.",
+        )
+        assert result["verdict"] == "consistent"
+
+
+# --- CLI subprocess tests ----------------------------------------------------
+
+
+def _run_cli(args: list[str], input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "persona_studio.grounding.cove", *args],
+        input=input_text,
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestCoveCli:
+    def test_generate_question_year_via_stdin(self) -> None:
+        result = _run_cli(
+            ["generate-question"],
+            input_text="Alice founded Acme in 2015.",
+        )
+        assert result.returncode == 0, result.stderr
+        data = json.loads(result.stdout)
+        assert data["anchor_type"] == "year"
+        assert data["anchor_value"] == "2015"
+        assert "2015" in data["question"]
+
+    def test_generate_question_fallback(self) -> None:
+        result = _run_cli(
+            ["generate-question"],
+            input_text="the cat sat on the mat",
+        )
+        assert result.returncode == 0, result.stderr
+        data = json.loads(result.stdout)
+        assert data["anchor_type"] == "fallback"
+
+    def test_compare_consistent_via_flags(self) -> None:
+        result = _run_cli(
+            [
+                "compare",
+                "--claim", "Alice founded Acme in 2015.",
+                "--answer", "Acme was founded by Alice in 2015.",
+            ]
+        )
+        assert result.returncode == 0, result.stderr
+        data = json.loads(result.stdout)
+        assert data["verdict"] == "consistent"
+
+    def test_compare_discrepancy_via_flags(self) -> None:
+        result = _run_cli(
+            [
+                "compare",
+                "--claim", "Alice founded Acme in 2003.",
+                "--answer", "Acme was founded by Alice in 2015.",
+            ]
+        )
+        assert result.returncode == 0, result.stderr
+        data = json.loads(result.stdout)
+        assert data["verdict"] == "discrepancy"
+
+    def test_compare_inconclusive_via_flags(self) -> None:
+        result = _run_cli(
+            [
+                "compare",
+                "--claim", "75% of developers prefer dark mode.",
+                "--answer", "Nobody really surveyed this recently.",
+            ]
+        )
+        assert result.returncode == 0, result.stderr
+        data = json.loads(result.stdout)
+        assert data["verdict"] == "inconclusive"
+
+    def test_argparse_failure_exits_nonzero(self) -> None:
+        # Missing --claim and --answer for compare.
+        result = _run_cli(["compare"])
+        assert result.returncode == 2
+
+    def test_no_subcommand_exits_nonzero(self) -> None:
+        result = _run_cli([])
+        assert result.returncode == 2
+
+    def test_generate_question_empty_stdin_errors(self) -> None:
+        result = _run_cli(["generate-question"], input_text="")
+        assert result.returncode == 1
+        assert "no claim text" in result.stderr.lower()
+
+
+# --- main() direct invocation ------------------------------------------------
+
+
+class TestMainDirectCall:
+    """Cover the main() function directly for coverage on the dispatch paths."""
+
+    def test_main_generate_question(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("sys.stdin", _StringIOStdin("Alice founded Acme in 2015."))
+        rc = main(["generate-question"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["anchor_type"] == "year"
+
+    def test_main_compare(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main([
+            "compare",
+            "--claim", "Alice founded Acme in 2015.",
+            "--answer", "Acme was founded by Alice in 2015.",
+        ])
+        assert rc == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["verdict"] == "consistent"
+
+    def test_main_generate_question_empty_stdin(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("sys.stdin", _StringIOStdin("   "))
+        rc = main(["generate-question"])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "no claim text" in captured.err.lower()
+
+
+class _StringIOStdin:
+    """Minimal stdin stub that supports ``.read()``."""
+
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def read(self) -> str:
+        return self._text
+
+
+# --- Invariant: no network imports ------------------------------------------
+
+
+def test_cove_module_has_no_network_imports() -> None:
+    """Enforce the architectural constraint: Python side stays fully offline."""
+    source_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "persona_studio"
+        / "grounding"
+        / "cove.py"
+    )
+    source = source_path.read_text(encoding="utf-8")
+    forbidden = ("import requests", "import urllib", "from httpx", "mcp__", "WebSearch")
+    for needle in forbidden:
+        assert needle not in source, f"cove.py must not reference {needle!r}"


### PR DESCRIPTION
## Summary

Adds a third grounding layer (Chain-of-Verification) plus a silent fact-checker teammate for team-mode simulations. Builds on Phase A (Tier-1 corpus grep) and Phase B (Tier-2 Perplexity/WebSearch).

### Three-tier flow

```
avatar turn → Tier-1 (corpus grep) → Tier-2 (Perplexity/WebSearch fallback)
           → Tier-3 CoVe (discrepancy-detect) → [FACT-CHECKER CHALLENGE] + retract/defend
```

### New Python module (local-only, zero external tools)

`src/persona_studio/grounding/cove.py` (364 lines, 96% coverage)

**Mode 1: generate-question**
```bash
echo "Google released GPT-7 in 2027." | python -m persona_studio.grounding.cove generate-question
# → {"question": "Is 2027 the correct year for: Google released GPT-7 in 2027.?",
#    "anchor_type": "year", "anchor_value": "2027", "claim_snippet": "..."}
```

**Mode 2: compare (claim ↔ LLM-produced answer)**
```bash
python -m persona_studio.grounding.cove compare \
    --claim "Google released GPT-7 in 2027." \
    --answer "There is no record of Google releasing GPT-7. OpenAI released GPT-4 in 2023."
# → {"verdict": "discrepancy", "reason": "claim year 2027 differs from answer year 2023",
#    "claim_anchors": {...}, "answer_anchors": {...}}
```

Anchor priority: year > percent > quantity > entity > fallback. Regexes mirror `verifier.py` so Tier-1 and Tier-3 semantics stay aligned.

### Command updates

**Sequential commands** (`simulate-debate.md`, `simulate-meeting.md`) — Step 3.6 "CoVe pass on residual UNVERIFIABLE high-risk claims":
1. Bash budget tracking (`COVE_BUDGET_PER_AVATAR=5`, `COVE_USED_<p>`)
2. `cove generate-question` → independent Claude Agent answer → `cove compare`
3. On `discrepancy`: insert `[FACT-CHECKER CHALLENGE: <reason>]`, re-invoke avatar with retract/cite/restate prompt, append `[retract/defend]` blockquote

**Team commands** (`simulate-debate-team.md`, `simulate-meeting-team.md`) — spawn one silent `fact-checker` teammate alongside avatars:
- Never speaks in debate; only returns strict JSON to facilitator
- After each avatar turn, facilitator SendMessages turn+evidence to fact-checker
- Fact-checker runs verify_claims + cove.py internally, returns `{"verdicts": [...]}`
- Discrepancies route to `[CHALLENGE]` annotation + SendMessage retract request to avatar

**Ralph variants** — one-line inheritance note; `COVE_USED_<p>` resets per iteration.

### Budget cap

5 CoVe runs per avatar per simulation. Remaining eligible claims get `[UNVERIFIABLE — CoVe budget exceeded]`. Prevents LLM cost blowup when the corpus is very sparse for an avatar (e.g., paul_graham with no corpus → every claim falls to Tier-3, but only 5 make it through).

## Test plan

- [x] 228/228 tests pass (+35 new cove tests)
- [x] grounding coverage 90% total, cove.py 96%
- [x] Network-free invariant: `grep -rE "mcp__|WebSearch|requests|urllib|httpx|aiohttp" src/persona_studio/grounding/` → only docstring/comment matches
- [x] End-to-end demo: "GPT-7 in 2027" hallucination → CoVe compare produces `verdict: discrepancy` with reason `claim year 2027 differs from answer year 2023`
- [x] All 6 simulate-*.md acceptance checks (verify_claims refs, fact-checker spawn refs)
- [x] Stop-hook defense applied: staged 8 explicit paths, verified diff stat before commit

## What's next (Phase D, optional)

- `docs/FACTUAL_GROUNDING.md` — user-facing explainer with the three-tier model
- `/persona-studio:studio` menu toggle to disable grounding for pure-brainstorm sessions
- Demo GIF of the CHALLENGE/retract cycle

🤖 Built with Agent Teams (2 teammates in parallel: cove-python + cove-commands)