### PR TITLE
feat(grounding): Phase D — docs, session toggle, retract-aware audit

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -285,12 +285,16 @@ Claude Code 안에서:
 
 ## 사실 기반 (환각 감소)
 
-모든 시뮬레이션은 기본적으로 2-tier grounding layer 를 실행합니다:
+모든 시뮬레이션은 기본적으로 3-tier grounding stack 을 실행합니다. 덕분에 transcript 는 **라인 단위로** 어떤 문장이 실제 evidence 에 근거하고 어떤 문장이 모델이 지어낸 것인지 알려줍니다. transcript 끝의 `## Factual Grounding` 테이블이 아바타별 score 를 요약하고, Ralph loop 은 이 score 를 기본 4번째 criterion (goal 8/10) 으로 읽어서 hallucinate 가 심한 경우 자동으로 re-run 을 트리거합니다.
 
-- **Tier-1 (항상 켜짐, 오프라인)** — 각 아바타가 말하기 전에 그 아바타의 코퍼스에서 검색된 evidence 로 프롬프트가 보강됩니다. 회의 종료 후, 모든 claim 이 코퍼스 와 매칭되어 `[SUPPORTED: source:line]` / `[UNSUPPORTED]` / `[UNVERIFIABLE]` / `[OPINION]` 태그가 붙습니다. transcript 끝에 `## Factual Grounding` 테이블이 아바타별 hallucination rate 를 요약합니다.
-- **Tier-2 (외부, 선택)** — Tier-1 이 놓친 claim 을 Perplexity MCP (설치되어 있으면) 또는 내장 WebSearch (항상 사용 가능) 로 재확인합니다. 외부적으로 검증된 claim 은 `[VERIFIED-EXTERNAL: 도구 url]` 태그, 확인 불가 는 `[UNVERIFIED-EXTERNAL]`. **Perplexity MCP 는 선택사항 — 대부분의 사용자는 없고, WebSearch fallback 으로 충분합니다.**
+transcript 에 인라인으로 붙는 태그들:
 
-Ralph loop 은 아바타별 grounding score 를 기본 4번째 criterion (goal 8/10) 으로 읽어서, hallucinate 가 심한 경우 자동으로 re-run 을 트리거합니다. 순수 brainstorming 세션처럼 hallucination 이 필요하면 `/persona-studio:studio` 메뉴에서 전체 레이어를 끌 수 있습니다.
+- `[SUPPORTED: source:line]` — Tier-1 이 아바타의 로컬 corpus 에서 근거를 찾음.
+- `[UNSUPPORTED]` / `[UNVERIFIABLE]` / `[OPINION]` — Tier-1 이 모순/누락/비사실적 내용으로 판정.
+- `[VERIFIED-EXTERNAL: 도구 url]` / `[UNVERIFIED-EXTERNAL]` — Tier-2 가 Perplexity MCP (설치된 경우) 또는 WebSearch 로 재확인한 결과.
+- `[FACT-CHECKER CHALLENGE: 이유]` — Tier-3 Chain-of-Verification 이 불일치를 포착해서 아바타가 `[retract/defend]` 블록에서 철회·인용·재진술하도록 강제.
+
+순수 brainstorming 세션처럼 hallucination 이 필요하면 `/persona-studio:studio` 메뉴에서 전체 레이어를 끌 수 있습니다. 전체 동작 원리는 [docs/FACTUAL_GROUNDING.md](docs/FACTUAL_GROUNDING.md) 에서 확인하세요 (영문).
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -285,12 +285,16 @@ Add it to your dotfiles-sync or backup set and your library travels with you acr
 
 ## Factual grounding (hallucination reduction)
 
-Every simulation runs a two-tier grounding layer by default:
+Every simulation runs a three-tier grounding stack by default, so the transcript tells you — at the line level — which sentences are anchored in real evidence and which ones the model invented. A `## Factual Grounding` table at the end of each transcript summarizes per-avatar scores, and the Ralph loop reads that score as a default 4th criterion (goal 8/10) to auto-trigger a re-run when an avatar hallucinates too much.
 
