### PR TITLE
feat(grounding): wire session toggle into all simulate-* commands

### DIFF
--- a/commands/simulate-debate-team-ralph.md
+++ b/commands/simulate-debate-team-ralph.md
@@ -6,6 +6,18 @@ description: Split-panes debate + satisfaction-score Ralph loop. Mandatory 3-axi
 
 Combines `/persona-studio:simulate-debate-team` with the scoring + Ralph loop pattern from `/persona-studio:simulate-meeting-team-ralph`. Satisfaction is evaluated after the round loop instead of after an agenda.
 
+## Preamble — session grounding flag check
+
+Inherits the same preamble as `/persona-studio:simulate-debate-team`. Run the session-flag check once at the top:
+
+```bash
+if [ "$(.venv/bin/python -m persona_studio.grounding.session status)" = "disabled" ]; then
+    GROUNDING_ENABLED=false
+fi
+```
+
+When `GROUNDING_ENABLED=false` the Ralph loop ALSO suppresses the automatic "Factual Grounding" 4th criterion (since there's no audit score to read). User's 3 manual criteria remain the only gates.
+
 ## Step 0 — Pre-flight + TUI
 
 Same as `/persona-studio:simulate-debate-team` Step 0 plus the `/persona-studio:simulate-meeting-team-ralph` TUI inputs (target score, max iterations, 3 measurement criteria, and the automatic **Factual Grounding 4th criterion** with default goal 8/10 — scored via `python -m persona_studio.grounding.audit`).

--- a/commands/simulate-debate-team.md
+++ b/commands/simulate-debate-team.md
@@ -8,6 +8,22 @@ Split-panes version of `/persona-studio:simulate-debate`. Each persona becomes a
 teammate running in its own pane. Sequential version stays at
 `/persona-studio:simulate-debate` for environments without tmux.
 
+## Preamble — session grounding flag check
+
+```bash
+if [ "$(.venv/bin/python -m persona_studio.grounding.session status)" = "disabled" ]; then
+    GROUNDING_ENABLED=false
+    echo "[grounding] disabled for this session — skipping the grounding pipeline"
+else
+    GROUNDING_ENABLED=true
+fi
+```
+
+When `GROUNDING_ENABLED=false`: SKIP the `[EVIDENCE BANK]` dispatch,
+`verify_claims` calls, Tier-2 external-verification fallback, the
+fact-checker teammate spawn, and post-meeting audit. The debate still
+runs with avatar teammates only.
+
 ## Step 0 — Pre-flight check
 
 Identical to `/persona-studio:simulate-meeting-team` Step 0:

--- a/commands/simulate-debate.md
+++ b/commands/simulate-debate.md
@@ -6,6 +6,29 @@ description: Round-robin debate among 2-5 persona avatars. Usage: /persona-studi
 
 $ARGUMENTS
 
+## Preamble — session grounding flag check (runs first)
+
+Read the session-scoped grounding flag BEFORE any grounding work:
+
+```bash
+if [ "$(.venv/bin/python -m persona_studio.grounding.session status)" = "disabled" ]; then
+    GROUNDING_ENABLED=false
+    echo "[grounding] disabled for this session — skipping the grounding pipeline"
+else
+    GROUNDING_ENABLED=true
+fi
+```
+
+When `GROUNDING_ENABLED=false`, every grounding-related step in this
+command is a no-op: SKIP the `[EVIDENCE BANK]` retrieval (Step 2 sub-step
+1.5), the `verify_claims` call, the Tier-2 external-verification
+fallback (Step 3.5), the Step 3.6 CoVe pass, and the `audit.py`
+invocation (Step 5). The debate still runs — it just produces a vanilla
+transcript without `[SUPPORTED]` / `[UNSUPPORTED]` /
+`[VERIFIED-EXTERNAL]` / `[FACT-CHECKER CHALLENGE]` tags and without the
+final `## Factual Grounding` section. Users re-enable via
+`/persona-studio:studio` → Toggle factual grounding.
+
 ## Step 0 — Normalize inputs
 
 Parse `<topic>` (quoted string) and participants (at least 2 persona slugs).

--- a/commands/simulate-meeting-team-ralph.md
+++ b/commands/simulate-meeting-team-ralph.md
@@ -6,6 +6,18 @@ description: Split-panes meeting + user satisfaction score goal + Ralph loop (au
 
 A variant of the split-panes meeting that adds a **Ralph loop + user-satisfaction score gate**. It keeps everything from `/persona-studio:simulate-meeting-team`, then adds a TUI goal-setting step before the meeting, post-meeting scoring, and an automatic re-run when the score is below the goal.
 
+## Preamble — session grounding flag check
+
+Inherits the same preamble as `/persona-studio:simulate-meeting-team`:
+
+```bash
+if [ "$(.venv/bin/python -m persona_studio.grounding.session status)" = "disabled" ]; then
+    GROUNDING_ENABLED=false
+fi
+```
+
+When `GROUNDING_ENABLED=false` the Ralph loop ALSO suppresses the automatic "Factual Grounding" 4th criterion (no audit score to read). User's 3 manual criteria remain the only gates.
+
 ## Step 0 — Pre-flight + TUI satisfaction-score setup
 
 1. Run the same tmux / teammate-mode pre-flight checks as `/persona-studio:simulate-meeting-team` Step 0.

--- a/commands/simulate-meeting-team.md
+++ b/commands/simulate-meeting-team.md
@@ -8,6 +8,22 @@ Split-panes version of `/persona-studio:simulate-meeting`. Each persona becomes 
 teammate running in its own pane. Sequential version stays at `/persona-studio:simulate-meeting`
 for environments without tmux.
 
+## Preamble — session grounding flag check
+
+```bash
+if [ "$(.venv/bin/python -m persona_studio.grounding.session status)" = "disabled" ]; then
+    GROUNDING_ENABLED=false
+    echo "[grounding] disabled for this session — skipping the grounding pipeline"
+else
+    GROUNDING_ENABLED=true
+fi
+```
+
+When `GROUNDING_ENABLED=false`: SKIP the `[EVIDENCE BANK]` dispatch,
+`verify_claims` calls, Tier-2 external-verification fallback, the
+fact-checker teammate spawn, and post-meeting audit. The meeting still
+runs with avatar teammates only.
+
 ## Step 0 — Pre-flight check (MUST pass before spawning any teammate)
 
 Run these checks in order. Abort with a clear user message if any fails.

--- a/commands/simulate-meeting.md
+++ b/commands/simulate-meeting.md
@@ -6,6 +6,23 @@ description: Facilitated meeting simulation. Usage: /persona-studio:simulate-mee
 
 $ARGUMENTS
 
+## Preamble — session grounding flag check
+
+```bash
+if [ "$(.venv/bin/python -m persona_studio.grounding.session status)" = "disabled" ]; then
+    GROUNDING_ENABLED=false
+    echo "[grounding] disabled for this session — skipping the grounding pipeline"
+else
+    GROUNDING_ENABLED=true
+fi
+```
+
+When `GROUNDING_ENABLED=false`: SKIP the `[EVIDENCE BANK]` retrieval,
+`verify_claims` calls, Tier-2 external-verification fallback, Tier-3 CoVe
+pass, and post-meeting `audit.py` invocation. The meeting still runs and
+produces a plain transcript. Users re-enable via `/persona-studio:studio`
+→ Toggle factual grounding.
+
 ## Step 0 — Normalize inputs
 
 Same participant validation as `/persona-studio:simulate-debate` (including the

--- a/commands/studio.md
+++ b/commands/studio.md
@@ -144,64 +144,45 @@ Tier-3 CoVe, and post-meeting audit). Default: ON. Turning it OFF is the
 escape hatch for pure-brainstorming sessions where divergent / speculative
 claims are welcome and hallucinations should not be suppressed.
 
-State lives in a single JSON file at the project root: `data/grounding-session.json`.
+State lives in a single JSON file at the project root: `data/grounding-session.json`. The `persona_studio.grounding.session` CLI manages reads and writes so this command stays a one-liner.
 
-1. Read the current state:
+1. Toggle via the session CLI:
+   ```bash
+   NEW_STATE=$(.venv/bin/python -m persona_studio.grounding.session toggle)
+   # NEW_STATE is literally "enabled" or "disabled"
+   ```
 
-```bash
-.venv/bin/python - <<'PY'
-import json, pathlib
-path = pathlib.Path("data/grounding-session.json")
-if path.exists():
-    state = json.loads(path.read_text(encoding="utf-8"))
-else:
-    state = {"enabled": True, "until": "session"}
-print(json.dumps(state))
-PY
-```
+2. Print the new state to the user exactly as:
+   - `Factual grounding: ON` (when output is `enabled`)
+   - `Factual grounding: OFF (this session only)` (when output is `disabled`)
 
-   - If the file does not exist, grounding is ON by default.
+3. Return to the main menu.
 
-2. Flip the `enabled` boolean and write back. On first toggle (file missing)
-   this writes `{"enabled": false, "until": "session"}`.
-
-```bash
-.venv/bin/python - <<'PY'
-import json, pathlib
-path = pathlib.Path("data/grounding-session.json")
-path.parent.mkdir(parents=True, exist_ok=True)
-if path.exists():
-    state = json.loads(path.read_text(encoding="utf-8"))
-    state["enabled"] = not bool(state.get("enabled", True))
-else:
-    state = {"enabled": False, "until": "session"}
-state["until"] = "session"
-path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
-print(json.dumps(state))
-PY
-```
-
-3. Print the new state to the user exactly as:
-   - `Factual grounding: ON` (when `enabled` is true)
-   - `Factual grounding: OFF (this session only)` (when `enabled` is false)
-
-4. Return to the main menu.
-
-**Flag contract (for `simulate-*.md` commands — follow-up task)**:
+**Flag contract (consumed by `simulate-*.md` commands)**:
 
 - Path: `data/grounding-session.json` (project-local, never committed —
-  already covered by the `data/` entry in `.gitignore`).
+  covered by the `data/` allowlist rules in `.gitignore`).
 - Shape: `{"enabled": bool, "until": "session"}`.
-- Semantics: `enabled == false` means the simulate-* command SHOULD skip
-  the entire grounding pipeline for that run — no `[EVIDENCE BANK]`
-  injection, no `verify_claims` call, no Tier-2 external verification,
-  no Tier-3 CoVe challenge pass, and no post-meeting
-  `persona_studio.grounding.audit` invocation.
-- Default: missing file == `enabled: true`. The `"until": "session"`
-  field is advisory — the state persists across commands within the same
-  project until the user toggles again or deletes the file manually.
-- This task only wires up the toggle + documents the contract; the
-  `simulate-*.md` commands will be updated in a follow-up task.
+- Semantics: `enabled == false` means the simulate-* command MUST skip the
+  entire grounding pipeline for that run — no `[EVIDENCE BANK]` injection,
+  no `verify_claims` call, no Tier-2 external verification, no Tier-3 CoVe
+  challenge pass, and no post-meeting `persona_studio.grounding.audit`
+  invocation.
+- Fail-safe: missing file / malformed JSON / missing `enabled` key all
+  resolve to `enabled: true` (grounding stays ON). A broken flag file
+  never silently disables grounding.
+- Default: missing file == `enabled: true`. The `"until": "session"` field
+  is advisory — state persists across commands within the same project
+  until the user toggles again or deletes the file.
+- Canonical programmatic check from a simulate-* command:
+  ```bash
+  if [ "$(.venv/bin/python -m persona_studio.grounding.session status)" = "disabled" ]; then
+      # skip the entire grounding pipeline for this run
+      GROUNDING_ENABLED=false
+  else
+      GROUNDING_ENABLED=true
+  fi
+  ```
 
 ## Non-negotiable rules
 

--- a/src/persona_studio/grounding/session.py
+++ b/src/persona_studio/grounding/session.py
@@ -1,0 +1,125 @@
+"""Session-scoped grounding toggle.
+
+Lets a single `/persona-studio:studio` session turn the entire grounding
+layer off (useful for pure-brainstorm scenarios where hallucinations are
+welcome). Flag lives in ``data/grounding-session.json`` — it's scoped to
+the checkout rather than the user, so different projects can hold
+different stances.
+
+Fail-safe default: missing file, malformed JSON, or a missing ``enabled``
+key all resolve to ``is_enabled() == True``. A broken flag file never
+silently disables grounding; the user must explicitly toggle off.
+
+CLI::
+
+    python -m persona_studio.grounding.session status   # prints "enabled" or "disabled"
+    python -m persona_studio.grounding.session enable
+    python -m persona_studio.grounding.session disable
+    python -m persona_studio.grounding.session toggle
+
+Exit code 0 for all successful operations; 2 on argparse failure.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+SESSION_FILE = Path("data") / "grounding-session.json"
+
+
+def _session_path(base: Path | None = None) -> Path:
+    return (base or Path.cwd()) / SESSION_FILE
+
+
+def load_flag(base: Path | None = None) -> dict[str, object] | None:
+    """Return the raw flag dict, or None if missing / unreadable."""
+    path = _session_path(base)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def is_enabled(base: Path | None = None) -> bool:
+    """Return True unless the flag explicitly sets ``enabled`` to False.
+
+    Fail-safe: any error, missing file, or missing key → True.
+    """
+    data = load_flag(base)
+    if data is None:
+        return True
+    value = data.get("enabled")
+    if isinstance(value, bool):
+        return value
+    return True
+
+
+def _write(enabled: bool, base: Path | None = None) -> Path:
+    path = _session_path(base)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"enabled": enabled, "until": "session"}, indent=2, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def enable(base: Path | None = None) -> bool:
+    _write(True, base=base)
+    return True
+
+
+def disable(base: Path | None = None) -> bool:
+    _write(False, base=base)
+    return False
+
+
+def toggle(base: Path | None = None) -> bool:
+    """Flip the flag; return the new enabled state."""
+    current = is_enabled(base=base)
+    if current:
+        disable(base=base)
+        return False
+    enable(base=base)
+    return True
+
+
+def _label(enabled: bool) -> str:
+    return "enabled" if enabled else "disabled"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m persona_studio.grounding.session",
+        description="Manage the session-scoped factual-grounding toggle.",
+    )
+    parser.add_argument(
+        "action",
+        choices=("status", "enable", "disable", "toggle"),
+        help="What to do.",
+    )
+    ns = parser.parse_args(argv)
+
+    if ns.action == "status":
+        print(_label(is_enabled()))
+        return 0
+    if ns.action == "enable":
+        enable()
+        print(_label(True))
+        return 0
+    if ns.action == "disable":
+        disable()
+        print(_label(False))
+        return 0
+    # toggle
+    new_state = toggle()
+    print(_label(new_state))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/grounding/test_session.py
+++ b/tests/grounding/test_session.py
@@ -1,0 +1,136 @@
+"""Tests for persona_studio.grounding.session — session toggle flag."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from persona_studio.grounding.session import (
+    SESSION_FILE,
+    disable,
+    enable,
+    is_enabled,
+    load_flag,
+    toggle,
+)
+
+
+class TestIsEnabled:
+    def test_default_is_enabled_when_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        assert is_enabled() is True
+
+    def test_disabled_when_flag_set_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        path = tmp_path / SESSION_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"enabled": False}), encoding="utf-8")
+        assert is_enabled() is False
+
+    def test_enabled_when_flag_set_true(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        path = tmp_path / SESSION_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"enabled": True}), encoding="utf-8")
+        assert is_enabled() is True
+
+    def test_malformed_json_defaults_to_enabled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fail-safe: broken flag file must not disable grounding silently."""
+        monkeypatch.chdir(tmp_path)
+        path = tmp_path / SESSION_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json", encoding="utf-8")
+        assert is_enabled() is True
+
+    def test_missing_enabled_key_defaults_to_enabled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        path = tmp_path / SESSION_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"other": "field"}), encoding="utf-8")
+        assert is_enabled() is True
+
+
+class TestToggle:
+    def test_toggle_from_missing_disables(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        new_state = toggle()
+        assert new_state is False
+        assert is_enabled() is False
+
+    def test_toggle_from_disabled_re_enables(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        disable()
+        new_state = toggle()
+        assert new_state is True
+        assert is_enabled() is True
+
+    def test_disable_then_enable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        disable()
+        assert is_enabled() is False
+        enable()
+        assert is_enabled() is True
+
+    def test_load_flag_returns_dict(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        disable()
+        flag = load_flag()
+        assert flag is not None
+        assert flag["enabled"] is False
+        assert "until" in flag
+
+
+class TestCli:
+    def _run(
+        self, args: list[str], cwd: Path
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-m", "persona_studio.grounding.session", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_status_default_enabled(self, tmp_path: Path) -> None:
+        result = self._run(["status"], cwd=tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == "enabled"
+
+    def test_status_after_disable(self, tmp_path: Path) -> None:
+        self._run(["disable"], cwd=tmp_path)
+        result = self._run(["status"], cwd=tmp_path)
+        assert result.stdout.strip() == "disabled"
+
+    def test_toggle_flips_state(self, tmp_path: Path) -> None:
+        r1 = self._run(["toggle"], cwd=tmp_path)
+        assert "disabled" in r1.stdout
+        r2 = self._run(["toggle"], cwd=tmp_path)
+        assert "enabled" in r2.stdout
+
+    def test_enable_is_idempotent(self, tmp_path: Path) -> None:
+        r1 = self._run(["enable"], cwd=tmp_path)
+        r2 = self._run(["enable"], cwd=tmp_path)
+        assert r1.returncode == 0 and r2.returncode == 0
+        result = self._run(["status"], cwd=tmp_path)
+        assert result.stdout.strip() == "enabled"


### PR DESCRIPTION
## Summary

Closes the loop on the Phase D studio menu toggle: the 6 `simulate-*` commands now actually read `data/grounding-session.json` and skip the grounding pipeline when the user turned it off via `/persona-studio:studio → Toggle factual grounding`.

## What's new

**`src/persona_studio/grounding/session.py`** (new module, 125 lines, 13 tests, 100% coverage)
- `load_flag()` / `is_enabled()` / `enable()` / `disable()` / `toggle()` — Python API.
- CLI: `status` / `enable` / `disable` / `toggle`. Prints literal `enabled` or `disabled` so shell checks stay trivial: `[ "$(... status)" = "disabled" ]`.
- **Fail-safe default**: missing file, malformed JSON, missing `enabled` key → `True`. A broken flag never silently disables grounding.

**`commands/studio.md` Route F refactor**
- Replaced two inline python heredocs with a single `session toggle` CLI call.
- Updated flag contract docs to reference the canonical CLI pattern.

**`commands/simulate-*.md` preamble (6 files)**
New "Preamble — session grounding flag check" section at the top of each command. When OFF:
- Sequential (`simulate-debate`, `simulate-meeting`): skip `[EVIDENCE BANK]`, `verify_claims`, Tier-2, CoVe, audit.
- Team variants: additionally skip the `fact-checker` teammate spawn.
- Ralph variants: additionally suppress the automatic 4th "Factual Grounding" criterion so user's 3 manual criteria remain the only gates.

## Test plan

- [x] 247/247 tests pass (+13 new session tests)
- [x] Grounding coverage maintained (session.py at 100%)
- [x] CLI round-trip smoke: `status → toggle → status → toggle → status` correctly alternates `enabled ↔ disabled`
- [x] All 6 simulate-*.md files contain the preamble (grep verified)
- [x] Fail-safe regression tests: malformed JSON, missing key, missing file all resolve to enabled