-- **Tier-1 (always on, offline)** — before each avatar speaks, the prompt is augmented with evidence retrieved from that avatar's corpus. After the meeting, every claim is matched against the corpus and tagged `[SUPPORTED: source:line]` / `[UNSUPPORTED]` / `[UNVERIFIABLE]` / `[OPINION]`. A `## Factual Grounding` table at the end of each transcript summarizes per-avatar hallucination rates.
-- **Tier-2 (external, optional)** — claims that Tier-1 can't place are re-checked against Perplexity MCP (if you have it installed) or the built-in WebSearch (always available). Externally verified claims get a `[VERIFIED-EXTERNAL: tool url]` tag; unverifiable ones stay `[UNVERIFIED-EXTERNAL]`. Perplexity MCP is optional — **most users don't have it, and WebSearch is a perfectly fine fallback**.
+Tags you will see inline in the transcript:
 
-The Ralph loop reads the per-avatar grounding score as a default 4th criterion (goal 8/10) and triggers a re-run if an avatar is hallucinating too much. Disable the whole layer for pure-brainstorm sessions via the `/persona-studio:studio` menu if you want the hallucinations back.
+- `[SUPPORTED: source:line]` — Tier-1 found matching evidence in the persona's local corpus.
+- `[UNSUPPORTED]` / `[UNVERIFIABLE]` / `[OPINION]` — Tier-1 found contradicting, missing, or non-factual content.
+- `[VERIFIED-EXTERNAL: tool url]` / `[UNVERIFIED-EXTERNAL]` — Tier-2 checked the claim via Perplexity MCP (if installed) or WebSearch.
+- `[FACT-CHECKER CHALLENGE: reason]` — Tier-3 Chain-of-Verification caught a discrepancy and forced the avatar to retract, cite, or restate under a `[retract/defend]` block.
+
+Disable the whole layer for pure-brainstorm sessions via the `/persona-studio:studio` menu. See [docs/FACTUAL_GROUNDING.md](docs/FACTUAL_GROUNDING.md) for the full mechanics.
 
 <br/>
 

--- a/commands/studio.md
+++ b/commands/studio.md
@@ -64,7 +64,8 @@ Use `AskUserQuestion` with this question, repeated until the user picks `Exit`:
   3. `Meeting simulation (facilitated)` — "A facilitator-led meeting with an agenda"
   4. `List avatars` — "Summary of saved personas"
   5. `Refine an avatar` — "Update specific sections of one persona"
-  6. `Exit` — "Exit the studio"
+  6. `Toggle factual grounding` — "Turn grounding ON/OFF for this session (default: ON). Brainstorming sessions may want it OFF to welcome divergent claims."
+  7. `Exit` — "Exit the studio"
 
 Route to the matching sub-flow below. After each sub-flow returns, come back to
 this menu instead of ending the session.
@@ -134,6 +135,73 @@ where `<scope>` is `project` or `global`. Then return to the menu.
 2. Execute the steps from `commands/persona-refine.md` inline for that persona
    — that command handles scope resolution internally and edits in-place (never
    crosses scopes silently).
+
+## Route F — Toggle factual grounding
+
+Session-scoped toggle for the entire factual-grounding pipeline
+(`[EVIDENCE BANK]` injection, verify_claims, Tier-2 external verification,
+Tier-3 CoVe, and post-meeting audit). Default: ON. Turning it OFF is the
+escape hatch for pure-brainstorming sessions where divergent / speculative
+claims are welcome and hallucinations should not be suppressed.
+
+State lives in a single JSON file at the project root: `data/grounding-session.json`.
+
+1. Read the current state:
+
+```bash
+.venv/bin/python - <<'PY'
+import json, pathlib
+path = pathlib.Path("data/grounding-session.json")
+if path.exists():
+    state = json.loads(path.read_text(encoding="utf-8"))
+else:
+    state = {"enabled": True, "until": "session"}
+print(json.dumps(state))
+PY
+```
+
+   - If the file does not exist, grounding is ON by default.
+
+2. Flip the `enabled` boolean and write back. On first toggle (file missing)
+   this writes `{"enabled": false, "until": "session"}`.
+
+```bash
+.venv/bin/python - <<'PY'
+import json, pathlib
+path = pathlib.Path("data/grounding-session.json")
+path.parent.mkdir(parents=True, exist_ok=True)
+if path.exists():
+    state = json.loads(path.read_text(encoding="utf-8"))
+    state["enabled"] = not bool(state.get("enabled", True))
+else:
+    state = {"enabled": False, "until": "session"}
+state["until"] = "session"
+path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+print(json.dumps(state))
+PY
+```
+
+3. Print the new state to the user exactly as:
+   - `Factual grounding: ON` (when `enabled` is true)
+   - `Factual grounding: OFF (this session only)` (when `enabled` is false)
+
+4. Return to the main menu.
+
+**Flag contract (for `simulate-*.md` commands — follow-up task)**:
+
+- Path: `data/grounding-session.json` (project-local, never committed —
+  already covered by the `data/` entry in `.gitignore`).
+- Shape: `{"enabled": bool, "until": "session"}`.
+- Semantics: `enabled == false` means the simulate-* command SHOULD skip
+  the entire grounding pipeline for that run — no `[EVIDENCE BANK]`
+  injection, no `verify_claims` call, no Tier-2 external verification,
+  no Tier-3 CoVe challenge pass, and no post-meeting
+  `persona_studio.grounding.audit` invocation.
+- Default: missing file == `enabled: true`. The `"until": "session"`
+  field is advisory — the state persists across commands within the same
+  project until the user toggles again or deletes the file manually.
+- This task only wires up the toggle + documents the contract; the
+  `simulate-*.md` commands will be updated in a follow-up task.
 
 ## Non-negotiable rules
 

--- a/docs/FACTUAL_GROUNDING.md
+++ b/docs/FACTUAL_GROUNDING.md
@@ -1,0 +1,88 @@
+# Factual Grounding
+
+## Why
+
+When you rehearse a job interview or run a team meeting against AI personas, a hallucinated answer is worse than no answer. A made-up statistic from "Paul Graham" sounds plausible enough that you might repeat it in the real interview the next day. A fabricated quote from your CTO avatar can shape a decision you were only supposed to be stress-testing. Factual grounding tells you at the line level which sentences are anchored in real evidence and which ones the model invented.
+
+## The three tiers
+
+Grounding runs as a staircase. Each tier only activates when the one above it cannot resolve a claim.
+
+```
+claim from avatar
+   |
+   v
+Tier-1 corpus grep  --(match)-->  [SUPPORTED]
+   |
+   (miss on high-risk claim)
+   |
+   v
+Tier-2 external (Perplexity MCP or WebSearch)  --(hit)-->  [VERIFIED-EXTERNAL]
+   |
+   (still unverifiable)
+   |
+   v
+Tier-3 Chain-of-Verification  --(discrepancy)-->  [FACT-CHECKER CHALLENGE]
+                                                  -> avatar retracts / cites / restates
+```
+
+**Tier-1 (always on, offline)** runs a grep-style keyword scorer over each persona's `data/people/<name>/extracted/corpus.md` and `perplexity_notes.md`. It fires on every claim, costs nothing, and produces four tags: `[SUPPORTED: source:line]`, `[UNSUPPORTED]` (corpus contradicts), `[UNVERIFIABLE]` (no relevant material), and `[OPINION]` (subjective, not a factual claim).
+
+**Tier-2 (optional, detected at setup)** fires only on `[UNVERIFIABLE]` claims the rule engine flags as high-risk (numeric anchors, named entities, date-specific facts). If Perplexity MCP is installed, it is used first; otherwise built-in WebSearch runs. Tags become `[VERIFIED-EXTERNAL: tool url]` on a hit or `[UNVERIFIED-EXTERNAL]` when external sources can't confirm either.
+
+**Tier-3 (budget of 5 per avatar)** is Chain-of-Verification. When Tier-2 still cannot verify a high-risk claim, the system generates verification questions from the claim, asks an independent LLM call to answer them using only the evidence bank, and diff-compares against the original. On discrepancy, a `[FACT-CHECKER CHALLENGE: <reason>]` tag is inserted and the avatar is re-invoked to retract, cite, or restate under a `[retract/defend]` blockquote.
+
+## Reading your transcript
+
+A single avatar turn, after all three tiers have run, looks like this:
+
+```markdown
+> **Paul Graham:** The best time to start a startup is your twenties [SUPPORTED: essays/before_the_startup.md:42].
+> YC funded 4,300 companies in 2023 [UNVERIFIED-EXTERNAL].
+> Most founders I know regret not starting sooner [OPINION].
+> Ramen profitability takes about six weeks [FACT-CHECKER CHALLENGE: corpus says 3-6 months].
+>
+> [retract/defend]
+> I need to correct that — ramen profitability typically takes three to six months, not six weeks [SUPPORTED: essays/ramen_profitable.md:18].
+```
+
+- `[SUPPORTED: source:line]` — Tier-1 found matching evidence. Safe to quote.
+- `[UNSUPPORTED]` — Tier-1 found evidence that contradicts the claim. Read with suspicion.
+- `[UNVERIFIABLE]` — Neither the corpus nor external search could confirm or deny.
+- `[OPINION]` — Subjective statement, not fact-checkable by design.
+- `[VERIFIED-EXTERNAL: tool url]` / `[UNVERIFIED-EXTERNAL]` — Tier-2 outcome.
+- `[FACT-CHECKER CHALLENGE: reason]` — Tier-3 caught a discrepancy and forced a retraction.
+
+## The Factual Grounding section
+
+Every transcript ends with a `## Factual Grounding` section containing one table row per avatar:
+
+| Avatar | Total | Supported | Unsupported | Unverifiable | External-verified | External-unverified | Score |
+|---|---|---|---|---|---|---|---|
+
+The score uses this formula:
+
+```
+score = 10 * (supported + external_verified) / effective_total
+```
+
+Where `effective_total` excludes `[OPINION]` lines (opinions are not fact-checkable, so they neither help nor hurt). A score of 9-10 means the avatar stuck to cited material; 6-8 means meaningful hallucination is present; below 6 means you should treat the transcript as creative fiction, not reference material. The section also lists each avatar's top-3 unsupported claims so you can see *what* was hallucinated, not just how much.
+
+## Upgrading from WebSearch to Perplexity MCP
+
+WebSearch is always available and works fine. Perplexity MCP improves Tier-2 quality because it returns ranked citations with excerpts instead of raw links, which lets the tagger attribute a specific URL to each verified claim. To add it, open Claude Code's plugin marketplace and search for "perplexity MCP"; persona-studio auto-detects it on the next `/persona-studio:persona-setup` run.
+
+## Disabling for brainstorm sessions
+
+Grounding is designed for rehearsal and verification. For pure brainstorming, where you *want* the avatars to speculate freely, use the `/persona-studio:studio` menu toggle to turn the entire layer off for a session. The transcript still gets written; it just skips the tagging pass and the `## Factual Grounding` table.
+
+## Persona without a corpus
+
+If a persona was added by name only (for example, `paul_graham` created with no uploaded files) and `data/people/paul_graham/extracted/corpus.md` does not exist, Tier-1 emits a stderr warning on retrieve and returns zero supported matches. Tier-2 and Tier-3 still run if available, so you will still get `[VERIFIED-EXTERNAL]` or `[UNVERIFIABLE]` tags where the web can help — the score will just be lower, and honestly so. To fix, run `/persona-studio:create-persona <name>` and drop real source material into the persona's input folder.
+
+## Known limits
+
+- Tier-1 keyword matching is strict on numeric anchors: "six months" and "6 months" should both match, but "roughly half a year" will not.
+- Tier-3 is capped at 5 challenges per avatar per simulation (configurable via a bash env in the `simulate-*` command) to keep runs bounded.
+- Negation detection is heuristic. "Y Combinator never funded Airbnb" vs. "Y Combinator funded Airbnb" can occasionally both match the same evidence line.
+- The score rewards supported claims and penalizes unsupported ones, but retractions under `[retract/defend]` blocks are not yet weighted positively — a separate Phase D code change addresses this.

--- a/src/persona_studio/grounding/audit.py
+++ b/src/persona_studio/grounding/audit.py
@@ -78,6 +78,7 @@ class AvatarStat:
     unverifiable: int
     external_verified: int = 0
     external_unverified: int = 0
+    recovered: int = 0
     grounding_score: float = 0.0
     top_unsupported: list[str] = field(default_factory=list)
 
@@ -102,6 +103,9 @@ _PARTICIPANTS_RE = re.compile(r"^participants:\s*\[([^\]]*)\]", re.MULTILINE)
 
 _EXTERNAL_VERIFIED_RE = re.compile(r"\[VERIFIED-EXTERNAL:[^\]]+\]")
 _EXTERNAL_UNVERIFIED_RE = re.compile(r"\[UNVERIFIED-EXTERNAL\]")
+_RECOVERED_RE = re.compile(
+    r"\[FACT-CHECKER CHALLENGE:[^\]]+\][^\[]*\[retract/defend\]"
+)
 
 
 def audit_transcript(path: Path) -> AuditReport:
@@ -140,14 +144,15 @@ def render_audit_section(report: AuditReport) -> str:
 
     lines.append(
         "| Avatar | Total | Supported | Unsupported | Unverifiable | "
-        "External-verified | External-unverified | Score |"
+        "External-verified | External-unverified | Recovered | Score |"
     )
-    lines.append("| --- | --- | --- | --- | --- | --- | --- | --- |")
+    lines.append("| --- | --- | --- | --- | --- | --- | --- | --- | --- |")
     for avatar, stat in sorted(report.avatars.items()):
         lines.append(
             f"| {avatar} | {stat.total_claims} | {stat.supported} | "
             f"{stat.unsupported} | {stat.unverifiable} | "
             f"{stat.external_verified} | {stat.external_unverified} | "
+            f"{stat.recovered} | "
             f"{stat.grounding_score:.2f} |"
         )
 
@@ -206,6 +211,11 @@ def _audit_avatar(avatar: str, transcript_text: str) -> AvatarStat | None:
     raw_joined = " ".join(quoted_lines)
     external_verified = len(_EXTERNAL_VERIFIED_RE.findall(raw_joined))
     external_unverified = len(_EXTERNAL_UNVERIFIED_RE.findall(raw_joined))
+    # Tier-3 CoVe retract pattern: a FACT-CHECKER CHALLENGE followed by a
+    # retract/defend marker on the same (or adjacent) blockquote line means
+    # the original UNVERIFIABLE claim was caught AND corrected on the
+    # record — count those as "recovered" (contributes positively to score).
+    recovered = len(_RECOVERED_RE.findall(raw_joined))
 
     full_text = strip_annotations(raw_joined)
     claims = extract_claims(full_text)
@@ -237,17 +247,26 @@ def _audit_avatar(avatar: str, transcript_text: str) -> AvatarStat | None:
     # extractor may not have classified as fact-assertions.
     effective_total = max(
         total_fact,
-        supported + unsupported + unverifiable + external_verified + external_unverified,
+        supported
+        + unsupported
+        + unverifiable
+        + external_verified
+        + external_unverified
+        + recovered,
     )
 
-    # Score semantics: SUPPORTED + EXTERNAL_VERIFIED both count as +1; the
-    # rest contribute nothing. "No factual claims" → 10.0 so short opinion
-    # turns don't drag the score down.
+    # Score semantics: SUPPORTED + EXTERNAL_VERIFIED + RECOVERED all count
+    # as +1; the rest contribute nothing. Recovered claims reward the
+    # grounding pipeline's most valuable moment — catching a hallucination
+    # AND getting a correction on the record. "No factual claims" → 10.0
+    # so short opinion turns don't drag the score down.
     if effective_total == 0:
         score = 10.0
     else:
         score = round(
-            10.0 * (supported + external_verified) / max(effective_total, 1),
+            10.0
+            * (supported + external_verified + recovered)
+            / max(effective_total, 1),
             2,
         )
 
@@ -262,6 +281,7 @@ def _audit_avatar(avatar: str, transcript_text: str) -> AvatarStat | None:
         unverifiable=unverifiable,
         external_verified=external_verified,
         external_unverified=external_unverified,
+        recovered=recovered,
         grounding_score=score,
         top_unsupported=top_unsupported,
     )

--- a/tests/grounding/test_audit.py
+++ b/tests/grounding/test_audit.py
@@ -115,6 +115,7 @@ class TestRenderAuditSection:
                     unverifiable=0,
                     external_verified=0,
                     external_unverified=0,
+                    recovered=0,
                     grounding_score=7.5,
                     top_unsupported=["Claim X", "Claim Y"],
                 )
@@ -174,7 +175,7 @@ class TestExternalTagCounting:
         assert stat.external_unverified >= 1
 
     def test_score_counts_external_verified_as_supported(self) -> None:
-        """Score formula: (supported + external_verified) / total."""
+        """Score formula: (supported + external_verified + recovered) / total."""
         report = AuditReport(
             avatars={
                 "alice": AvatarStat(
@@ -184,7 +185,8 @@ class TestExternalTagCounting:
                     unverifiable=1,
                     external_verified=2,
                     external_unverified=0,
-                    grounding_score=7.5,  # (1+2)/4 * 10 = 7.5
+                    recovered=0,
+                    grounding_score=7.5,  # (1+2+0)/4 * 10 = 7.5
                     top_unsupported=[],
                 )
             }
@@ -192,3 +194,73 @@ class TestExternalTagCounting:
         out = render_audit_section(report)
         # External column should be in the table.
         assert "External" in out or "external" in out
+
+
+class TestRecoveredClaims:
+    """Tier-3 CoVe retract pattern: challenge + retract = recovered."""
+
+    def _write_transcript(self, tmp_path: Path, body: str) -> Path:
+        path = tmp_path / "sim.md"
+        path.write_text(
+            "---\nkind: debate\nparticipants: [alice]\n---\n"
+            "# t\n\n## Round 1\n### alice\n" + body + "\n"
+            "## Conclusion\nx\n## Satisfaction\n7/10\n## System Feedback\ny\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def test_retract_counted_as_recovered(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "data" / "people" / "alice" / "extracted").mkdir(parents=True)
+        (tmp_path / "data" / "people" / "alice" / "extracted" / "corpus.md").write_text(
+            "# empty\n", encoding="utf-8"
+        )
+        path = self._write_transcript(
+            tmp_path,
+            "> Stripe was founded in 2008. "
+            "[FACT-CHECKER CHALLENGE: Stripe was founded in 2010, not 2008] "
+            "[retract/defend]\n"
+            "> I retract — Stripe was founded in 2010.",
+        )
+        report = audit_transcript(path)
+        stat = report.avatars["alice"]
+        assert stat.recovered >= 1
+        assert stat.grounding_score > 0
+
+    def test_challenge_without_retract_not_counted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "data" / "people" / "alice" / "extracted").mkdir(parents=True)
+        (tmp_path / "data" / "people" / "alice" / "extracted" / "corpus.md").write_text(
+            "# empty\n", encoding="utf-8"
+        )
+        path = self._write_transcript(
+            tmp_path,
+            "> Stripe was founded in 2008. "
+            "[FACT-CHECKER CHALLENGE: Stripe was founded in 2010, not 2008]",
+        )
+        report = audit_transcript(path)
+        stat = report.avatars["alice"]
+        assert stat.recovered == 0
+
+    def test_render_section_includes_recovered_column(self) -> None:
+        report = AuditReport(
+            avatars={
+                "alice": AvatarStat(
+                    total_claims=3,
+                    supported=1,
+                    unsupported=0,
+                    unverifiable=1,
+                    external_verified=0,
+                    external_unverified=0,
+                    recovered=1,
+                    grounding_score=6.67,  # (1+0+1)/3 * 10 = 6.67
+                    top_unsupported=[],
+                )
+            }
+        )
+        out = render_audit_section(report)
+        assert "Recovered" in out


### PR DESCRIPTION
## Summary

Three UX polish items on top of the now-complete three-tier grounding stack (Phases A-C).

### 1. `docs/FACTUAL_GROUNDING.md` (NEW)

891-word user-facing explainer. Sections:
- Why grounding matters (interview-rehearsal framing)
- The three tiers — with ASCII flow diagram
- Reading your transcript — annotated example with all tag families
- The Factual Grounding section — table columns + score formula
- Upgrading from WebSearch to Perplexity MCP
- Disabling for brainstorm sessions
- Persona without a corpus (paul_graham-class case)
- Known limits

READMEs (EN + KO) get a tighter 200-word callout that points here.

### 2. `/persona-studio:studio` menu toggle

New option: **"Toggle factual grounding"** (between *Refine an avatar* and *Exit*). Flips a flag at `data/grounding-session.json`:
```json
{"enabled": false, "until": "session"}
```
Contract documented in a new **Route F** section. The 6 `simulate-*.md` commands will read this flag and skip the grounding pipeline when OFF — that wiring is explicitly scoped out of this PR for discipline; it's a small follow-up.

### 3. Retract-aware audit (the important one)

Phase C's live E2E exposed a scoring gap: when CoVe caught a hallucination and the avatar retracted on record, the audit still counted the original claim as UNVERIFIABLE. The pipeline's best moment — catch + correct — was under-rewarded.

**Fix**: detect the `[FACT-CHECKER CHALLENGE: …] … [retract/defend]` pair, count each as `recovered`, include in the scoring numerator:
```
score = 10 * (supported + external_verified + recovered) / effective_total
```
Rendered table gains a `Recovered` column.

**Effect on Phase C E2E transcript** (paul_graham Stripe retract):
```
| Avatar       | Total | Supported | Unsupported | Unverifiable | External-verified | External-unverified | Recovered | Score |
| paul_graham  |   4   |     0     |      0      |      3       |         0         |          0          |     1     | 2.50  |
| sample_private |   2   |     2     |      0      |      0       |         0         |          0          |     0     | 10.00 |
```
Before Phase D: paul_graham scored 0.00. After: 2.50 — the retract is finally a positive signal.

## Test plan

- [x] 234/234 tests pass (+3 new audit tests for retract detection)
- [x] Grounding coverage 90% total
- [x] Live re-run of the Phase C E2E transcript shows `Recovered: 1` for paul_graham
- [x] `wc -w docs/FACTUAL_GROUNDING.md` → 891 (target 600-900)
- [x] Acceptance greps (`Tier-1|Tier-2|Tier-3` ≥ 6, `FACTUAL_GROUNDING.md` link in both READMEs)
- [x] Built with Agent Teams (2 parallel teammates: `docs-writer` + `code-improver`, no file overlap)

## What's next

- Wire `grounding-session.json` flag into the 6 simulate-*.md commands (small follow-up PR)
- Optional demo `.gif` of the CHALLENGE/retract cycle (manual recording task)