### PR TITLE
feat(web): add clickable browser prototype (hifi-v2 + 8 screens)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -316,6 +316,37 @@ transcript 에 인라인으로 붙는 태그들:
 
 <br/>
 
+## 브라우저 프로토타입 (실험적)
+
+지금까지 Persona Studio 는 CLI 플러그인 전용이었지만, 제안된 웹 UI 의 **클릭 가능 프로토타입** 이 [`web/`](web/) 에 추가됐습니다 — 9개 화면 (Home, Library, Avatar 상세, Create, Setup, Live 시뮬레이션, Results, Settings, Cloud · soon), 런타임에 JSX 파일을 로드하는 단일 HTML 페이지. **빌드 단계 없음**.
+
+```bash
+cd web/
+# 옵션 1 — static server
+python3 -m http.server 7777
+# 옵션 2 — npx serve
+npx --yes serve -l 7777 .
+# 브라우저에서 http://localhost:7777/hifi-v2.html
+```
+
+지금 할 수 있는 것:
+
+- **완전한 클릭 플로우** — 네비 pill 또는 ← / → 화살표로 9개 화면 이동; 각 화면의 hotspot 을 눌러 happy path (Home → Setup → Live → Results) 전진.
+- **Mock data 만** — 아바타·시뮬레이션·transcript 는 디자인 placeholder. 이 프로토타입은 아직 `src/persona_studio/` 의 Python grounding / simulation 파이프라인을 호출하지 않습니다.
+- **Guest mode 표시** — chrome 에 "GUEST MODE · LOCAL ONLY" 표시로 미래 동작 시사; 현재는 nav 선택만 `localStorage` 에 저장.
+
+아직 안 되는 것:
+
+- 실제 Ralph 시뮬레이션 없음 (Live view 는 scripted animated turn 이지 진짜 LLM 출력 아님).
+- `data/people/` · `simulations/` 에 기록 없음.
+- auth / account / Cloud 기능 없음 — 해당 화면은 의도적으로 숨김 + "Cloud · soon" 라벨.
+
+프로토타입을 실제 백엔드에 연결하고 싶으시면 다음 단계는 Streamlit 또는 FastAPI+React 프론트엔드로 `persona_studio.grounding.audit`, `verify_claims`, 그리고 live 시뮬레이션 turn 을 스트리밍할 새 SSE/WebSocket 엔드포인트를 호출하는 것. 로드맵 참조.
+
+> `web/` 번들은 [Claude Design](https://claude.ai/design) 핸드오프. 원본 design README + chat transcript 는 작성자 의도 보존을 위해 `web/docs/` 에 보존. 라이선스 주: design 은 ELv2 를 권장했지만 이 레포는 MIT 유지 — 레포 루트 `LICENSE` 참조.
+
+<br/>
+
 ## 뭐가 만들어지나?
 
 모든 회의는 `simulations/<주제>/`에 세 파일을 남깁니다:

--- a/README.md
+++ b/README.md
@@ -316,6 +316,37 @@ Disable the whole layer for pure-brainstorm sessions via the `/persona-studio:st
 
 <br/>
 
+## Browser prototype (experimental)
+
+Persona Studio has been a CLI plugin from day one, but a **clickable browser prototype** of the proposed web UI now lives in [`web/`](web/) — 9 screens (Home, Library, Avatar detail, Create, Setup, Live simulation, Results, Settings, Cloud · soon), built as a single HTML page that loads JSX files at runtime. **No build step required**.
+
+```bash
+cd web/
+# Option 1 — any static server
+python3 -m http.server 7777
+# Option 2 — npx serve
+npx --yes serve -l 7777 .
+# then open http://localhost:7777/hifi-v2.html
+```
+
+What it does today:
+
+- **Fully clickable flow** — use the nav pills or ← / → arrows to walk through the 9 screens; click hotspots on each screen to move forward on the "happy path" (Home → Setup → Live → Results).
+- **Mock data only** — avatars, simulations, and transcripts shown are design placeholders. This prototype does not yet call the Python grounding or simulation pipeline under `src/persona_studio/`.
+- **Guest mode indicator** — the chrome shows "GUEST MODE · LOCAL ONLY" to signal the future behavior; today there is no persistence beyond the nav selection in `localStorage`.
+
+What it does NOT do yet:
+
+- No real Ralph simulation (the Live view is animated with scripted turns, not actual LLM output).
+- No write to `data/people/` or `simulations/`.
+- No auth / account / Cloud features — those screens are intentionally hidden and labelled "Cloud · soon".
+
+Want to help wire the prototype to the real backend? The next phase would be a Streamlit or FastAPI+React frontend that calls `persona_studio.grounding.audit`, `verify_claims`, and a new SSE/WebSocket endpoint for streaming live simulation turns. See the ROADMAP.
+
+> The `web/` bundle is a [Claude Design](https://claude.ai/design) handoff. Original design README + chat transcripts are preserved under `web/docs/` for authorial intent. License note: the design recommended ELv2, but this repo stays MIT — see `LICENSE` at the repo root.
+
+<br/>
+
 ## What gets generated?
 
 Every meeting produces three files in `simulations/<your-topic>/`:

--- a/tests/web/test_web_prototype.py
+++ b/tests/web/test_web_prototype.py
@@ -1,0 +1,204 @@
+"""Static regression tests for the browser prototype under web/.
+
+We don't run a full headless-browser E2E in CI — that requires a chromium
+install and slows the suite down significantly for what is today a
+static HTML bundle. Instead this test file guards the failure modes most
+likely to break the prototype after a file move / rename / accidental
+delete:
+
+  * every JSX file referenced by <script> tags in hifi-v2.html actually
+    exists on disk;
+  * the HTML parses cleanly and has the expected entry markers;
+  * the license disambiguation note survives at the top of web/README.md;
+  * the top-level README (EN + KO) points at web/ for the browser
+    prototype section.
+
+The live clickable end-to-end — 9-screen navigation, localStorage
+persistence, keyboard arrows, happy-path hotspots — was verified
+manually via Playwright on 2026-04-23 (see web/README.md → "Testing the
+prototype"). Re-run that procedure when making substantive UI changes.
+"""
+from __future__ import annotations
+
+import html.parser
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parent.parent.parent
+WEB = REPO / "web"
+
+
+class _ScriptSrcExtractor(html.parser.HTMLParser):
+    """Collect `src=` values for every <script> tag we encounter."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.src_values: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() != "script":
+            return
+        for k, v in attrs:
+            if k.lower() == "src" and v:
+                self.src_values.append(v)
+
+
+def _script_sources(html_path: Path) -> list[str]:
+    parser = _ScriptSrcExtractor()
+    parser.feed(html_path.read_text(encoding="utf-8"))
+    return parser.src_values
+
+
+# --- file layout --------------------------------------------------------------
+
+
+def test_web_dir_exists() -> None:
+    assert WEB.is_dir(), f"web/ directory missing at {WEB}"
+
+
+def test_hifi_v2_entry_exists() -> None:
+    assert (WEB / "hifi-v2.html").is_file()
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "hifi-v2.html",
+        "landing.html",
+        "wireframes.html",
+        "hifi.html",
+        "hifi-atoms.jsx",
+        "hifi-home.jsx",
+        "hifi-library.jsx",
+        "hifi-live.jsx",
+        "hifi-live-animated.jsx",
+        "hifi-results.jsx",
+        "hifi-v2-screens.jsx",
+        "hifi-auth-screens.jsx",
+        "hifi-avatars.jsx",
+        "design-canvas.jsx",
+        "wireframes-screens.jsx",
+        "README.md",
+        "CONTRIBUTING.md",
+    ],
+)
+def test_expected_file_present(name: str) -> None:
+    assert (WEB / name).is_file(), f"expected web/{name}"
+
+
+def test_docs_handoff_preserved() -> None:
+    assert (WEB / "docs" / "HANDOFF.md").is_file()
+    assert (WEB / "docs" / "design-chats").is_dir()
+    # 4 chat transcripts from design session
+    chats = sorted((WEB / "docs" / "design-chats").glob("chat*.md"))
+    assert len(chats) == 4, f"expected 4 chat transcripts, found {len(chats)}"
+
+
+# --- JSX import graph ---------------------------------------------------------
+
+
+def test_hifi_v2_script_imports_resolve() -> None:
+    """Every <script src="..."> relative to the HTML must exist on disk.
+
+    A broken import here would show up at runtime as a blank screen with
+    a 404 in the console. Static check catches the regression before the
+    user ever opens the page.
+    """
+    html_path = WEB / "hifi-v2.html"
+    for src in _script_sources(html_path):
+        if src.startswith(("http://", "https://")):
+            continue  # external CDN (React, Babel) — skip
+        target = (WEB / src).resolve()
+        assert target.is_file(), (
+            f"hifi-v2.html references '{src}' but {target} does not exist"
+        )
+
+
+def test_hifi_v2_imports_the_8_core_jsx_modules() -> None:
+    """Ensure the 8 JSX files the v2 prototype depends on are all imported.
+
+    If someone removes one and forgets to update the HTML, either the
+    script becomes a 404 (caught above) or the file is silently orphaned
+    (caught here — we assert the HTML still references it).
+    """
+    html_text = (WEB / "hifi-v2.html").read_text(encoding="utf-8")
+    required = {
+        "hifi-atoms.jsx",
+        "hifi-home.jsx",
+        "hifi-library.jsx",
+        "hifi-live.jsx",
+        "hifi-results.jsx",
+        "hifi-v2-screens.jsx",
+        "hifi-live-animated.jsx",
+        "hifi-auth-screens.jsx",
+    }
+    missing = {m for m in required if m not in html_text}
+    assert not missing, f"hifi-v2.html no longer imports: {sorted(missing)}"
+
+
+# --- README safeguards --------------------------------------------------------
+
+
+def test_web_readme_disambiguation_note_present() -> None:
+    """web/README.md is the design handoff's README, which carried an
+    ELv2 badge. We preserved it unedited but added a top-of-file note
+    clarifying that the actual repo license is MIT. That note must stay
+    — otherwise a future reader sees ELv2 at the top and assumes wrong."""
+    content = (WEB / "README.md").read_text(encoding="utf-8")
+    assert "Heads-up for readers" in content, (
+        "license disambiguation front-matter note missing from web/README.md"
+    )
+    assert "actual repo license is MIT" in content, (
+        "MIT license clarification stripped from web/README.md front matter"
+    )
+
+
+def test_top_level_readme_mentions_browser_prototype() -> None:
+    for readme in (REPO / "README.md", REPO / "README.ko.md"):
+        content = readme.read_text(encoding="utf-8")
+        assert "web/" in content and "Browser prototype" in content.replace(
+            "브라우저 프로토타입", "Browser prototype"
+        ), f"{readme.name} does not point at web/ for the browser prototype"
+
+
+# --- prototype-level invariants ----------------------------------------------
+
+
+def test_hifi_v2_has_nine_screen_definitions() -> None:
+    """The SCREENS array in hifi-v2.html drives the nav pills. If a
+    future edit drops a screen, the nav + happy-path logic silently
+    loses it. Lock the count."""
+    content = (WEB / "hifi-v2.html").read_text(encoding="utf-8")
+    # Count lines inside the SCREENS array that look like `{ id: '...', ...`
+    screens_match = re.search(
+        r"const SCREENS = \[(.*?)\];",
+        content,
+        re.DOTALL,
+    )
+    assert screens_match, "SCREENS array not found in hifi-v2.html"
+    screens_body = screens_match.group(1)
+    ids = re.findall(r"id:\s*'([^']+)'", screens_body)
+    # As of 2026-04-23 the Home→Library→Detail→Create→Setup→Live→Results→
+    # Settings→Pricing flow gives exactly 9 screens.
+    assert len(ids) == 9, f"expected 9 screens, found {len(ids)}: {ids}"
+
+
+def test_auth_screens_removed_from_flow_but_kept_in_source() -> None:
+    """OSS-first decision (see web/docs/design-chats/chat4.md): auth
+    screens are hidden from SCREENS but the source JSX is preserved so
+    a future managed/cloud build can re-enable them. Regression guard
+    for both halves of that decision."""
+    content = (WEB / "hifi-v2.html").read_text(encoding="utf-8")
+    screens_match = re.search(r"const SCREENS = \[(.*?)\];", content, re.DOTALL)
+    assert screens_match
+    screens_body = screens_match.group(1)
+    for auth_id in ("signin", "signup", "onboard", "upgrade"):
+        assert auth_id not in screens_body, (
+            f"auth screen '{auth_id}' leaked back into SCREENS"
+        )
+    assert (WEB / "hifi-auth-screens.jsx").is_file(), (
+        "hifi-auth-screens.jsx source removed — should stay as dormant scaffolding"
+    )

--- a/web/CONTRIBUTING.md
+++ b/web/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to Persona Studio
+
+First: thanks for even reading this page. Real contributions make this project worth doing.
+
+## Before you start
+
+- Search [Issues](https://github.com/your-org/persona-studio/issues) and [Discussions](https://github.com/your-org/persona-studio/discussions) — someone may already be on it.
+- For anything bigger than a typo or a one-line fix, **open an issue first** so we can agree on the shape of the change. This saves you from writing a PR we can't merge.
+
+## Local dev
+
+```bash
+pnpm install
+pnpm dev
+```
+
+The hi-fi prototype lives at `hifi-v2.html`. Open it directly — there's no build step for the prototype layer.
+
+## Pull requests
+
+- One concern per PR. Split refactors from features.
+- Keep diffs small. If a PR exceeds ~400 lines, consider splitting it.
+- Include a screenshot or short screen recording for any UI change.
+- Update the relevant docs in the same PR.
+- No new runtime dependencies without discussion.
+
+## Design changes
+
+Design work happens in the `hifi-*` files. When you propose a visual change:
+
+1. Post a before/after screenshot in the PR.
+2. If you're adding a new pattern, justify it against the existing design tokens in `hifi-atoms.jsx`.
+3. Touch the design tokens themselves only in a dedicated PR.
+
+## Code style
+
+- Follow what's already there. Match the existing vocabulary before inventing new abstractions.
+- Comments should explain **why**, not **what**. The code shows what.
+- No dead code. No commented-out blocks "for later."
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [Elastic License 2.0](./LICENSE).
+
+## Code of conduct
+
+Be decent. Assume good intent. Disagree on the thing, not the person. We'll write something more formal when we need to.

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,95 @@
+# Persona Studio — Web Prototype
+
+> **Heads-up for readers**: this README is the **design handoff original** from Claude Design. It lives here unedited so the design authorial intent stays readable. **The actual repo license is MIT** (see `LICENSE` at the repo root), not ELv2 as the badge below suggests. The ELv2 language was the design's license recommendation; we kept MIT for contributor friendliness at this stage. The "clone / run" paths below also reflect the design intent — the real runtime today is a static prototype (see `../README.md` → **Browser prototype** section for how to open it).
+>
+> TL;DR: this file is a design artifact. For canonical install / run / license info, read the project root README.
+
+---
+
+> Build AI personas from public writing, real conversations, or your own notes — then stress-test ideas against them before you ship.
+
+[![License: ELv2](https://img.shields.io/badge/license-ELv2-1f6feb)]() [![Status: Alpha](https://img.shields.io/badge/status-alpha-c96442)]() [![PRs welcome](https://img.shields.io/badge/PRs-welcome-4a7c4e)]()
+
+![Persona Studio — hero](./docs/hero.png)
+
+---
+
+## What is this?
+
+Persona Studio lets you build a library of **AI avatars** grounded in real writing — essays, interviews, chat logs, your own notes — and then:
+
+- **Simulate** — hand them a prompt, a pitch, a feature spec, and watch how they'd react, in voice, in character.
+- **Grade** — score the response against a target rubric (Ralph score), see where it missed.
+- **Iterate** — tweak the input, re-run, compare.
+
+It's a thinking tool, not a chat toy. The point is to catch weaknesses in your ideas before a real audience does.
+
+## Quick start
+
+```bash
+# Clone and run
+git clone https://github.com/your-org/persona-studio
+cd persona-studio
+pnpm install
+pnpm dev
+
+# Open the prototype
+open http://localhost:7777
+```
+
+No signup. No API key wall. First run drops you straight into **Guest Mode** — everything lives in `localStorage` until you decide to self-host properly or move to the Cloud build.
+
+## Features
+
+- **Avatar library** — public figures with curated corpora (Paul Graham, Naval, DHH…) + private mode for your own sources.
+- **Live simulation** — real-time response playback with voice, pacing, interruptions.
+- **Ralph score** — objective-ish rubric grading (0–10) against a target you define.
+- **i18n** — English, Español, 한국어, 日本語.
+- **Bring your own model** — OpenAI, Anthropic, local (Ollama, llama.cpp) via adapter.
+- **Exportable** — avatars, simulations, and results are JSON. Own your data.
+
+## Roadmap
+
+- [x] Hi-fi prototype (clickable)
+- [x] Guest mode (localStorage)
+- [ ] Model adapter layer
+- [ ] Avatar corpus ingestion CLI
+- [ ] Voice pipeline (TTS + STT)
+- [ ] Team workspace (Cloud build)
+- [ ] SSO + audit log (Cloud build)
+
+See [Issues](https://github.com/your-org/persona-studio/issues) for the full list. Good first issues are tagged `good first issue`.
+
+## Contributing
+
+We'd love your help. Before opening a PR, skim [`CONTRIBUTING.md`](./CONTRIBUTING.md). The short version:
+
+1. Open an issue first for anything non-trivial — saves everyone time.
+2. One change per PR. Small diffs get merged faster.
+3. No new dependencies without a good reason.
+4. Design changes: post a screenshot/GIF in the PR description.
+
+Join the conversation:
+- [GitHub Discussions](https://github.com/your-org/persona-studio/discussions) — ideas, questions, show-and-tell
+- [Discord](https://discord.gg/persona-studio) — loose chat, office hours
+
+## License
+
+**Elastic License 2.0 (ELv2).** See [LICENSE](./LICENSE).
+
+In plain English:
+
+- ✅ Use it personally, internally at your company, in research, in your product.
+- ✅ Fork it, modify it, ship it, embed it.
+- ✅ Self-host for your own team.
+- ❌ Resell it as a hosted/managed service that competes with the official Cloud build.
+
+If that sounds like most of what people actually want to do with open-source software — it is. ELv2 exists to keep the project sustainable without locking the code away.
+
+## The team
+
+Persona Studio is built in the open by a small team of humans and a rotating cast of contributors.
+
+---
+
+<sub>Not affiliated with any of the public figures whose writing appears in the example library. All public-figure avatars are clearly labelled and sourced from publicly-available material.</sub>

--- a/web/README.md
+++ b/web/README.md
@@ -4,6 +4,34 @@
 >
 > TL;DR: this file is a design artifact. For canonical install / run / license info, read the project root README.
 
+## Testing the prototype
+
+**Static regression** (runs with every `pytest`, no browser needed):
+
+```bash
+pytest tests/web/ -v
+```
+
+Verifies that every JSX file imported by `hifi-v2.html` exists, the SCREENS array still has exactly 9 entries, auth screens stay out of the flow while their source files survive for future cloud mode, and the license disambiguation notes stay in place. Catches ~80% of "broke the prototype" regressions without spinning up a browser.
+
+**Live end-to-end** (manual, Playwright — run after substantive UI edits):
+
+```bash
+cd web && python3 -m http.server 7780 &
+# in another shell (or via Playwright MCP / a browser)
+open http://localhost:7780/hifi-v2.html
+```
+
+Walkthrough checklist (verified 2026-04-23):
+
+1. Page loads with zero application-level console errors (favicon 404 + Babel dev warning are expected).
+2. Clicking each of the 9 nav pills renders a screen whose body text contains its expected marker (Home → "Rehearse tomorrow's", Library → "New avatar", Detail → "simulation", Create → "Upload", Setup → "Ralph", Live → "Live", Results → "transcript", Settings → "Data", Cloud → "soon").
+3. Arrow keys navigate between screens (← previous, → next); `localStorage['ps_screen']` persists the selection across reloads.
+4. On the Home screen, clicking the "Start a simulation →" hotspot overlay lands on Setup; "Build an avatar" lands on Create.
+5. Reloading mid-flow restores the last visited screen from `localStorage`.
+
+If any step fails, either a JSX file broke or the `SCREENS` / `HOTSPOTS` tables in `hifi-v2.html` drifted.
+
 ---
 
 > Build AI personas from public writing, real conversations, or your own notes — then stress-test ideas against them before you ship.

--- a/web/design-canvas.jsx
+++ b/web/design-canvas.jsx
@@ -1,0 +1,622 @@
+
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// Artboards are reorderable (grip-drag), labels/titles are inline-editable,
+// and any artboard can be opened in a fullscreen focus overlay (←/→/Esc).
+// State persists to a .design-canvas.state.json sidecar via the host
+// bridge. No assets, no deps.
+//
+// Usage:
+//   <DesignCanvas>
+//     <DCSection id="onboarding" title="Onboarding" subtitle="First-run variants">
+//       <DCArtboard id="a" label="A · Dusk" width={260} height={480}>…</DCArtboard>
+//       <DCArtboard id="b" label="B · Minimal" width={260} height={480}>…</DCArtboard>
+//     </DCSection>
+//   </DesignCanvas>
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// One-time CSS injection (classes are dc-prefixed so they don't collide with
+// the hosted design's own styles).
+if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
+  const s = document.createElement('style');
+  s.id = 'dc-styles';
+  s.textContent = [
+    '.dc-editable{cursor:text;outline:none;white-space:nowrap;border-radius:3px;padding:0 2px;margin:0 -2px}',
+    '.dc-editable:focus{background:#fff;box-shadow:0 0 0 1.5px #c96442}',
+    '[data-dc-slot]{transition:transform .18s cubic-bezier(.2,.7,.3,1)}',
+    '[data-dc-slot].dc-dragging{transition:none;z-index:10;pointer-events:none}',
+    '[data-dc-slot].dc-dragging .dc-card{box-shadow:0 12px 40px rgba(0,0,0,.25),0 0 0 2px #c96442;transform:scale(1.02)}',
+    '.dc-card{transition:box-shadow .15s,transform .15s}',
+    '.dc-card *{scrollbar-width:none}',
+    '.dc-card *::-webkit-scrollbar{display:none}',
+    '.dc-labelrow{display:flex;align-items:center;gap:4px;height:24px}',
+    '.dc-grip{cursor:grab;display:flex;align-items:center;padding:5px 4px;border-radius:4px;transition:background .12s}',
+    '.dc-grip:hover{background:rgba(0,0,0,.08)}',
+    '.dc-grip:active{cursor:grabbing}',
+    '.dc-labeltext{cursor:pointer;border-radius:4px;padding:3px 6px;display:flex;align-items:center;transition:background .12s}',
+    '.dc-labeltext:hover{background:rgba(0,0,0,.05)}',
+    '.dc-expand{position:absolute;bottom:100%;right:0;margin-bottom:5px;z-index:2;opacity:0;transition:opacity .12s,background .12s;',
+    '  width:22px;height:22px;border-radius:5px;border:none;cursor:pointer;padding:0;',
+    '  background:transparent;color:rgba(60,50,40,.7);display:flex;align-items:center;justify-content:center}',
+    '.dc-expand:hover{background:rgba(0,0,0,.06);color:#2a251f}',
+    '[data-dc-slot]:hover .dc-expand{opacity:1}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+const DCCtx = React.createContext(null);
+
+// ─────────────────────────────────────────────────────────────
+// DesignCanvas — stateful wrapper around the pan/zoom viewport.
+// Owns runtime state (per-section order, renamed titles/labels, focused
+// artboard). Order/titles/labels persist to a .design-canvas.state.json
+// sidecar next to the HTML. Reads go via plain fetch() so the saved
+// arrangement is visible anywhere the HTML + sidecar are served together
+// (omelette preview, direct link, downloaded zip). Writes go through the
+// host's window.omelette bridge — editing requires the omelette runtime.
+// Focus is ephemeral.
+// ─────────────────────────────────────────────────────────────
+const DC_STATE_FILE = '.design-canvas.state.json';
+
+function DesignCanvas({ children, minScale, maxScale, style }) {
+  const [state, setState] = React.useState({ sections: {}, focus: null });
+  // Hold rendering until the sidecar read settles so the saved order/titles
+  // appear on first paint (no source-order flash). didRead gates writes until
+  // the read settles so the empty initial state can't clobber a slow read;
+  // skipNextWrite suppresses the one echo-write that would otherwise follow
+  // hydration.
+  const [ready, setReady] = React.useState(false);
+  const didRead = React.useRef(false);
+  const skipNextWrite = React.useRef(false);
+
+  React.useEffect(() => {
+    let off = false;
+    fetch('./' + DC_STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((saved) => {
+        if (off || !saved || !saved.sections) return;
+        skipNextWrite.current = true;
+        setState((s) => ({ ...s, sections: saved.sections }));
+      })
+      .catch(() => {})
+      .finally(() => { didRead.current = true; if (!off) setReady(true); });
+    const t = setTimeout(() => { if (!off) setReady(true); }, 150);
+    return () => { off = true; clearTimeout(t); };
+  }, []);
+
+  React.useEffect(() => {
+    if (!didRead.current) return;
+    if (skipNextWrite.current) { skipNextWrite.current = false; return; }
+    const t = setTimeout(() => {
+      window.omelette?.writeFile(DC_STATE_FILE, JSON.stringify({ sections: state.sections })).catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [state.sections]);
+
+  // Build registries synchronously from children so FocusOverlay can read
+  // them in the same render. Only direct DCSection > DCArtboard children are
+  // walked — wrapping them in other elements opts out of focus/reorder.
+  const registry = {};     // slotId -> { sectionId, artboard }
+  const sectionMeta = {};  // sectionId -> { title, subtitle, slotIds[] }
+  const sectionOrder = [];
+  React.Children.forEach(children, (sec) => {
+    if (!sec || sec.type !== DCSection) return;
+    const sid = sec.props.id ?? sec.props.title;
+    if (!sid) return;
+    sectionOrder.push(sid);
+    const persisted = state.sections[sid] || {};
+    const srcIds = [];
+    React.Children.forEach(sec.props.children, (ab) => {
+      if (!ab || ab.type !== DCArtboard) return;
+      const aid = ab.props.id ?? ab.props.label;
+      if (!aid) return;
+      registry[`${sid}/${aid}`] = { sectionId: sid, artboard: ab };
+      srcIds.push(aid);
+    });
+    const kept = (persisted.order || []).filter((k) => srcIds.includes(k));
+    sectionMeta[sid] = {
+      title: persisted.title ?? sec.props.title,
+      subtitle: sec.props.subtitle,
+      slotIds: [...kept, ...srcIds.filter((k) => !kept.includes(k))],
+    };
+  });
+
+  const api = React.useMemo(() => ({
+    state,
+    section: (id) => state.sections[id] || {},
+    patchSection: (id, p) => setState((s) => ({
+      ...s,
+      sections: { ...s.sections, [id]: { ...s.sections[id], ...(typeof p === 'function' ? p(s.sections[id] || {}) : p) } },
+    })),
+    setFocus: (slotId) => setState((s) => ({ ...s, focus: slotId })),
+  }), [state]);
+
+  // Esc exits focus; any outside pointerdown commits an in-progress rename.
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') api.setFocus(null); };
+    const onPd = (e) => {
+      const ae = document.activeElement;
+      if (ae && ae.isContentEditable && !ae.contains(e.target)) ae.blur();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPd, true);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPd, true);
+    };
+  }, [api]);
+
+  return (
+    <DCCtx.Provider value={api}>
+      <DCViewport minScale={minScale} maxScale={maxScale} style={style}>{ready && children}</DCViewport>
+      {state.focus && registry[state.focus] && (
+        <DCFocusOverlay entry={registry[state.focus]} sectionMeta={sectionMeta} sectionOrder={sectionOrder} />
+      )}
+    </DCCtx.Provider>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCViewport — transform-based pan/zoom (internal)
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DCViewport({ children, minScale = 0.1, maxScale = 8, style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (el) el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if (e.ctrlKey) {
+        // trackpad pinch (or explicit ctrl+wheel)
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button on canvas
+    // background (anything that isn't an artboard or an inline editor).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = !e.target.closest('[data-dc-slot], .dc-editable');
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+        }}
+      >
+        <div style={{ position: 'absolute', inset: -6000, backgroundImage: gridSvg, backgroundSize: '120px 120px', pointerEvents: 'none', zIndex: -1 }} />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCSection — editable title + h-row of artboards in persisted order
+// ─────────────────────────────────────────────────────────────
+function DCSection({ id, title, subtitle, children, gap = 48 }) {
+  const ctx = React.useContext(DCCtx);
+  const sid = id ?? title;
+  const all = React.Children.toArray(children);
+  const artboards = all.filter((c) => c && c.type === DCArtboard);
+  const rest = all.filter((c) => !(c && c.type === DCArtboard));
+  const srcOrder = artboards.map((a) => a.props.id ?? a.props.label);
+  const sec = (ctx && sid && ctx.section(sid)) || {};
+
+  const order = React.useMemo(() => {
+    const kept = (sec.order || []).filter((k) => srcOrder.includes(k));
+    return [...kept, ...srcOrder.filter((k) => !kept.includes(k))];
+  }, [sec.order, srcOrder.join('|')]);
+
+  const byId = Object.fromEntries(artboards.map((a) => [a.props.id ?? a.props.label, a]));
+
+  return (
+    <div data-dc-section={sid} style={{ marginBottom: 80, position: 'relative' }}>
+      <div style={{ padding: '0 60px 56px' }}>
+        <DCEditable tag="div" value={sec.title ?? title}
+          onChange={(v) => ctx && sid && ctx.patchSection(sid, { title: v })}
+          style={{ fontSize: 28, fontWeight: 600, color: DC.title, letterSpacing: -0.4, marginBottom: 6, display: 'inline-block' }} />
+        {subtitle && <div style={{ fontSize: 16, color: DC.subtitle }}>{subtitle}</div>}
+      </div>
+      <div style={{ display: 'flex', gap, padding: '0 60px', alignItems: 'flex-start', width: 'max-content' }}>
+        {order.map((k) => (
+          <DCArtboardFrame key={k} sectionId={sid} artboard={byId[k]} order={order}
+            label={(sec.labels || {})[k] ?? byId[k].props.label}
+            onRename={(v) => ctx && ctx.patchSection(sid, (x) => ({ labels: { ...x.labels, [k]: v } }))}
+            onReorder={(next) => ctx && ctx.patchSection(sid, { order: next })}
+            onFocus={() => ctx && ctx.setFocus(`${sid}/${k}`)} />
+        ))}
+      </div>
+      {rest}
+    </div>
+  );
+}
+
+// DCArtboard — marker; rendered by DCArtboardFrame via DCSection.
+function DCArtboard() { return null; }
+
+function DCArtboardFrame({ sectionId, artboard, label, order, onRename, onReorder, onFocus }) {
+  const { id: rawId, label: rawLabel, width = 260, height = 480, children, style = {} } = artboard.props;
+  const id = rawId ?? rawLabel;
+  const ref = React.useRef(null);
+
+  // Live drag-reorder: dragged card sticks to cursor; siblings slide into
+  // their would-be slots in real time via transforms. DOM order only
+  // changes on drop.
+  const onGripDown = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    const me = ref.current;
+    // translateX is applied in local (pre-scale) space but pointer deltas and
+    // getBoundingClientRect().left are screen-space — divide by the viewport's
+    // current scale so the dragged card tracks the cursor at any zoom level.
+    const scale = me.getBoundingClientRect().width / me.offsetWidth || 1;
+    const peers = Array.from(document.querySelectorAll(`[data-dc-section="${sectionId}"] [data-dc-slot]`));
+    const homes = peers.map((el) => ({ el, id: el.dataset.dcSlot, x: el.getBoundingClientRect().left }));
+    const slotXs = homes.map((h) => h.x);
+    const startIdx = order.indexOf(id);
+    const startX = e.clientX;
+    let liveOrder = order.slice();
+    me.classList.add('dc-dragging');
+
+    const layout = () => {
+      for (const h of homes) {
+        if (h.id === id) continue;
+        const slot = liveOrder.indexOf(h.id);
+        h.el.style.transform = `translateX(${(slotXs[slot] - h.x) / scale}px)`;
+      }
+    };
+
+    const move = (ev) => {
+      const dx = ev.clientX - startX;
+      me.style.transform = `translateX(${dx / scale}px)`;
+      const cur = homes[startIdx].x + dx;
+      let nearest = 0, best = Infinity;
+      for (let i = 0; i < slotXs.length; i++) {
+        const d = Math.abs(slotXs[i] - cur);
+        if (d < best) { best = d; nearest = i; }
+      }
+      if (liveOrder.indexOf(id) !== nearest) {
+        liveOrder = order.filter((k) => k !== id);
+        liveOrder.splice(nearest, 0, id);
+        layout();
+      }
+    };
+
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      const finalSlot = liveOrder.indexOf(id);
+      me.classList.remove('dc-dragging');
+      me.style.transform = `translateX(${(slotXs[finalSlot] - homes[startIdx].x) / scale}px)`;
+      // After the settle transition, kill transitions + clear transforms +
+      // commit the reorder in the same frame so there's no visual snap-back.
+      setTimeout(() => {
+        for (const h of homes) { h.el.style.transition = 'none'; h.el.style.transform = ''; }
+        if (liveOrder.join('|') !== order.join('|')) onReorder(liveOrder);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          for (const h of homes) h.el.style.transition = '';
+        }));
+      }, 180);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
+  return (
+    <div ref={ref} data-dc-slot={id} style={{ position: 'relative', flexShrink: 0 }}>
+      <div className="dc-labelrow" style={{ position: 'absolute', bottom: '100%', left: -4, marginBottom: 4, color: DC.label }}>
+        <div className="dc-grip" onPointerDown={onGripDown} title="Drag to reorder">
+          <svg width="9" height="13" viewBox="0 0 9 13" fill="currentColor"><circle cx="2" cy="2" r="1.1"/><circle cx="7" cy="2" r="1.1"/><circle cx="2" cy="6.5" r="1.1"/><circle cx="7" cy="6.5" r="1.1"/><circle cx="2" cy="11" r="1.1"/><circle cx="7" cy="11" r="1.1"/></svg>
+        </div>
+        <div className="dc-labeltext" onClick={onFocus} title="Click to focus">
+          <DCEditable value={label} onChange={onRename} onClick={(e) => e.stopPropagation()}
+            style={{ fontSize: 15, fontWeight: 500, color: DC.label, lineHeight: 1 }} />
+        </div>
+      </div>
+      <button className="dc-expand" onClick={onFocus} onPointerDown={(e) => e.stopPropagation()} title="Focus">
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M7 1h4v4M5 11H1V7M11 1L7.5 4.5M1 11l3.5-3.5"/></svg>
+      </button>
+      <div className="dc-card"
+        style={{ borderRadius: 2, boxShadow: '0 1px 3px rgba(0,0,0,.08),0 4px 16px rgba(0,0,0,.06)', overflow: 'hidden', width, height, background: '#fff', ...style }}>
+        {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb', fontSize: 13, fontFamily: DC.font }}>{id}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Inline rename — commits on blur or Enter.
+function DCEditable({ value, onChange, style, tag = 'span', onClick }) {
+  const T = tag;
+  return (
+    <T className="dc-editable" contentEditable suppressContentEditableWarning
+      onClick={onClick}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={(e) => onChange && onChange(e.currentTarget.textContent)}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); } }}
+      style={style}>{value}</T>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Focus mode — overlay one artboard; ←/→ within section, ↑/↓ across
+// sections, Esc or backdrop click to exit.
+// ─────────────────────────────────────────────────────────────
+function DCFocusOverlay({ entry, sectionMeta, sectionOrder }) {
+  const ctx = React.useContext(DCCtx);
+  const { sectionId, artboard } = entry;
+  const sec = ctx.section(sectionId);
+  const meta = sectionMeta[sectionId];
+  const peers = meta.slotIds;
+  const aid = artboard.props.id ?? artboard.props.label;
+  const idx = peers.indexOf(aid);
+  const secIdx = sectionOrder.indexOf(sectionId);
+
+  const go = (d) => { const n = peers[(idx + d + peers.length) % peers.length]; if (n) ctx.setFocus(`${sectionId}/${n}`); };
+  const goSection = (d) => {
+    const ns = sectionOrder[(secIdx + d + sectionOrder.length) % sectionOrder.length];
+    const first = sectionMeta[ns] && sectionMeta[ns].slotIds[0];
+    if (first) ctx.setFocus(`${ns}/${first}`);
+  };
+
+  React.useEffect(() => {
+    const k = (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); go(1); }
+      if (e.key === 'ArrowUp') { e.preventDefault(); goSection(-1); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); goSection(1); }
+    };
+    document.addEventListener('keydown', k);
+    return () => document.removeEventListener('keydown', k);
+  });
+
+  const { width = 260, height = 480, children } = artboard.props;
+  const [vp, setVp] = React.useState({ w: window.innerWidth, h: window.innerHeight });
+  React.useEffect(() => { const r = () => setVp({ w: window.innerWidth, h: window.innerHeight }); window.addEventListener('resize', r); return () => window.removeEventListener('resize', r); }, []);
+  const scale = Math.max(0.1, Math.min((vp.w - 200) / width, (vp.h - 260) / height, 2));
+
+  const [ddOpen, setDd] = React.useState(false);
+  const Arrow = ({ dir, onClick }) => (
+    <button onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{ position: 'absolute', top: '50%', [dir]: 28, transform: 'translateY(-50%)',
+        border: 'none', background: 'rgba(255,255,255,.08)', color: 'rgba(255,255,255,.9)',
+        width: 44, height: 44, borderRadius: 22, fontSize: 18, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'background .15s' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.18)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.08)')}>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d={dir === 'left' ? 'M11 3L5 9l6 6' : 'M7 3l6 6-6 6'} /></svg>
+    </button>
+  );
+
+  // Portal to body so position:fixed is the real viewport regardless of any
+  // transform on DesignCanvas's ancestors (including the canvas zoom itself).
+  return ReactDOM.createPortal(
+    <div onClick={() => ctx.setFocus(null)}
+      onWheel={(e) => e.preventDefault()}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(24,20,16,.6)', backdropFilter: 'blur(14px)',
+        fontFamily: DC.font, color: '#fff' }}>
+
+      {/* top bar: section dropdown (left) · close (right) */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 72, display: 'flex', alignItems: 'flex-start', padding: '16px 20px 0', gap: 16 }}>
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setDd((o) => !o)}
+            style={{ border: 'none', background: 'transparent', color: '#fff', cursor: 'pointer', padding: '6px 8px',
+              borderRadius: 6, textAlign: 'left', fontFamily: 'inherit' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3 }}>{meta.title}</span>
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" style={{ opacity: .7 }}><path d="M2 4l3.5 3.5L9 4"/></svg>
+            </span>
+            {meta.subtitle && <span style={{ display: 'block', fontSize: 13, opacity: .6, fontWeight: 400, marginTop: 2 }}>{meta.subtitle}</span>}
+          </button>
+          {ddOpen && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: '#2a251f', borderRadius: 8,
+              boxShadow: '0 8px 32px rgba(0,0,0,.4)', padding: 4, minWidth: 200, zIndex: 10 }}>
+              {sectionOrder.map((sid) => (
+                <button key={sid} onClick={() => { setDd(false); const f = sectionMeta[sid].slotIds[0]; if (f) ctx.setFocus(`${sid}/${f}`); }}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer',
+                    background: sid === sectionId ? 'rgba(255,255,255,.1)' : 'transparent', color: '#fff',
+                    padding: '8px 12px', borderRadius: 5, fontSize: 14, fontWeight: sid === sectionId ? 600 : 400, fontFamily: 'inherit' }}>
+                  {sectionMeta[sid].title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1 }} />
+        <button onClick={() => ctx.setFocus(null)}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.12)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          style={{ border: 'none', background: 'transparent', color: 'rgba(255,255,255,.7)', width: 32, height: 32,
+            borderRadius: 16, fontSize: 20, cursor: 'pointer', lineHeight: 1, transition: 'background .12s' }}>×</button>
+      </div>
+
+      {/* card centered, label + index below — only the card itself stops
+          propagation so any backdrop click (including the margins around
+          the card) exits focus */}
+      <div
+        style={{ position: 'absolute', top: 64, bottom: 56, left: 100, right: 100, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+        <div onClick={(e) => e.stopPropagation()} style={{ width: width * scale, height: height * scale, position: 'relative' }}>
+          <div style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', background: '#fff', borderRadius: 2, overflow: 'hidden',
+            boxShadow: '0 20px 80px rgba(0,0,0,.4)' }}>
+            {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb' }}>{aid}</div>}
+          </div>
+        </div>
+        <div onClick={(e) => e.stopPropagation()} style={{ fontSize: 14, fontWeight: 500, opacity: .85, textAlign: 'center' }}>
+          {(sec.labels || {})[aid] ?? artboard.props.label}
+          <span style={{ opacity: .5, marginLeft: 10, fontVariantNumeric: 'tabular-nums' }}>{idx + 1} / {peers.length}</span>
+        </div>
+      </div>
+
+      <Arrow dir="left" onClick={() => go(-1)} />
+      <Arrow dir="right" onClick={() => go(1)} />
+
+      {/* dots */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 8 }}>
+        {peers.map((p, i) => (
+          <button key={p} onClick={() => ctx.setFocus(`${sectionId}/${p}`)}
+            style={{ border: 'none', padding: 0, cursor: 'pointer', width: 6, height: 6, borderRadius: 3,
+              background: i === idx ? '#fff' : 'rgba(255,255,255,.3)' }} />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
+

--- a/web/docs/HANDOFF.md
+++ b/web/docs/HANDOFF.md
@@ -1,0 +1,25 @@
+# CODING AGENTS: READ THIS FIRST
+
+This is a **handoff bundle** from Claude Design (claude.ai/design).
+
+A user mocked up designs in HTML/CSS/JS using an AI design tool, then exported this bundle so a coding agent can implement the designs for real.
+
+## What you should do — IMPORTANT
+
+**Read the chat transcripts first.** There are 4 chat transcript(s) in `persona-studio/chats/`. The transcripts show the full back-and-forth between the user and the design assistant — they tell you **what the user actually wants** and **where they landed** after iterating. Don't skip them. The final HTML files are the output, but the chat is where the intent lives.
+
+**Read `persona-studio/project/hifi-v2.html` in full.** The user had this file open when they triggered the handoff, so it's almost certainly the primary design they want built. Read it top to bottom — don't skim. Then **follow its imports**: open every file it pulls in (shared components, CSS, scripts) so you understand how the pieces fit together before you start implementing.
+
+**If anything is ambiguous, ask the user to confirm before you start implementing.** It's much cheaper to clarify scope up front than to build the wrong thing.
+
+## About the design files
+
+The design medium is **HTML/CSS/JS** — these are prototypes, not production code. Your job is to **recreate them pixel-perfectly** in whatever technology makes sense for the target codebase (React, Vue, native, whatever fits). Match the visual output; don't copy the prototype's internal structure unless it happens to fit.
+
+**Don't render these files in a browser or take screenshots unless the user asks you to.** Everything you need — dimensions, colors, layout rules — is spelled out in the source. Read the HTML and CSS directly; a screenshot won't tell you anything they don't.
+
+## Bundle contents
+
+- `persona-studio/README.md` — this file
+- `persona-studio/chats/` — conversation transcripts (read these!)
+- `persona-studio/project/` — the `persona-studio` project files (HTML prototypes, assets, components)

--- a/web/docs/design-chats/chat1.md
+++ b/web/docs/design-chats/chat1.md
@@ -1,0 +1,113 @@
+# Chat
+
+_Started 2026-04-21 13:06 UTC_
+
+---
+
+## User
+
+GitHub connected
+
+## Assistant
+
+Welcome! You can paste a github.com repository URL and I'll explore it with you — then pull in the specific files you want to use as reference for design mockups.
+
+## User
+
+https://github.com/zirubak/persona-studio 를 만들었는데 이걸 claude code 에서 지금 사용 중인데 local 웹 브라우저에서도 사용하게 하고 싶어. 
+
+그리고 나는 애플 공식 웹사이트 같은 디자인을 좋아해. 
+
+시작하기 전에 질문 있으면 질문해.
+
+## Assistant
+
+안녕하세요! 시작하기 전에 몇 가지 확인하고 싶은 게 있어요. 먼저 레포를 살펴볼게요.
+
+_[tool: local_ls]_
+
+_[tool: github_list_repos]_
+
+_[tool: local_read]_
+
+_[tool: local_ls]_
+
+좋아요, 프로젝트 구조 이해했습니다. 지금 이건 **Claude Code 플러그인 (CLI/tmux 기반)** 이고, 이걸 로컬 브라우저에서도 쓸 수 있는 웹 UI로 만들고 싶으신 거네요.
+
+시작하기 전에 몇 가지 질문 드릴게요 — 방향을 제대로 잡는 게 중요해서요.
+
+_[tool: questions_v2]_
+
+## User
+
+Questions answered:
+- scope: 디자인 목업/와이어프레임 후에 인터렉티브 프로트타입 이 목표. 
+- primary_flow: 아바타(persona) 라이브러리 관리, 새 아바타 만들기 (파일 업로드, 셀럽 이름 검색), Ralph loop으로 반복 실행 + 점수 보기, 미팅/디베이트 시뮬레이션 실행, 과거 시뮬레이션 결과 열람 (transcript, docx, pptx), 실시간으로 여러 아바타가 동시에 말하는 모습 (tmux 대체), Other
+- tmux_replacement: Explore a few options
+- apple_aspect: 넉넉한 여백과 단순한 타이포그래피
+- pages: 랜딩/홈 (로컬에서 켜면 제일 먼저 보이는 화면), 아바타 라이브러리 (그리드, 카드), 아바타 상세 (프로필, 편집), 새 아바타 만들기 (파일 업로드, 진행 상태), 시뮬레이션 설정 (주제, 참가자 선택, Ralph 옵션), 시뮬레이션 실행 중 (라이브 뷰), 시뮬레이션 결과 (transcript + 다운로드), 설정/환경, Decide for me
+- accent_color: 각 아바타마다 다른 색
+- dark_mode: 둘 다 (토글)
+- variations: Decide for me
+
+## Assistant
+
+좋아요, 방향 잡혔습니다. 정리하면:
+
+- **Phase 1**: Apple 스타일 로우파이 와이어프레임으로 주요 화면 전체 훑기 (구조/플로우 확인)
+- **Phase 2**: 선택한 방향을 하이파이 인터랙티브 프로토타입으로 발전
+
+지금은 Phase 1부터 시작할게요. Apple 감성(넉넉한 여백, 심플한 타이포, 미묘한 톤)을 기본으로 한 **저해상도 와이어프레임 시리즈**를 만듭니다. 8개 화면 × 2-3개 변형을 design_canvas에 올려서 side-by-side로 볼 수 있게 하겠습니다.
+
+**디자인 시스템 선언:**
+- 타이포: SF Pro 대체로 `-apple-system, Inter` + `"Kalam"` 손글씨 폰트 (스케치 느낌)
+- 컬러: 웜 뉴트럴 (#fafaf8 bg, #1a1a1a fg), 각 아바타는 다른 hue (oklch로 고정 chroma/lightness)
+- 와이어프레임은 b&w + 1개 액센트, 최종 방향에서 컬러 확장
+
+먼저 아바타 파일들을 살펴서 실제 이름/콘텐츠로 목업을 채울게요.
+
+_[tool: snip]_
+
+_[tool: local_read]_
+
+_[tool: local_read]_
+
+_[tool: copy_starter_component]_
+
+_[tool: snip]_
+
+이제 와이어프레임 파일을 만들게요. 8개 화면 × 각 2-3개 변형 = design_canvas에 전부 배치. 스케치 감성 (Kalam 손글씨 폰트 + 회색 톤 + 간단한 도형).
+
+디자인 시스템:
+- **스케치 모드**: Kalam 손글씨 + Inter 보조, #fafaf8 bg, #1a1a1a stroke, 액센트 1개 (warm orange #c96442 — 레포 기존 톤)
+- 8 sections: Home / Library / Detail / Create / Simulation Setup / Live View / Results / Settings
+- 각 섹션마다 2-3개 방향 변형
+
+_[tool: write_file]_
+
+Now writing the screens file with all the variants.
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: done]_
+
+_[tool: snip]_
+
+_[tool: fork_verifier_agent]_
+
+와이어프레임 올렸습니다 — **8개 화면 × 2-4개 변형**을 Figma 스타일 캔버스에 배치했어요.
+
+**읽는 법:**
+- 가로로 스크롤하면서 각 행(화면)마다 방향들을 비교
+- 카드 라벨 클릭 → 포커스 모드 (화살표로 이동)
+- 오렌지 손글씨는 제 여백 노트, UI 아님
+
+**꼭 봐주실 곳:**
+1. **Live View (행 6)** — tmux 대체가 이 앱의 핵심. A(3분할) / B(Slack-ish) / C(Keynote 스포트라이트) / D(카드+트랜스크립트 콤보) 중 어느 느낌이 좋으신지
+2. **Home (행 1)** — 로컬에서 켰을 때 첫 인상. A(조용한 히어로) / B(사람 중심) / C(⌘K 커맨드바)
+3. **Create Avatar (행 4)** — 위저드 / 단일 드롭존 / 모드 선택
+
+고르신 조합 알려주시면 그다음에 하이파이 인터랙티브 프로토타입으로 진행할게요. 각 행에서 좋은 것 하나씩 집어주셔도 되고, 섞어도 돼요.
+

--- a/web/docs/design-chats/chat2.md
+++ b/web/docs/design-chats/chat2.md
@@ -1,0 +1,400 @@
+# Chat
+
+_Started 2026-04-21 14:49 UTC_
+
+---
+
+## User
+
+지금 만든 wireframe 너무 좋아 그럼 다음은 뭘 할 수 있지?
+
+## Assistant
+
+좋아요! 와이어프레임이 마음에 드셨다니 다행이에요 🎉
+
+지금 와이어프레임이 완성됐으니, 다음 단계로 갈 수 있는 방향은 여러 가지가 있어요:
+
+### 1. **하이파이 디자인 (Hi-Fi Mockup)**
+와이어프레임을 실제 비주얼 디자인으로 발전시키기
+- 컬러 팔레트, 타이포그래피, 브랜드 적용
+- 실제 컴포넌트, 아이콘, 이미지 배치
+- 여러 비주얼 방향을 variation으로 비교
+
+### 2. **인터랙티브 프로토타입**
+클릭 가능한 프로토타입으로 만들어서 실제 플로우 체험
+- 화면 간 이동, 상태 변화, 애니메이션
+- 사용자 테스트 가능한 수준까지 구현
+
+### 3. **핵심 화면 집중 탐색**
+가장 중요한 1~2개 화면을 깊이 있게 여러 버전으로 탐색
+- 레이아웃 A/B/C 비교
+- 인터랙션 패턴 다양화
+
+### 4. **디자인 시스템 구축**
+이 제품에 쓸 토큰, 컴포넌트 라이브러리 정리
+- 컬러, 타이포, 스페이싱, 컴포넌트
+
+### 5. **특정 플로우 심화**
+온보딩, 핵심 작업 플로우 등 특정 journey 상세 설계
+
+---
+
+**어떤 방향이 끌리세요?** 
+
+개인적으로는 **"하이파이 디자인 2~3개 variation → 마음에 드는 방향으로 인터랙티브 프로토타입"** 순서를 추천드려요. 와이어프레임에서 구조는 잡혔으니, 이제 비주얼 언어를 정하고 → 실제 동작을 입히는 흐름이 자연스러워요.
+
+혹시 참고할 디자인 시스템이나 브랜드 가이드, 레퍼런스 이미지가 있으면 알려주세요. 없다면 몇 가지 방향을 제안드릴 수도 있어요!
+
+## User
+
+너의 추천대로 해줘.
+
+## Assistant
+
+좋아요! 그럼 먼저 현재 와이어프레임과 프로젝트 맥락을 파악하고, 하이파이 variation을 만들기 전에 몇 가지 확인할 게 있어요.
+
+_[tool: list_files]_
+
+_[tool: local_ls]_
+
+_[tool: read_file]_
+
+_[tool: read_file]_
+
+_[tool: local_read]_
+
+[Let me snip the large tool outputs from earlier exploration before continuing.]
+
+_[tool: snip]_
+
+좋아요, 와이어프레임을 충분히 읽었어요. 이제 몇 가지만 짧게 확인하고 하이파이로 들어갈게요.
+
+## 현재까지 파악한 맥락
+- **제품**: Persona Studio — 실제 사람의 자료로 AI 아바타를 만들어 가상 회의/토론을 돌리는 Claude Code 플러그인
+- **와이어프레임 톤**: Apple-ish 절제 · 여백 · b&w + warm orange accent (#c96442) · Inter + Kalam
+- **8개 화면 × 2-4 variation** 이미 탐색됨
+
+## 하이파이 진행 전 몇 가지 질문
+
+비주얼 언어를 정하기 전에, 방향성을 맞춰두면 훨씬 좋은 결과가 나와요. 답변 주시면 바로 variation 작업 들어갈게요.
+
+_[tool: questions_v2]_
+
+## User
+
+Questions answered:
+- winning_variations: '디자이너가 골라줘' 애플 웹사이트 같은 느낌이 좋았어. 
+- screen_priority: 디자이너가 정해줘
+- visual_tone: Apple-ish 미니멀 (흰 배경 · 큰 타이포 · 여백)
+- color_direction: Decide for me
+- type_system: Decide for me
+- avatar_treatment: Explore a few options
+- motion_level: Decide for me
+- must_show: 'Kalam 손글씨 노트는 유지하고 싶다', 'Ralph 점수 시각화 재밌게 해줘', '실제 사람 사진을 넣고 싶다'
+
+## Assistant
+
+_[tool: update_todos]_
+
+_[tool: snip]_
+
+[Declaring visual system out loud so I stick to it:
+
+**Visual system for hi-fi**
+- **Aesthetic**: Apple.com-like restraint — very white background (#fbfaf7 warm paper), huge display type, massive negative space, single hero-per-fold, mono-style metadata lines
+- **Type**: "Söhne-like" via Inter tight + "New York-like" display via Fraunces (serif for editorial moments, like Apple does with quiet headlines), Kalam for handwritten margin notes (preserved per request), JetBrains Mono for metadata
+- **Color**: 95% warm paper + ink, single terracotta accent #c96442 inherited from wireframes. Add one cool secondary (teal oklch) ONLY for Ralph score contrast
+- **Avatars**: Explore 3 treatments — (A) real photo headshot B&W duotone, (B) photo natural color with colored ring, (C) initials + hue (current). I'll use placeholder photo slots with mono labels since I have no real photos.
+- **Motion**: Light hover/transition feel — static mockups but with implied motion via waveform bars etc.
+- **Ralph score viz**: Make it playful — circular progress ring with target notch + trajectory line across iterations.]
+
+_[tool: list_files]_
+
+_[tool: snip]_
+
+_[tool: read_file]_
+
+Good — canvas is ready. Now I'll build the hi-fi screens. Let me create the hi-fi screens file split into manageable pieces.
+
+_[tool: write_file]_
+
+[Snipping the large exploration messages now that I've extracted what I need.]
+
+_[tool: snip]_
+
+Now let me build the Home hi-fi screens.
+
+_[tool: write_file]_
+
+[Snipping old completed phases.]
+
+_[tool: snip]_
+
+Now the Live Simulation screens — the core experience.
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+Now let me build the Results screen with the playful Ralph score visualization, then wire it all into the canvas.
+
+_[tool: write_file]_
+
+## Assistant
+
+Now the Results screen with the Ralph score viz.
+
+_[tool: write_file]_
+
+## Assistant
+
+Now the Results screen with fun Ralph score viz.
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+Now let me also make one more library/cast variation, then wrap it all in a design canvas.
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+Now let me build the main HTML wrapper and an avatar-treatment exploration.
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+Now the main HTML wrapper.
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: done]_
+
+_[tool: snip]_
+
+_[tool: fork_verifier_agent]_
+
+**Hi-fi v1 완성 ✅**
+
+방금 `hifi.html` 열었어요. 와이어프레임에서 합의한 구조 위에 Apple.com 느낌의 하이파이를 입혔습니다.
+
+### 선택한 시스템
+- **타입**: Fraunces italic (display · 부드러운 강조) + Inter (body) + Kalam (마진 노트) + JetBrains Mono (메타데이터)
+- **컬러**: 웜 페이퍼 + 잉크 + terracotta accent + 차가운 teal (Ralph "passed" 전용)
+- **아바타**: 실사 사진 자리를 위한 duotone 플레이스홀더 기본 — 3가지 treatment 비교 섹션 포함
+
+### 담긴 것 (14 artboards)
+- **0 · System** — 팔레트 + 아바타 3 방향
+- **1 · Home** — A 조용한 히어로 / B 얼굴 위주 / C 다크 ⌘K
+- **2 · Library** — A 에디토리얼 그리드 / B 뮤지엄 로우
+- **3 · Live Simulation** — A 패널 그리드 / B 원형 테이블 / C 트랜스크립트 리버
+- **4 · Results** — A 스코어카드 히어로 / B 트랜스크립트 / C 이터레이션 타임라인 (Ralph 점수 viz는 원형 링 + 궤적 그래프)
+
+Kalam 손글씨 노트는 모든 아트보드에 남겨뒀어요.
+
+### 다음 제안
+1. 마음에 드는 조합 골라주시면 (예: "Home B + Live C + Results A") 나머지 화면을 그 방향으로 통일
+2. 실제 사진 1-2장 주시면 placeholder 자리에 drop-in
+3. 고른 방향으로 클릭 가능한 프로토타입 진행
+
+어떤 variation이 와닿으세요?
+
+## User
+
+0 · System —C · SOLID CHIP
+1 · Home —  A 조용한 히어로
+2 · Library —A 에디토리얼 그리드
+3 · Live Simulation — B 원형 테이블
+4 · Results —  A 스코어카드 히어
+
+## Assistant
+
+_[tool: snip]_
+
+좋아요 — 선택 정리:
+- **Avatars**: C (Solid chip initials)
+- **Home**: A (Quiet hero)
+- **Library**: A (Editorial grid)
+- **Live**: B (Round table)
+- **Results**: A (Scorecard hero)
+
+승인된 방향으로 정리하고, 이어서 할 수 있는 다음 단계를 제안드릴게요.
+
+### 이 조합으로 다음에 할 수 있는 것
+1. **통일된 v2 하이파이 파일** — 승인된 5개 화면만 남기고 아바타 treatment를 Solid Chip으로 전체 교체
+2. **빠진 화면 채우기 (같은 방향으로)** — Avatar Detail · Create Avatar · Simulation Setup · Settings
+3. **클릭 가능한 프로토타입** — 5개 화면을 flow로 연결 (Home → Setup → Live → Results)
+4. **실제 사진 drop-in** — 지금은 chip이라 사진 필요 없지만, 원하시면 사진 버전도 병행
+
+어떤 걸로 갈까요? 개인적으론 **2 → 3 순서** (먼저 빠진 화면을 같은 언어로 채워서 전체 그림을 완성하고, 그다음 프로토타입으로 연결) 추천드려요.
+
+## User
+
+그래 너의 추천대로 하자.
+
+## Assistant
+
+[Snipping all completed earlier phases.]
+
+_[tool: snip]_
+
+_[tool: update_todos]_
+
+[Switching `HF.Av` to InitialsAv globally is the cleanest way to swap the avatar treatment across all screens. I'll also update the hi-fi atoms to default to InitialsAv, add the missing screens, and wire clickable navigation.]
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+[Let me build the v2 now with the approved direction, adding missing screens and clickable nav. I'll make the v2 use InitialsAv throughout and add the missing screens.]
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+Now let me build the v2 HTML with clickable navigation connecting the approved screens into a flow.
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: snip]_
+
+Now let me check the existing hifi atoms/screens files to see what I need to build on top of.
+
+_[tool: list_files]_
+
+_[tool: read_file]_
+
+_[tool: read_file]_
+
+Good — hifi-v2-screens.jsx already exists. Let me check if it's complete.
+
+_[tool: read_file]_
+
+<dropped_messages count="1">The preceding 1 messages were removed from the transcript to fit the context window.</dropped_messages>
+
+_[tool: snip]_
+
+All files are in place. Let me verify and finish.
+
+_[tool: done]_
+
+<dropped_messages count="1">The preceding 1 messages were removed from the transcript to fit the context window.</dropped_messages>
+
+_[tool: snip]_
+
+_[tool: fork_verifier_agent]_
+
+**v2 프로토타입 완성 ✅**
+
+`hifi-v2.html` — 승인된 방향(Home A · Library A · Live B · Results A · Solid Chip)을 유지하면서 빠진 화면들을 같은 언어로 채웠고, 클릭 가능한 flow로 연결했어요.
+
+### 들어간 것
+- **8개 화면 네비게이션 바** (0 Home → 7 Settings) · localStorage로 위치 저장 · ← → 키로 이동
+- **Happy path 푸터**: Home → Setup → Live → Results (한 번에 보이는 flow map)
+- **새로 추가된 화면** (hifi-v2-screens.jsx):
+  - **Avatar Detail** — Fraunces display · 탭 네비 · signature phrasings · "4 simulations · avg Ralph 7.6"
+  - **Create Avatar** — Private vs Celebrity 카드 대비 · 경고 배너
+  - **Simulation Setup** — Topic · Participants · Format · Ralph loop · 다크 summary sidebar
+  - **Settings** — 사이드바 nav · 모델 선택 · 라이브러리 위치
+- **Hotspot overlays** — Home의 "Start simulation" → Setup, Library 카드 → Detail 등 주요 CTA에 보이지 않는 클릭 영역
+
+### 다음 단계 제안
+1. **실제 사진 drop-in** — 1-2명 사진 주시면 placeholder 자리에 넣어드릴게요
+2. **Live 시뮬레이션 애니메이션** — 지금은 정적; "speaking" 상태가 자동으로 돌아가는 버전
+3. **빈 상태 / 에러 상태** — 첫 실행 (no avatars), 업로드 실패 등
+
+어떤 방향으로 계속할까요?
+
+## User
+
+A background task has completed. Here are the results:
+
+## Assistant
+
+Verifier caught a real bug — `PhotoAv` is still rendering as duotone gradients instead of Solid Chip initials. Let me fix all four files.
+
+_[tool: grep]_
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+<dropped_messages count="1">The preceding 1 messages were removed from the transcript to fit the context window.</dropped_messages>
+
+_[tool: snip]_
+
+_[tool: done]_
+
+**수정 완료 ✅**
+
+Solid Chip 아바타가 이제 전체 화면에 일관되게 적용됐어요. Library/Home/Live/Results 모두 duotone gradient 대신 initials 칩으로 렌더됩니다.
+
+## User
+
+Live 시뮬레이션 애니메이션
+
+## Assistant
+
+<dropped_messages count="2">The preceding 2 messages were removed from the transcript to fit the context window.</dropped_messages>
+
+Live 시뮬레이션을 정적 스크린샷에서 진짜 움직이는 시뮬레이션으로 만들어볼게요. "speaking" 상태가 자동으로 돌아가면서 텍스트가 타이핑되는 형태로요.
+
+_[tool: read_file]_
+
+<dropped_messages count="1">The preceding 1 messages were removed from the transcript to fit the context window.</dropped_messages>
+
+_[tool: snip]_
+
+Now I'll create an animated version of Live B — the approved Round Table. The simulation will auto-cycle through speakers with typing animation, live transcript, and a timer.
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+<dropped_messages count="1">The preceding 1 messages were removed from the transcript to fit the context window.</dropped_messages>
+
+_[tool: snip]_
+
+_[tool: done]_
+
+<dropped_messages count="1">The preceding 1 messages were removed from the transcript to fit the context window.</dropped_messages>
+
+**Live 시뮬레이션 애니메이션 완성 ✅**
+
+Live 탭을 클릭하면 이제 실제 미팅이 돌아갑니다:
+
+### 들어간 동작
+- **Phase 머신**: thinking (1.4s) → speaking (typing) → linger (0.9s) → 다음 발화자
+- **타이핑 애니메이션**: 각 라인이 speed별로 한 글자씩 뽑혀나옴 + 깜빡이는 커서
+- **활성 좌석 스케일업**: speaking 중인 아바타는 1.08x 확대 + 펄스 링 2겹 + 말풍선 꼬리
+- **Thinking indicator**: 다음 발화자 아바타 우하단에 3-dot 로딩
+- **라이브 트랜스크립트**: 진행 중 라인이 top에 live로 올라오고, 끝나면 아래로 타임스탬프 찍혀 쌓임 (최신이 위)
+- **Ralph draft 점수**: 발화 진행도에 따라 실시간으로 5.2 → 7.8로 상승 (좌하단 칩)
+- **컨트롤**: ❚❚ Pause / ▶ Resume / ↻ Replay
+- **타이머**: MM:SS 실시간, turn count, 토큰 카운터
+
+6턴 스크립트 (Paul → Naval → DHH 왕복 2바퀴)로 루프합니다.
+
+### 다음 제안
+1. **실제 사진 drop-in** — 1-2명 사진 주시면 chip → photo 교체
+2. **빈 상태 / 에러 상태** — 첫 실행 (아바타 0개), 업로드 실패 등
+3. **Setup → Live 전환 때 실제 "첫 발화" 로딩 연출** — 지금은 즉시 thinking 시작
+
+뭐 할까요?
+

--- a/web/docs/design-chats/chat3.md
+++ b/web/docs/design-chats/chat3.md
@@ -1,0 +1,272 @@
+# Chat
+
+_Started 2026-04-21 18:21 UTC_
+
+---
+
+## User
+
+Simulate에서 원탁 테이블은 좋은데 말풍선이 좀더 직사각형이면 어떨가? 물론 사람들이 많아 지면 문제가 될수 도 있겠지만 너가 지금 그렇게 사람이 적을때 많아 질때 생각해서 말풍선 한번 잘 업데이트 해봐.
+
+## Assistant
+
+_[tool: read_file]_
+
+_[tool: list_files]_
+
+The user wants to update the Simulate (Live) screen. The round table is good but they want the speech bubbles to be more rectangular, considering both small and large participant counts.
+
+_[tool: read_file]_
+
+Now I understand the structure. The user wants me to update the speech bubble to be more rectangular, and think about how it should work when there are few vs many participants.
+
+Let me think about the design:
+
+**Current state:** Bubbles are below each avatar (150px wide, rounded, with tail pointing up). Works OK for 4 people around a round table with 2 top + 2 bottom positioning.
+
+**Problem:** Round/small bubbles look cramped. A more rectangular bubble (wider, shorter, more letter-like) would feel more intentional and readable.
+
+**Scaling consideration:**
+- 2-4 people: wide rectangular bubbles can be generous (e.g., 280-320px wide)
+- 5-7 people: bubbles need to get narrower or stack differently
+- 8+ people: bubbles probably need to float toward center or be shown in a dedicated zone, avatars shrink
+
+**Approach:** I'll redesign the bubble to be a more rectangular/letter-shaped card that:
+1. Scales width based on participant count
+2. Positions smartly based on seat location (top seats → bubble above avatar; bottom seats → bubble below)
+3. For many people (6+), bubble expands toward the table center with a pointer line to the avatar
+4. Keep the same aesthetic (thin border, hue-tinted, Fraunces type, tail)
+
+Let me also add a Tweaks control to let the user test participant count (3, 4, 6, 8) so they can see it scale.
+
+_[tool: read_file]_
+
+Now I have a good grasp. Let me redesign the speech bubble to be more rectangular, and also make the layout adapt to participant count. I'll add a Tweaks control so the user can see it scale.
+
+Key design moves:
+1. **Rectangular bubbles** — wider, shorter, more "card-like" with a thin border and attribution strip
+2. **Adaptive sizing** — bubble width/anchor depends on seat position and count
+3. **Seat layout scales** — 2 seats (facing), 3 (triangle), 4 (current), 6 (hex around oval), 8 (octagon around larger oval)
+4. **Bubble placement** — for many people, bubble floats outward from the seat with a connector line, so bubbles don't collide with the table
+
+Let me write this:
+
+_[tool: copy_files]_
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: done]_
+
+Simulate 화면의 말풍선을 직사각형 "노트카드" 형태로 바꿨어요:
+
+- **헤더 스트립**(이름 + SPEAKING 배지) + 본문으로 나뉜 가로형 카드
+- 참가자 수에 따라 자동 배치되는 좌석/말풍선 시스템을 도입 — 2, 3, 4, 6, 8명까지 테스트 가능 (스테이지 우상단 SEATS 토글)
+- 자리 위치(top/bottom/left/right)에 따라 말풍선이 아바타 반대쪽, 즉 테이블 바깥 방향으로 도킹되고, 꼬리(pointer)가 아바타 쪽을 향함
+- 인원이 많아질수록 말풍선 폭과 아바타/테이블이 점차 작아지면서 겹치지 않도록 조정
+
+_[tool: fork_verifier_agent]_
+
+_[tool: snip]_
+
+Simulate의 원탁 말풍선을 직사각형 노트카드 형태로 업데이트했어요. 2~8명까지 좌석 수에 따라 자동으로 말풍선 크기와 위치(top/bottom/left/right 도킹)가 조정되고, 스테이지 우상단 SEATS 토글로 바로 확인할 수 있어요.
+
+## User
+
+A background task has completed. Here are the results:
+
+## Assistant
+
+Good feedback. Let me fix these:
+
+1. Move SEATS tweaker out of stage — into the top bar
+2. Tighten vertical spread for n≥6
+3. Rework n=8 layout
+
+_[tool: str_replace_edit]_
+
+The user wants the bubble to face INTO the table (so the bubble extends toward the center, not outside). This prevents top/bottom clipping. Let me flip the anchor logic — bubble should be on the table-center side of the avatar instead of outside.
+
+_[tool: snip]_
+
+Let me flip the bubble anchor to face INTO the table, and rework the layout so bubbles don't clip.
+
+_[tool: read_file]_
+
+I need to flip every seat anchor so bubbles point INTO the table instead of out. Currently top seats (y low) have anchor:'top' which puts bubbles ABOVE them (outside frame). I'll flip: top seats → anchor:'bottom' (bubble toward center), bottom seats → anchor:'top', left seats → anchor:'right', right seats → anchor:'left'.
+
+_[tool: str_replace_edit]_
+
+Now I also need to reduce the avatar-to-bubble gap since bubbles point toward center and shouldn't be TOO far from the avatar. Also move the SEATS tweaker out of the stage per verifier feedback.
+
+_[tool: snip]_
+
+Let me check and move the SEATS tweaker, plus reduce bubble gap.
+
+_[tool: read_file]_
+
+Let me move SEATS tweaker into the top bar and reduce bubble gap:
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+Now pass nPeople/setNPeople into LiveTopBar and remove the old stage tweaker:
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: done]_
+
+말풍선을 원탁 방향(안쪽)으로 뒤집었고, SEATS 토글은 상단 바로 옮겨서 아바타/말풍선과 겹치지 않게 했어요. 2·3·4·6·8명 모두 위·아래 짤림 없이 테이블 중앙을 향해 카드가 펼쳐집니다.
+
+_[tool: snip]_
+
+_[tool: fork_verifier_agent]_
+
+말풍선이 이제 원탁 안쪽 방향으로 향하도록 바뀌었고, SEATS 토글은 상단 바로 옮겼어요.
+
+## User
+
+A background task has completed. Here are the results:
+
+## Assistant
+
+_[tool: snip]_
+
+확인 완료 — Simulate 화면의 말풍선이 원탁 안쪽을 향하도록 업데이트됐고, SEATS 토글(2·3·4·6·8)로 인원 수를 바꿔가며 바로 확인할 수 있어요.
+
+## User
+
+아주 좋아.
+
+## Assistant
+
+감사합니다! 필요한 조정 더 있으면 말씀해 주세요.
+
+## User
+
+내가 이걸 나중에 유료로 돈을 받고 서비스 제공한다고 생각하면 사람들 로그인이나 가입하는 절차도 필요하지 않을까? 그리고 멀티 랭귀지도 생각을 미리 하는게 좋지 않을까?
+
+## Assistant
+
+좋은 포인트예요. 유료 서비스로 가려면 인증 플로우(로그인/가입/소셜/비밀번호 재설정/이메일 확인)와 플랜/결제, 그리고 멀티 랭귀지 전략(언어 선택, 날짜/숫자/통화 포맷, RTL 대응 등)을 미리 설계해두는 게 맞아요.
+
+진행 전에 몇 가지 방향을 정해두면 훨씬 일관된 디자인을 드릴 수 있어요:
+
+_[tool: questions_v2]_
+
+## User
+
+Questions timed out; go with defaults
+
+## Assistant
+
+기본값으로 진행할게요. 방향 요약:
+
+- **Auth**: 이메일+비밀번호, Google, Apple, Magic Link (4개 옵션 모두)
+- **가입 플로우**: 중간 깊이 — 이름/용도 2~3 스텝 온보딩
+- **플랜**: Free + Pro (월 구독)
+- **Paywall**: 전용 Pricing 페이지 + 컨텍스트 업그레이드 모달 둘 다
+- **계정 범위**: 개인 계정만 (팀은 나중에)
+- **지원 언어**: 한국어, English, 日本語 (3개로 시작)
+- **언어 전환**: 상단 네비의 글로브 아이콘 + Settings 둘 다
+- **페르소나 언어**: 시뮬 시작 시 응답 언어 선택 가능
+- **새 화면**: Sign in, Sign up, 온보딩, Pricing, Upgrade 모달, Settings(Account/Billing/Language)
+- **변형**: 화면당 2안 정도
+- **톤**: 지금 톤 유지 — 미니멀, 페이퍼
+
+계획을 세우고 작업 시작할게요:
+
+_[tool: update_todos]_
+
+_[tool: snip]_
+
+_[tool: read_file]_
+
+Let me build the i18n system and auth/pricing screens. I'll create a new file for these screens and add i18n to atoms.
+
+_[tool: str_replace_edit]_
+
+Add the i18n dictionary before the window.HF export:
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+Now I'll also update the AppNav to use i18n + add a globe (language switcher) and account menu. Let me edit AppNav:
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+Now let me create the new auth/onboarding/pricing/settings screens file:
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+Now register the new screens in hifi-v2.html:
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: done]_
+
+유료 서비스 고려해서 다음을 추가했어요:
+
+**인증 & 온보딩**
+- Sign in / Sign up — Google + Apple OAuth, 이메일+비밀번호, 매직 링크 링크
+- 3스텝 온보딩 — 이름 → 용도 → 페르소나 시드 선택
+
+**결제**
+- Pricing 페이지 — Free ($0, 월 3회) vs Pro ($18/월, 연간 20% 할인 토글), 팀 워크스페이스 대기 리스트
+- Upgrade 모달 — 시뮬 한도 초과 시 컨텍스트로 뜨는 업그레이드 프롬프트
+
+**Settings**
+- Account (프로필, 이메일, 로그아웃/삭제)
+- Billing (현재 플랜, 결제 수단, 인보이스 히스토리)
+- Language (인터페이스 + 페르소나 응답 언어)
+
+**i18n 인프라**
+- 한국어 / English / 日本語 사전 + 런타임 언어 전환 hook (`i18n.useLang`)
+- 상단 네비에 🌐 글로브 + 계정 드롭다운 추가 (어디서든 언어 전환 / Settings·Pricing 이동)
+- 언어 변경 시 모든 화면이 즉시 리렌더
+
+라우팅에 `signin`, `signup`, `onboard`, `pricing`, `upgrade`를 추가했으니 상단 pill에서 바로 확인해보세요.
+
+_[tool: fork_verifier_agent]_
+
+_[tool: snip]_
+
+Sign in/up, 온보딩, Pricing, Upgrade 모달, Settings(Account/Billing/Language)와 i18n(ko/en/ja)을 추가했어요. 상단 네비의 🌐·아바타 메뉴에서 언어/플랜/설정으로 바로 갈 수 있습니다.
+
+## User
+
+언어는 영어가 기본. 그 다음  스페니쉬 / 한국어. / 일본어 /
+
+## Assistant
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+Now I need to add the Spanish dictionary:
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: done]_
+
+언어 순서를 영어(기본) → 스페인어 → 한국어 → 일본어로 바꿨고, 스페인어 사전을 추가했어요. 기본 언어도 `en`으로 변경됐습니다.
+

--- a/web/docs/design-chats/chat4.md
+++ b/web/docs/design-chats/chat4.md
@@ -1,0 +1,327 @@
+# Chat
+
+_Started 2026-04-21 20:10 UTC_
+
+---
+
+## User
+
+아니다. 일단 오픈소스로 가자. 로그인 관련해서는 나중에 하자. 어때? 너의 생각은 어떻게 하는게 좋겠어?
+
+## Assistant
+
+좋은 방향이에요! 오픈소스로 가는 거, 제 생각을 정리해볼게요.
+
+## 오픈소스 전략에 대한 제 생각
+
+**찬성하는 이유:**
+1. **신뢰 구축이 빠름** — Persona Studio 같은 AI 페르소나 도구는 "이 AI가 내 데이터로 뭘 하지?" 하는 불안이 큰 영역이에요. 코드가 공개돼 있으면 그 장벽이 크게 낮아집니다.
+2. **커뮤니티 기여로 페르소나 템플릿/플러그인 생태계** 만들 수 있음 — 이게 장기적으로 제품의 moat가 될 수 있어요.
+3. **로그인 없이 바로 써볼 수 있는 경험**이 OSS 철학과 잘 맞아요. "Clone → run → try"가 첫인상이 되면 도입 허들이 확 낮아져요.
+
+**고려할 점:**
+1. **라이선스 선택이 중요** — MIT는 확산에 좋지만 경쟁자가 그대로 베껴서 SaaS로 팔 수 있어요. AGPL이나 BSL(Business Source License, 예: 2년 후 MIT 전환)이 "오픈소스 + 상업적 방어" 균형에 좋습니다. Sentry, PostHog가 이 모델이에요.
+2. **"오픈 코어" vs "풀 오픈소스"** 결정 필요 — 핵심 페르소나 엔진은 오픈, 팀 협업/SSO/Analytics는 클라우드 유료. 이게 가장 현실적인 수익 모델이에요.
+3. **로그인을 미루는 건 좋지만** 나중에 붙일 자리는 미리 설계해두는 게 좋아요 — 지금 UI에 "Sign in" 자리 placeholder만 남겨두면 나중에 덜 고통스러워요.
+
+## 제안
+
+**지금 당장 할 일:**
+- 현재 hi-fi에서 상단 우측에 작게 **"★ Star on GitHub"** 배지 하나 + **"Open Source"** 태그 추가
+- 로그인 영역은 **"Guest mode"** 로 처리 (작업물은 localStorage에 저장)
+- Footer 혹은 About에 간단한 라이선스 표기 자리 마련
+
+**질문 드리고 싶은 것:**
+1. 라이선스는 MIT / Apache 2.0 / AGPL / BSL 중 어디 선호하세요? (잘 모르시면 제가 BSL 추천)
+2. 완전 오픈소스 vs 오픈 코어(유료 cloud 버전 병행) — 어느 쪽 생각하세요?
+3. 지금 hi-fi v2에 OSS 뱃지/표기를 바로 반영할까요, 아니면 방향만 먼저 합의하고 다음 스텝에서 할까요?
+
+셋 중 어떤 쪽이든 말씀 주시면 바로 반영하겠습니다. 개인적으로는 **BSL + 오픈 코어 + Guest mode 우선**이 Persona Studio 같은 툴에 가장 잘 맞을 것 같아요.
+
+## User
+
+그래 그렇게 하자. 라이센스는 너가 알아서 정해. 너의 추천을 따를게.
+
+## Assistant
+
+좋습니다. 먼저 현재 상태를 파악하고 반영하겠습니다.
+
+_[tool: list_files]_
+
+_[tool: read_file]_
+
+좋아요, 방향을 정리하고 바로 반영할게요.
+
+## 결정 사항
+
+**라이선스: Elastic License 2.0 (ELv2) 추천** 
+- 이유: AGPL은 기업 도입에 거부감이 있고, MIT는 보호가 약해요. ELv2는 "누구나 쓰고, 포크하고, 수정해도 되지만, **경쟁하는 managed/hosted 서비스로 파는 것만 금지**"라는 조항이 있어서 Persona Studio 같은 SaaS 가능성이 있는 툴에 가장 잘 맞아요. Elasticsearch, Redis, MinIO가 쓰는 모델입니다.
+- "Source-available" 이라고 부르기도 해요 (엄밀한 OSI 오픈소스는 아니지만 실무적으로는 거의 동일).
+- 나중에 프로젝트가 커지면 **core는 MIT, enterprise features는 ELv2**로 분리하는 open-core 전환이 쉬워요.
+
+**로그인 관련 처리 방침:**
+- Sign in / Sign up 화면은 프로토타입에서 **숨김 처리** (flow에서 제거)
+- Home의 상단에 "Guest mode · 로컬에만 저장됨" 작은 표시
+- 우측 상단 "★ Star" GitHub 뱃지 + "Open source · ELv2" 작은 라벨
+- Settings는 남겨두되 "Account" 섹션은 "Coming soon" 처리
+- Pricing/Upgrade는 남겨두되 "Cloud (coming soon)"로 라벨링 — 나중에 붙일 자리 확보
+
+바로 반영하겠습니다.
+
+_[tool: read_file]_
+
+_[tool: snip]_
+
+이제 변경사항을 반영할게요. `hifi-v2.html`을 수정해서:
+1. Auth 화면 (signin/signup/onboard)을 flow에서 제거
+2. OSS 뱃지 + "Guest mode" 표시
+3. Pricing/Upgrade는 "Cloud · Coming soon" 으로 라벨링
+
+그리고 `hifi-atoms.jsx`의 AppNav에서 "Sign out" → "This is guest mode"로 변경하고, 이메일 표시를 OSS 관련 문구로 바꿀게요.
+
+_[tool: str_replace_edit]_
+
+이제 상단의 prototype chrome에 OSS 뱃지 + 라이선스 + Guest mode 표시를 추가하겠습니다.
+
+_[tool: str_replace_edit]_
+
+이제 AppNav의 account chip을 "Guest" 상태로 바꿀게요. 이메일은 "guest · local session", "Sign out"은 숨기고 대신 "Running in guest mode" 표시로.
+
+_[tool: str_replace_edit]_
+
+마지막으로, 기본 화면이 'home'인지 확인 (localStorage에 'signin' 같은 구버전 값이 남아있으면 깨질 수 있어요).
+
+_[tool: str_replace_edit]_
+
+flow map footer도 확인했는데 'home → setup → live → results' 라서 auth 관련 참조가 없네요. 완료하겠습니다.
+
+_[tool: done]_
+
+_[tool: fork_verifier_agent]_
+
+반영 완료했어요.
+
+## 변경 요약
+- **Auth flow 제거**: signin / signup / onboard / upgrade 화면을 네비게이션에서 빼고, 기본 화면을 Home으로
+- **OSS 뱃지 추가**: 상단 chrome에 `OSS · ELv2` 라벨 + `GUEST MODE · LOCAL ONLY` 상태 표시 + `★ Star on GitHub` 카운터
+- **AppNav account chip**: 이니셜(JH) 대신 ★ 아이콘 + guest 드롭다운. 이메일 대신 "Local session · no account", "Elastic License 2.0" 표기
+- **Pricing은 "Cloud · soon"** 으로 리라벨 (미래 managed 서비스 자리만 남김)
+- **소스 파일(hifi-auth-screens.jsx)은 유지** — 나중에 붙일 때 그대로 쓸 수 있게
+
+라이선스는 **Elastic License 2.0 (ELv2)** 로 결정했어요. "누구나 쓰고 수정 가능하지만 경쟁 SaaS로 호스팅해서 파는 것만 금지" — Persona Studio가 나중에 Cloud 버전으로 수익화할 여지를 남기면서도 커뮤니티 기여와 자가 호스팅은 자유롭게 허용합니다.
+
+## 다음 스텝 제안
+1. 실제 `LICENSE` 파일 + `README.md` 초안 작성 (OSS 바이브 맞추기)
+2. Home에 "Contribute on GitHub" 섹션 또는 작은 footer 추가 여부
+3. Guest mode에서 뭘 저장하고 뭘 안 저장할지 정하기 (avatars·sims → localStorage? 파일 export?)
+
+어느 것부터 할까요?
+
+## User
+
+OSS 바이브 가 뭐야? 
+1,2,3, 너가 알아서해. 나는 너를 믿어.
+
+## Assistant
+
+## "OSS 바이브"가 뭐냐면
+
+OSS (Open Source Software) 프로젝트들이 공통으로 갖는 **분위기·미감·관습** 같은 거예요. 구체적으로:
+
+- **README가 첫인상** — 로고, 한 줄 설명, GIF 데모, Quick start 코드 블럭, Star/Fork 뱃지
+- **개발자 친화적 톤** — 마케팅 카피("Revolutionize your workflow!") 대신 담백한 설명 ("A tool for X. Run `npm i` to start.")
+- **모노스페이스 폰트** 많이 사용, 터미널/코드 느낌
+- **뱃지(shields.io)** — License, Build, Version 같은 작은 라벨들
+- **Contributors 섹션** — 기여자 아바타 그리드
+- **"Made by humans" 느낌** — 과한 그라디언트/일러스트보다 솔직하고 기술적인 톤
+- **Discord/Slack 커뮤니티 링크**, Issues/Discussions로 연결
+- **투명한 로드맵** — "여기 오픈돼 있고, 같이 만들어가는 거예요"
+
+참고 예시: Linear, Supabase, Cal.com, PostHog, Plausible 같은 프로젝트들 랜딩 페이지가 전형적인 OSS 바이브예요. 기업 SaaS처럼 반들반들하지 않고, 약간 날것의 기술적인 텍스처가 있어요.
+
+---
+
+좋아요, 1-2-3 다 제가 알아서 진행할게요. 먼저 작업 정리하고 시작합니다.
+
+_[tool: update_todos]_
+
+## 1) LICENSE + README 작성
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: update_todos]_
+
+_[tool: read_file]_
+
+## 2) Home에 OSS footer 섹션 추가
+
+HomeA 하단에 OSS 관련 요소 (GitHub, License, Contributors, Discord) 를 담담하게 녹여넣을게요.
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+근데 HomeA가 fixed viewport (860px height) 안에서 렌더링되는데 `bottom: -160`으로 두면 화면 밖으로 나가서 잘릴 거예요. 다시 정리할게요 — Home A의 레이아웃 재조정이 필요해요.
+
+_[tool: read_file]_
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+Dead code 남아있는 걸 정리하고 3번 작업을 진행할게요.
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: update_todos]_
+
+## 3) Guest mode 저장 정책 결정 + UI 반영
+
+결정한 정책:
+- **localStorage**: UI 상태, language, 최근 열어본 avatar
+- **IndexedDB**: avatars, simulations, results (용량 큼)
+- **Export/Import (JSON)**: 백업, 기기 간 이동
+- **Privacy-first**: 아무 데이터도 서버로 나가지 않음
+
+Settings 화면에 "Data (Guest mode)" 섹션을 추가해서 export / import / clear 를 노출할게요. Auth 섹션은 숨기고 대신 OSS 정보로 교체.
+
+_[tool: read_file]_
+
+_[tool: snip]_
+
+Settings 화면의 account 탭을 OSS guest mode용으로 교체할게요 — 계정 정보 대신 "Data (local only)" 섹션을 넣겠습니다.
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+Account 탭을 Guest mode용 Data 탭으로, Billing 탭을 Cloud 대기 화면으로, About 탭을 새로 추가할게요.
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: update_todos]_
+
+_[tool: done]_
+
+_[tool: snip]_
+
+_[tool: fork_verifier_agent]_
+
+세 작업 모두 완료했어요.
+
+## 이번에 한 일
+
+**1. 라이선스 + 문서** 
+- `LICENSE` — Elastic License 2.0 전문 
+- `README.md` — 로고/배지/Quick start/Features/Roadmap/Contributing/License 섹션이 담긴 OSS 스타일 README 
+- `CONTRIBUTING.md` — PR 규칙, design change 가이드, 행동 규범
+
+**2. Home에 OSS footer 추가** 
+Home 하단에 technical하고 담백한 스트립 추가: GitHub repo + ★ 2.4k, ELv2 라벨, 기여자 아바타, Discord/Docs/Changelog, `pnpm i persona-studio` 설치 명령.
+
+**3. Settings 재구성 — Guest mode 친화적으로** 
+- **Data** 탭: 로컬 저장 현황 (Avatars 7, Sims 12, Prefs 4), 저장소 quota 바, **Export/Import JSON** 백업, **Model provider** 선택 (Anthropic / OpenAI / Ollama), "Clear all local data" 
+- **Cloud** 탭: "Coming soon" 웨이팅리스트 + self-host 설치 커맨드 (`curl -fsSL get.persona-studio.dev | sh`) 
+- **About** 탭: 버전, 링크 (GitHub, Discord, Docs, License, Issues), 43명 기여자 그리드
+
+## 결정한 데이터 정책
+- `localStorage` → UI 상태, 언어, prefs 
+- `IndexedDB` → avatars, simulations, results (용량 큼) 
+- JSON export/import → 백업, 기기 이동, git 체크인 가능 
+- 서버로 나가는 데이터: **없음**. API 키는 브라우저에 저장되고 해당 provider에만 직접 호출.
+
+다음에 뭐 할까요? 몇 가지 아이디어:
+- Landing page (persona-studio.dev) 디자인 — OSS 바이브의 도입부 
+- Model provider 연결 흐름 (API key 입력 → 테스트) 화면 추가 
+- Library에서 avatar import (URL, file, clipboard) 흐름
+
+## User
+
+Landing page (persona-studio.dev) 디자인 — OSS 바이브의 도입부
+Library에서 avatar import (URL, file, clipboard) 흐름
+
+## Assistant
+
+좋아요, 두 개 다 진행할게요.
+
+_[tool: update_todos]_
+
+_[tool: read_file]_
+
+Library는 `LibraryA`가 쓰이고 있으니 "+ New avatar" 클릭 시 import modal을 띄우는 식으로 추가할게요. 먼저 Landing page 만들고, 그 다음 import flow 작업하겠습니다.
+
+## 1. Landing page 생성
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: update_todos]_
+
+## 2. Library avatar import flow
+
+Library에 Import modal을 추가합니다. "+ New avatar" 클릭 시 URL / File / Clipboard 세 탭이 있는 모달이 뜨는 형태로.
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: update_todos]_
+
+_[tool: grep]_
+
+Library는 이미 v2에 연결돼 있어요. 마무리합니다.
+
+_[tool: done]_
+
+_[tool: fork_verifier_agent]_
+
+두 작업 모두 완료했어요.
+
+## 1. Landing page (`landing.html`)
+
+**구조:**
+- **Nav** — 로고 + 링크 + ★2.4k GitHub 배지 + "Try live"
+- **Hero** — "Rehearse tomorrow's meeting *today*" + hand-crafted floating cast cards (PG/Naval/DHH), `pnpm i persona-studio` 설치 커맨드 (클릭 시 복사)
+- **Running strip** — OSS 슬로건 가로 띠
+- **How it works** — 3단계 (Ingest / Round / Grade), 각 카드에 CLI 데모 포함
+- **Product shot** — 다크 브라우저 목업에 실제 로브테이블 + Ralph score 링 8.1
+- **Features** — 2×3 그리드 (BYOM, live round-table, Ralph, private corpora, keyboard-first, JSON-first)
+- **Open source** — ELv2 YES/NO 매트릭스 + 43 contributors + clone/curl 터미널
+- **CTA** — "The room is *waiting*"
+- **Footer** — 4-column + version/commit footer
+
+**톤:** Fraunces italic + Inter 500, oklch 기반 warm palette (paper `#fbfaf7`, accent `#c96442`, cool `#2f6b6b`). OSS 바이브는 터미널 블록·commit hash·배지·contributor stack 같은 디테일로 표현.
+
+## 2. Library avatar import flow
+
+`hifi-library.jsx`의 `LibraryA`에 Import modal 추가. "+ New avatar" 또는 "add a voice" 카드 클릭 시 오픈.
+
+**3-탭 모달:**
+- **URL / RSS** — input + Detect 버튼, 4개 예시 칩 (paulgraham.com, nav.al, hey.com/dhh, stratechery)
+- **Files** — 드롭존 (.md/.txt/.pdf/.json/.zip), "Files stay on your machine" 라벨
+- **Paste text** — textarea + word/token 카운터
+
+**Stage flow:** `input → detecting → preview`
+- Detecting: 4단계 체크리스트 (Fetching / Parsing / Extracting voice / Building corpus), done/running/queued 상태
+- Preview: 아바타 + 이름 + 184 essays / 84k tokens / 2004–2025 span 통계, voice sample 인용구, Public/Shared 체크박스, Add to library 버튼
+
+**가드레일:** 헤더에 `LOCAL · NEVER UPLOADED` 라벨 — Guest mode 정책과 일관.
+
+hifi-v2.html을 열면 Library 탭에서 바로 확인 가능하고, `landing.html`은 별도 파일로 독립적으로 열 수 있어요.
+
+다음 후보:
+- Model provider 연결 흐름 (BYOM onboarding — API key 입력/테스트)
+- Landing page에 Ralph 점수 섹션 확장 (실제 rubric 빌더 미리보기)
+- Import flow의 파일 탭에 실제 파일 타입별 다른 프리뷰 추가
+

--- a/web/hifi-atoms.jsx
+++ b/web/hifi-atoms.jsx
@@ -1,0 +1,465 @@
+// hifi-atoms.jsx — design tokens + atoms for Persona Studio hi-fi
+// Exposes: window.HF = { tokens, Av, PhotoAv, AppNav, Browser, Note, Mono, Kalam, Wave, RalphRing, ... }
+
+(function () {
+  const tokens = {
+    // warm paper palette (Apple-ish but slightly warmer)
+    paper: '#fbfaf7',
+    paperSoft: '#f4f2ed',
+    paperDeep: '#eae6dd',
+    ink: '#1a1714',
+    inkSoft: '#3a342d',
+    mute: '#8a857b',
+    hair: '#e8e3d9',
+    accent: '#c96442',      // terracotta
+    accentSoft: '#f6e6dd',
+    cool: '#2f6b6b',        // teal for Ralph contrast
+    coolSoft: '#dbe9e7',
+    green: '#4a7c4e',
+
+    fSans: '"Inter", -apple-system, "SF Pro Display", system-ui, sans-serif',
+    fDisplay: '"Fraunces", "New York", Georgia, serif',
+    fHand: '"Kalam", cursive',
+    fMono: '"JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace',
+  };
+
+  const PEOPLE = [
+    { id: 'pg',  name: 'Paul Graham',       role: 'Essayist · Y Combinator',  hue: 28,  born: 1964, mode: 'public',  corpus: '84k' },
+    { id: 'nv',  name: 'Naval Ravikant',    role: 'AngelList · aphorist',     hue: 195, born: 1974, mode: 'public',  corpus: '61k' },
+    { id: 'dhh', name: 'DHH',               role: 'Rails · Basecamp',         hue: 350, born: 1979, mode: 'public',  corpus: '112k' },
+    { id: 'jhb', name: 'JH Baek',           role: 'Staff Engineer',           hue: 142, born: 1988, mode: 'private', corpus: '12k' },
+    { id: 'dv',  name: 'Devesh Upadhyay',   role: 'Engineer',                 hue: 260, born: 1991, mode: 'private', corpus: '9k' },
+    { id: 'wb',  name: 'Wes Bailey',        role: 'Product Manager',          hue: 90,  born: 1987, mode: 'private', corpus: '18k' },
+    { id: 'sp',  name: 'sample_private',    role: 'Fictional · KR',           hue: 322, born: 1985, mode: 'private', corpus: '4k' },
+  ];
+
+  const hueBg   = (h) => `oklch(0.70 0.11 ${h})`;
+  const hueDeep = (h) => `oklch(0.42 0.12 ${h})`;
+  const hueSoft = (h) => `oklch(0.93 0.04 ${h})`;
+
+  // Photo-ish avatar: monochrome duotone placeholder made from gradient
+  // to stand in for a real portrait — mono caption makes it obvious.
+  const PhotoAv = ({ p, size = 64, tone = 'duotone', ring }) => {
+    const bg = tone === 'duotone'
+      ? `linear-gradient(135deg, ${hueBg(p.hue)} 0%, ${hueDeep(p.hue)} 100%)`
+      : `linear-gradient(135deg, ${hueSoft(p.hue)} 0%, ${hueBg(p.hue)} 100%)`;
+    return (
+      <div style={{
+        width: size, height: size, borderRadius: '50%',
+        background: bg,
+        boxShadow: ring ? `0 0 0 2px ${tokens.paper}, 0 0 0 3.5px ${hueBg(p.hue)}` : 'inset 0 -8px 18px rgba(0,0,0,0.12)',
+        position: 'relative', flexShrink: 0, overflow: 'hidden',
+        display: 'inline-flex', alignItems: 'flex-end', justifyContent: 'center',
+      }}>
+        {/* face silhouette hint */}
+        <div style={{
+          width: size * 0.5, height: size * 0.5, borderRadius: '50%',
+          background: `radial-gradient(circle at 50% 40%, rgba(255,255,255,0.25), transparent 60%)`,
+          position: 'absolute', top: size * 0.18, left: size * 0.25,
+        }}/>
+        <div style={{
+          width: size * 0.8, height: size * 0.45, borderRadius: '50% 50% 0 0',
+          background: `radial-gradient(ellipse at 50% 0%, rgba(255,255,255,0.15), transparent 70%)`,
+          position: 'absolute', bottom: 0, left: size * 0.1,
+        }}/>
+      </div>
+    );
+  };
+
+  // Classic initials avatar (carry-over from wireframes)
+  const InitialsAv = ({ p, size = 40, ring }) => (
+    <div style={{
+      width: size, height: size, borderRadius: '50%',
+      background: hueBg(p.hue), color: '#fff',
+      fontSize: size * 0.36, fontWeight: 600, fontFamily: tokens.fSans,
+      letterSpacing: -0.5,
+      display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+      boxShadow: ring ? `0 0 0 2px ${tokens.paper}, 0 0 0 3.5px ${hueBg(p.hue)}` : 'none',
+      flexShrink: 0,
+    }}>
+      {p.name.split(' ').map(w => w[0]).slice(0,2).join('').toUpperCase()}
+    </div>
+  );
+
+  // Illustrated avatar: soft color block with elegant serif initials
+  const IllusAv = ({ p, size = 56 }) => (
+    <div style={{
+      width: size, height: size, borderRadius: '50%',
+      background: hueSoft(p.hue),
+      color: hueDeep(p.hue),
+      fontFamily: tokens.fDisplay, fontSize: size * 0.42, fontWeight: 400,
+      fontStyle: 'italic',
+      display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+      flexShrink: 0, border: `1px solid ${hueBg(p.hue)}33`,
+    }}>
+      {p.name.split(' ').map(w => w[0]).slice(0,2).join('')}
+    </div>
+  );
+
+  // Default Av is the approved Solid Chip (initials)
+  const Av = InitialsAv;
+
+  const Kalam = ({ children, size = 14, color, rot = 0, style }) => (
+    <span style={{
+      fontFamily: tokens.fHand, fontSize: size, color: color || tokens.accent,
+      display: 'inline-block', transform: `rotate(${rot}deg)`, lineHeight: 1.25,
+      ...style,
+    }}>{children}</span>
+  );
+
+  const Mono = ({ children, size = 11, color, style }) => (
+    <span style={{
+      fontFamily: tokens.fMono, fontSize: size, color: color || tokens.mute,
+      letterSpacing: 0.2, ...style,
+    }}>{children}</span>
+  );
+
+  // Hand-note with optional arrow
+  const Note = ({ children, top, left, right, bottom, w = 180, rot = -2, arrow }) => (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width: w,
+      fontFamily: tokens.fHand, color: tokens.accent, fontSize: 13, lineHeight: 1.3,
+      transform: `rotate(${rot}deg)`, zIndex: 5, pointerEvents: 'none',
+    }}>
+      {children}
+      {arrow && (
+        <svg width="50" height="28" viewBox="0 0 50 28" style={{ display: 'block', marginTop: 4 }}>
+          <path d="M2 4 Q 18 22, 44 22" fill="none" stroke={tokens.accent} strokeWidth="1.4" strokeLinecap="round"/>
+          <path d="M38 18 L44 22 L38 26" fill="none" stroke={tokens.accent} strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      )}
+    </div>
+  );
+
+  // App chrome — with language globe + account chip
+  const AppNav = ({ active = 'home', dark = false, onNav }) => {
+    const fg = dark ? '#fff' : tokens.ink;
+    const mu = dark ? 'rgba(255,255,255,0.55)' : tokens.mute;
+    const bg = dark ? tokens.ink : tokens.paper;
+    const hair = dark ? 'rgba(255,255,255,0.08)' : tokens.hair;
+    const [lang, setLang] = (window.HF && window.HF.i18n) ? window.HF.i18n.useLang() : [i18n.get(), i18n.set];
+    const t = (k) => i18n.t(k, lang);
+    const [globeOpen, setGlobeOpen] = React.useState(false);
+    const [acctOpen, setAcctOpen] = React.useState(false);
+    return (
+      <div style={{
+        height: 56, padding: '0 24px', display: 'flex', alignItems: 'center', gap: 28,
+        borderBottom: `1px solid ${hair}`, background: bg, color: fg,
+        fontFamily: tokens.fSans, position: 'relative',
+      }}>
+        <div style={{ fontWeight: 600, letterSpacing: -0.3, fontSize: 14, display: 'flex', alignItems: 'center', gap: 8 }}>
+          <div style={{
+            width: 20, height: 20, borderRadius: 6,
+            background: `conic-gradient(from 180deg, ${tokens.accent}, ${tokens.cool}, ${tokens.accent})`,
+          }}/>
+          Persona Studio
+        </div>
+        {[
+          ['home','nav.home'],
+          ['library','nav.library'],
+          ['create','nav.new'],
+          ['sim','nav.simulate'],
+          ['results','nav.results'],
+        ].map(([k,tk]) => (
+          <div key={k} onClick={() => onNav && onNav(k === 'sim' ? 'live' : k)} style={{
+            fontSize: 13, letterSpacing: -0.1, cursor: onNav ? 'pointer' : 'default',
+            color: active === k ? fg : mu,
+            fontWeight: active === k ? 500 : 400,
+            position: 'relative',
+          }}>
+            {t(tk)}
+            {active === k && <div style={{ position: 'absolute', left: '50%', bottom: -19, transform: 'translateX(-50%)', width: 4, height: 4, borderRadius: 4, background: tokens.accent }}/>}
+          </div>
+        ))}
+        <div style={{ flex: 1 }}/>
+        <div style={{ fontFamily: tokens.fMono, fontSize: 11, color: mu }}>⌘K</div>
+
+        {/* Language globe */}
+        <div style={{ position: 'relative' }}>
+          <div onClick={() => { setGlobeOpen(v => !v); setAcctOpen(false); }} style={{
+            display: 'flex', alignItems: 'center', gap: 6, padding: '5px 10px', borderRadius: 999,
+            cursor: 'pointer', border: `1px solid ${hair}`, fontSize: 12, color: fg,
+          }}>
+            <span style={{ fontSize: 13 }}>🌐</span>
+            <span style={{ fontFamily: tokens.fMono, fontSize: 10, letterSpacing: 1 }}>{LANGS.find(l => l.code === lang)?.short}</span>
+          </div>
+          {globeOpen && (
+            <div style={{ position: 'absolute', top: 36, right: 0, background: dark ? '#1f1a15' : '#fff', border: `1px solid ${hair}`, borderRadius: 10, padding: 6, minWidth: 140, boxShadow: '0 12px 28px rgba(0,0,0,0.12)', zIndex: 100 }}>
+              {LANGS.map(L => (
+                <div key={L.code} onClick={() => { setLang(L.code); setGlobeOpen(false); }} style={{
+                  padding: '8px 12px', borderRadius: 6, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 10,
+                  background: L.code === lang ? (dark ? 'rgba(255,255,255,0.06)' : tokens.paperSoft) : 'transparent',
+                  fontSize: 13, color: fg,
+                }}>
+                  <span style={{ fontFamily: tokens.fMono, fontSize: 10, color: mu, width: 22 }}>{L.short}</span>
+                  <span>{L.name}</span>
+                  {L.code === lang && <span style={{ marginLeft: 'auto', color: tokens.accent, fontSize: 11 }}>●</span>}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Account chip — guest mode (OSS build) */}
+        <div style={{ position: 'relative' }}>
+          <div onClick={() => { setAcctOpen(v => !v); setGlobeOpen(false); }} style={{
+            width: 28, height: 28, borderRadius: '50%', cursor: 'pointer',
+            background: dark ? '#333' : tokens.paperDeep,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: 11, fontWeight: 500, color: dark ? '#fff' : tokens.ink,
+            position: 'relative',
+          }}>
+            <span>★</span>
+            <span style={{ position: 'absolute', bottom: -1, right: -1, width: 9, height: 9, borderRadius: '50%', background: tokens.green, border: `2px solid ${bg}` }}/>
+          </div>
+          {acctOpen && (
+            <div style={{ position: 'absolute', top: 36, right: 0, background: dark ? '#1f1a15' : '#fff', border: `1px solid ${hair}`, borderRadius: 10, padding: 6, minWidth: 220, boxShadow: '0 12px 28px rgba(0,0,0,0.12)', zIndex: 100, fontSize: 13, color: fg }}>
+              <div style={{ padding: '10px 12px', borderBottom: `1px solid ${hair}` }}>
+                <div style={{ fontWeight: 500, display: 'flex', alignItems: 'center', gap: 6 }}>
+                  Guest
+                  <span style={{ fontFamily: tokens.fMono, fontSize: 9, letterSpacing: 1, padding: '2px 6px', background: tokens.coolSoft, color: tokens.cool, borderRadius: 3 }}>OSS</span>
+                </div>
+                <div style={{ fontSize: 11, color: mu, marginTop: 2 }}>Local session · no account</div>
+              </div>
+              <div onClick={() => onNav && onNav('settings')} style={{ padding: '8px 12px', cursor: 'pointer', borderRadius: 6 }}>{t('settings.title')}</div>
+              <div onClick={() => onNav && onNav('pricing')} style={{ padding: '8px 12px', cursor: 'pointer', borderRadius: 6 }}>Cloud <span style={{ fontSize: 10, color: mu, marginLeft: 4 }}>· soon</span></div>
+              <div style={{ height: 1, background: hair, margin: '4px 0' }}/>
+              <div style={{ padding: '8px 12px', cursor: 'pointer', borderRadius: 6, display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span>★</span> Star on GitHub
+              </div>
+              <div style={{ padding: '6px 12px 10px', fontSize: 10, color: mu, fontFamily: tokens.fMono, letterSpacing: 0.5 }}>
+                Elastic License 2.0
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  // Browser chrome (light, restrained)
+  const Browser = ({ url = 'localhost:7777', dark = false, children }) => (
+    <div style={{
+      height: '100%', background: dark ? tokens.ink : tokens.paper,
+      display: 'flex', flexDirection: 'column', overflow: 'hidden',
+      fontFamily: tokens.fSans, color: dark ? '#fff' : tokens.ink,
+    }}>
+      <div style={{
+        height: 30, display: 'flex', alignItems: 'center', gap: 6, padding: '0 12px',
+        background: dark ? '#0f0d0b' : tokens.paperSoft,
+        borderBottom: `1px solid ${dark ? 'rgba(255,255,255,0.06)' : tokens.hair}`,
+      }}>
+        <div style={{ width: 10, height: 10, borderRadius: '50%', background: '#ed6a5e' }}/>
+        <div style={{ width: 10, height: 10, borderRadius: '50%', background: '#f4bf4f' }}/>
+        <div style={{ width: 10, height: 10, borderRadius: '50%', background: '#61c554' }}/>
+        <div style={{
+          flex: 1, marginLeft: 12, height: 18, borderRadius: 5,
+          background: dark ? 'rgba(255,255,255,0.06)' : tokens.paper,
+          border: `1px solid ${dark ? 'rgba(255,255,255,0.06)' : tokens.hair}`,
+          fontFamily: tokens.fMono, fontSize: 10, color: tokens.mute,
+          display: 'flex', alignItems: 'center', padding: '0 10px',
+        }}>{url}</div>
+      </div>
+      <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>{children}</div>
+    </div>
+  );
+
+  // Live waveform
+  const Wave = ({ color, bars = 9, height = 20 }) => (
+    <div style={{ display: 'inline-flex', alignItems: 'center', gap: 2, height }}>
+      {Array.from({ length: bars }).map((_, i) => {
+        const h = 4 + Math.abs(Math.sin(i * 1.7)) * (height - 4);
+        return <div key={i} style={{ width: 2, height: h, background: color, borderRadius: 1, opacity: 0.4 + (h / height) * 0.6 }}/>;
+      })}
+    </div>
+  );
+
+  // Ralph score ring — circular progress with target tick
+  const RalphRing = ({ score = 7.2, target = 7, size = 160, label = true }) => {
+    const r = size / 2 - 10;
+    const c = 2 * Math.PI * r;
+    const pct = Math.min(Math.max(score / 10, 0), 1);
+    const targetPct = target / 10;
+    const passed = score >= target;
+    const fg = passed ? tokens.cool : tokens.accent;
+    return (
+      <div style={{ position: 'relative', width: size, height: size }}>
+        <svg width={size} height={size} style={{ transform: 'rotate(-90deg)' }}>
+          <circle cx={size/2} cy={size/2} r={r} fill="none" stroke={tokens.hair} strokeWidth="8"/>
+          <circle cx={size/2} cy={size/2} r={r} fill="none" stroke={fg} strokeWidth="8" strokeLinecap="round"
+            strokeDasharray={`${c * pct} ${c}`} />
+          {/* Target notch */}
+          <circle cx={size/2 + r * Math.cos(targetPct * 2 * Math.PI)} cy={size/2 + r * Math.sin(targetPct * 2 * Math.PI)}
+            r="5" fill={tokens.paper} stroke={tokens.ink} strokeWidth="1.5" />
+        </svg>
+        <div style={{
+          position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column',
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <div style={{ fontFamily: tokens.fDisplay, fontSize: size * 0.32, fontWeight: 400, letterSpacing: -1, color: tokens.ink, lineHeight: 1 }}>
+            {score.toFixed(1)}
+          </div>
+          {label && <div style={{ fontFamily: tokens.fMono, fontSize: 10, color: tokens.mute, letterSpacing: 1, marginTop: 4 }}>
+            {passed ? 'PASSED' : `TARGET ${target}`}
+          </div>}
+        </div>
+      </div>
+    );
+  };
+
+  // A typography-only display block (Apple homepage feel)
+  const Display = ({ size = 72, lh = 1.02, children, weight = 500, serif = false, color, style }) => (
+    <div style={{
+      fontFamily: serif ? tokens.fDisplay : tokens.fSans,
+      fontSize: size, lineHeight: lh, fontWeight: weight,
+      letterSpacing: serif ? -1.2 : -2.2, color: color || tokens.ink,
+      textWrap: 'balance', ...style,
+    }}>{children}</div>
+  );
+
+  // CTA button (Apple pill)
+  const Btn = ({ primary, accent, children, dark, size = 'md', style }) => {
+    const pad = size === 'lg' ? '14px 26px' : size === 'sm' ? '6px 14px' : '10px 20px';
+    const fs = size === 'lg' ? 15 : size === 'sm' ? 12 : 13;
+    const base = {
+      display: 'inline-flex', alignItems: 'center', gap: 8,
+      padding: pad, borderRadius: 999, fontSize: fs, fontWeight: 500,
+      fontFamily: tokens.fSans, cursor: 'pointer', transition: 'all .15s',
+      border: '1px solid transparent', letterSpacing: -0.1,
+    };
+    if (primary) return <div style={{ ...base, background: tokens.ink, color: '#fff', ...style }}>{children}</div>;
+    if (accent)  return <div style={{ ...base, background: tokens.accent, color: '#fff', ...style }}>{children}</div>;
+    if (dark)    return <div style={{ ...base, background: '#fff', color: tokens.ink, ...style }}>{children}</div>;
+    return <div style={{ ...base, background: 'transparent', color: tokens.ink, border: `1px solid ${tokens.ink}`, ...style }}>{children}</div>;
+  };
+
+  // Placeholder with mono caption (what we'll drop in later)
+  const Slot = ({ label, w, h, style, radius = 10 }) => (
+    <div style={{
+      width: w, height: h, borderRadius: radius,
+      background: tokens.paperSoft,
+      backgroundImage: `repeating-linear-gradient(135deg, transparent 0 11px, rgba(26,23,20,0.04) 11px 12px)`,
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontFamily: tokens.fMono, fontSize: 10, color: tokens.mute, letterSpacing: 1,
+      textTransform: 'uppercase', ...style,
+    }}>{label}</div>
+  );
+
+  // Eyebrow (small caps label above a display headline)
+  const Eyebrow = ({ children, color, style }) => (
+    <div style={{
+      fontFamily: tokens.fMono, fontSize: 11, color: color || tokens.accent,
+      letterSpacing: 2, textTransform: 'uppercase', fontWeight: 500, ...style,
+    }}>{children}</div>
+  );
+
+  // ── i18n ──────────────────────────────────────────────────────────────────
+  // Tiny translation helper. Ships with ko/en/ja dictionaries; falls back to
+  // the key itself if missing. Persists language in localStorage.
+  const DICT = {
+    ko: {
+      'nav.home': '홈', 'nav.library': '라이브러리', 'nav.new': '새로', 'nav.simulate': '시뮬레이트', 'nav.results': '결과',
+      'auth.signin': '로그인', 'auth.signup': '가입하기', 'auth.continue': '계속',
+      'auth.email': '이메일', 'auth.password': '비밀번호', 'auth.magic': '매직 링크로 로그인',
+      'auth.orContinueWith': '또는 다음으로 계속', 'auth.google': 'Google로 계속', 'auth.apple': 'Apple로 계속',
+      'auth.noAccount': '계정이 없으신가요?', 'auth.haveAccount': '이미 계정이 있으신가요?',
+      'auth.forgot': '비밀번호를 잊으셨나요?', 'auth.terms': '가입하면 이용약관과 개인정보 처리방침에 동의하는 것으로 간주됩니다.',
+      'onboard.welcome': '환영합니다', 'onboard.name': '어떻게 불러드릴까요?',
+      'onboard.purpose': '어떤 일에 쓰실 건가요?', 'onboard.seed': '첫 페르소나를 골라보세요',
+      'onboard.next': '다음', 'onboard.skip': '건너뛰기', 'onboard.finish': '시작하기',
+      'pricing.title': '요금제', 'pricing.sub': '먼저 써보고, 필요할 때 업그레이드하세요.',
+      'pricing.free': 'Free', 'pricing.pro': 'Pro', 'pricing.month': '/ 월',
+      'pricing.cta.free': '현재 요금제', 'pricing.cta.pro': 'Pro 시작하기',
+      'upgrade.title': '시뮬레이션 한도에 도달했어요', 'upgrade.body': '무료 요금제는 월 3회까지 시뮬레이션을 저장할 수 있어요. Pro에서는 무제한이에요.',
+      'upgrade.cta': 'Pro로 업그레이드', 'upgrade.later': '나중에',
+      'settings.title': '설정', 'settings.account': '계정', 'settings.billing': '결제', 'settings.language': '언어',
+      'settings.signout': '로그아웃', 'settings.delete': '계정 삭제',
+      'lang.current': '현재 언어', 'lang.interface': '인터페이스', 'lang.persona': '페르소나 응답',
+    },
+    en: {
+      'nav.home': 'Home', 'nav.library': 'Library', 'nav.new': 'New', 'nav.simulate': 'Simulate', 'nav.results': 'Results',
+      'auth.signin': 'Sign in', 'auth.signup': 'Sign up', 'auth.continue': 'Continue',
+      'auth.email': 'Email', 'auth.password': 'Password', 'auth.magic': 'Email me a magic link',
+      'auth.orContinueWith': 'or continue with', 'auth.google': 'Continue with Google', 'auth.apple': 'Continue with Apple',
+      'auth.noAccount': 'No account yet?', 'auth.haveAccount': 'Already have an account?',
+      'auth.forgot': 'Forgot password?', 'auth.terms': 'By signing up, you agree to the Terms and Privacy Policy.',
+      'onboard.welcome': 'Welcome', 'onboard.name': 'What should we call you?',
+      'onboard.purpose': 'What will you use this for?', 'onboard.seed': 'Pick a persona to start',
+      'onboard.next': 'Next', 'onboard.skip': 'Skip', 'onboard.finish': 'Get started',
+      'pricing.title': 'Pricing', 'pricing.sub': 'Try it first. Upgrade when you need more.',
+      'pricing.free': 'Free', 'pricing.pro': 'Pro', 'pricing.month': '/ month',
+      'pricing.cta.free': 'Current plan', 'pricing.cta.pro': 'Start Pro',
+      'upgrade.title': "You've hit your simulation limit", 'upgrade.body': 'Free includes 3 saved sims per month. Pro is unlimited.',
+      'upgrade.cta': 'Upgrade to Pro', 'upgrade.later': 'Maybe later',
+      'settings.title': 'Settings', 'settings.account': 'Account', 'settings.billing': 'Billing', 'settings.language': 'Language',
+      'settings.signout': 'Sign out', 'settings.delete': 'Delete account',
+      'lang.current': 'Current language', 'lang.interface': 'Interface', 'lang.persona': 'Persona replies',
+    },
+    es: {
+      'nav.home': 'Inicio', 'nav.library': 'Biblioteca', 'nav.new': 'Nuevo', 'nav.simulate': 'Simular', 'nav.results': 'Resultados',
+      'auth.signin': 'Iniciar sesión', 'auth.signup': 'Crear cuenta', 'auth.continue': 'Continuar',
+      'auth.email': 'Correo', 'auth.password': 'Contraseña', 'auth.magic': 'Envíame un enlace mágico',
+      'auth.orContinueWith': 'o continúa con', 'auth.google': 'Continuar con Google', 'auth.apple': 'Continuar con Apple',
+      'auth.noAccount': '¿Aún no tienes cuenta?', 'auth.haveAccount': '¿Ya tienes cuenta?',
+      'auth.forgot': '¿Olvidaste tu contraseña?', 'auth.terms': 'Al registrarte, aceptas los Términos y la Política de Privacidad.',
+      'onboard.welcome': 'Bienvenido', 'onboard.name': '¿Cómo te llamamos?',
+      'onboard.purpose': '¿Para qué lo usarás?', 'onboard.seed': 'Elige un persona para empezar',
+      'onboard.next': 'Siguiente', 'onboard.skip': 'Omitir', 'onboard.finish': 'Empezar',
+      'pricing.title': 'Planes', 'pricing.sub': 'Pruébalo primero. Mejora cuando necesites más.',
+      'pricing.free': 'Gratis', 'pricing.pro': 'Pro', 'pricing.month': '/ mes',
+      'pricing.cta.free': 'Plan actual', 'pricing.cta.pro': 'Empezar Pro',
+      'upgrade.title': 'Alcanzaste tu límite de simulaciones', 'upgrade.body': 'Gratis incluye 3 simulaciones al mes. Pro es ilimitado.',
+      'upgrade.cta': 'Mejorar a Pro', 'upgrade.later': 'Quizás después',
+      'settings.title': 'Ajustes', 'settings.account': 'Cuenta', 'settings.billing': 'Facturación', 'settings.language': 'Idioma',
+      'settings.signout': 'Cerrar sesión', 'settings.delete': 'Eliminar cuenta',
+      'lang.current': 'Idioma actual', 'lang.interface': 'Interfaz', 'lang.persona': 'Respuestas de personas',
+    },
+    ja: {
+      'nav.home': 'ホーム', 'nav.library': 'ライブラリ', 'nav.new': '新規', 'nav.simulate': 'シミュレート', 'nav.results': '結果',
+      'auth.signin': 'ログイン', 'auth.signup': '登録', 'auth.continue': '続ける',
+      'auth.email': 'メールアドレス', 'auth.password': 'パスワード', 'auth.magic': 'マジックリンクでログイン',
+      'auth.orContinueWith': 'または次で続ける', 'auth.google': 'Google で続ける', 'auth.apple': 'Apple で続ける',
+      'auth.noAccount': 'アカウントがありませんか?', 'auth.haveAccount': 'すでにアカウントをお持ちですか?',
+      'auth.forgot': 'パスワードを忘れた?', 'auth.terms': '登録すると利用規約とプライバシーポリシーに同意したことになります。',
+      'onboard.welcome': 'ようこそ', 'onboard.name': 'お名前は?',
+      'onboard.purpose': '何に使いますか?', 'onboard.seed': '最初のペルソナを選んでください',
+      'onboard.next': '次へ', 'onboard.skip': 'スキップ', 'onboard.finish': '始める',
+      'pricing.title': '料金', 'pricing.sub': 'まず試してから、必要に応じてアップグレード。',
+      'pricing.free': 'Free', 'pricing.pro': 'Pro', 'pricing.month': '/ 月',
+      'pricing.cta.free': '現在のプラン', 'pricing.cta.pro': 'Pro を始める',
+      'upgrade.title': 'シミュレーションの上限に達しました', 'upgrade.body': '無料プランは月3回まで保存できます。Pro は無制限です。',
+      'upgrade.cta': 'Pro にアップグレード', 'upgrade.later': '後で',
+      'settings.title': '設定', 'settings.account': 'アカウント', 'settings.billing': '支払い', 'settings.language': '言語',
+      'settings.signout': 'ログアウト', 'settings.delete': 'アカウント削除',
+      'lang.current': '現在の言語', 'lang.interface': 'インターフェース', 'lang.persona': 'ペルソナの返答',
+    },
+  };
+  const LANGS = [
+    { code: 'en', name: 'English', short: 'EN' },
+    { code: 'es', name: 'Español', short: 'ES' },
+    { code: 'ko', name: '한국어', short: 'KO' },
+    { code: 'ja', name: '日本語', short: 'JA' },
+  ];
+  const i18n = {
+    LANGS,
+    DICT,
+    get: () => { try { return localStorage.getItem('ps_lang') || 'en'; } catch { return 'en'; } },
+    set: (l) => { try { localStorage.setItem('ps_lang', l); } catch {} window.dispatchEvent(new CustomEvent('ps_lang_change', { detail: l })); },
+    t: (key, lang) => {
+      const l = lang || i18n.get();
+      return (DICT[l] && DICT[l][key]) || DICT.en[key] || key;
+    },
+    // Simple hook to re-render on language change
+    useLang: () => {
+      const [l, setL] = React.useState(i18n.get());
+      React.useEffect(() => {
+        const on = (e) => setL(e.detail);
+        window.addEventListener('ps_lang_change', on);
+        return () => window.removeEventListener('ps_lang_change', on);
+      }, []);
+      return [l, (code) => i18n.set(code)];
+    },
+  };
+
+  window.HF = { tokens, PEOPLE, hueBg, hueDeep, hueSoft, PhotoAv, InitialsAv, IllusAv, Av, AppNav, Browser, Note, Kalam, Mono, Wave, RalphRing, Display, Btn, Slot, Eyebrow, i18n };
+})();

--- a/web/hifi-auth-screens.jsx
+++ b/web/hifi-auth-screens.jsx
@@ -1,0 +1,622 @@
+// hifi-auth-screens.jsx — Auth, Onboarding, Pricing, Upgrade, Settings
+// Exposes window.HF_Auth = { SignInScreen, SignUpScreen, OnboardScreen, PricingScreen, UpgradeModal, SettingsScreen }
+
+(function(){
+  const { tokens: T, i18n, Btn, Mono, Eyebrow, Display, AppNav, Browser, PEOPLE: P, InitialsAv: Av, hueBg, hueSoft, hueDeep } = window.HF;
+  const { useState } = React;
+
+  // Shared auth page frame: left = brand/marquee, right = form
+  function AuthFrame({ children, eyebrow, title, sub }){
+    return (
+      <div style={{ height: '100%', display: 'grid', gridTemplateColumns: '1fr 1fr', background: T.paper, fontFamily: T.fSans }}>
+        {/* Left panel — atmospheric */}
+        <div style={{ background: T.paperSoft, padding: 48, display: 'flex', flexDirection: 'column', justifyContent: 'space-between', position: 'relative', overflow: 'hidden', borderRight: `1px solid ${T.hair}` }}>
+          <div style={{ fontWeight: 600, fontSize: 14, display: 'flex', alignItems: 'center', gap: 8 }}>
+            <div style={{ width: 20, height: 20, borderRadius: 6, background: `conic-gradient(from 180deg, ${T.accent}, ${T.cool}, ${T.accent})` }}/>
+            Persona Studio
+          </div>
+          <div>
+            <div style={{ fontFamily: T.fDisplay, fontStyle: 'italic', fontWeight: 300, fontSize: 42, lineHeight: 1.1, letterSpacing: -1, color: T.ink }}>
+              "Talk to the<br/>people you<br/>wish you could."
+            </div>
+            <div style={{ marginTop: 14, fontFamily: T.fMono, fontSize: 10, color: T.mute, letterSpacing: 1.5 }}>PERSONA STUDIO · ROUNDTABLE</div>
+          </div>
+          <div style={{ display: 'flex', gap: -8 }}>
+            {P.slice(0, 5).map((p, i) => (
+              <div key={p.id} style={{ marginLeft: i === 0 ? 0 : -10, border: `2px solid ${T.paperSoft}`, borderRadius: '50%' }}>
+                <Av p={p} size={36}/>
+              </div>
+            ))}
+            <div style={{ marginLeft: 14, alignSelf: 'center', fontFamily: T.fMono, fontSize: 10, color: T.mute, letterSpacing: 1.2 }}>7 PERSONAS AVAILABLE</div>
+          </div>
+        </div>
+        {/* Right — form */}
+        <div style={{ padding: '56px 64px', display: 'flex', flexDirection: 'column', justifyContent: 'center', maxWidth: 520, width: '100%' }}>
+          {eyebrow && <Eyebrow>{eyebrow}</Eyebrow>}
+          <div style={{ fontFamily: T.fDisplay, fontWeight: 400, fontSize: 34, letterSpacing: -0.8, marginTop: 8, color: T.ink }}>{title}</div>
+          {sub && <div style={{ fontSize: 14, color: T.mute, marginTop: 6 }}>{sub}</div>}
+          <div style={{ marginTop: 28 }}>{children}</div>
+        </div>
+      </div>
+    );
+  }
+
+  // Text field
+  function Field({ label, type = 'text', placeholder, value, trailing }){
+    return (
+      <label style={{ display: 'block', marginBottom: 14 }}>
+        <div style={{ fontSize: 11, color: T.mute, fontFamily: T.fMono, letterSpacing: 1, marginBottom: 6, textTransform: 'uppercase' }}>{label}</div>
+        <div style={{ position: 'relative' }}>
+          <input type={type} defaultValue={value} placeholder={placeholder} style={{
+            width: '100%', padding: '12px 14px', fontSize: 14,
+            border: `1px solid ${T.hair}`, borderRadius: 10, background: '#fff',
+            fontFamily: T.fSans, color: T.ink, outline: 'none',
+          }}/>
+          {trailing && <div style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 11, color: T.mute, fontFamily: T.fMono }}>{trailing}</div>}
+        </div>
+      </label>
+    );
+  }
+
+  function OAuthRow({ lang, t, horizontal = true }){
+    const btns = [
+      { label: 'Google', icon: 'G', bg: '#fff', fg: T.ink, border: T.hair },
+      { label: 'Apple',  icon: '', bg: T.ink, fg: '#fff', border: T.ink },
+    ];
+    return (
+      <div style={{ display: 'grid', gridTemplateColumns: horizontal ? '1fr 1fr' : '1fr', gap: 10, marginBottom: 14 }}>
+        {btns.map(b => (
+          <div key={b.label} style={{
+            padding: '11px 14px', border: `1px solid ${b.border}`, background: b.bg, color: b.fg,
+            borderRadius: 10, fontSize: 13, fontWeight: 500, cursor: 'pointer',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 10,
+          }}>
+            <span style={{ fontFamily: T.fDisplay, fontSize: 15 }}>{b.icon}</span>
+            <span>{t(b.label === 'Google' ? 'auth.google' : 'auth.apple')}</span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  function Divider({ label }){
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, margin: '6px 0 16px', color: T.mute }}>
+        <div style={{ flex: 1, height: 1, background: T.hair }}/>
+        <Mono size={10}>{label}</Mono>
+        <div style={{ flex: 1, height: 1, background: T.hair }}/>
+      </div>
+    );
+  }
+
+  function SignInScreen({ onNav }){
+    const [lang] = i18n.useLang();
+    const t = (k) => i18n.t(k, lang);
+    return (
+      <Browser url="personastudio.app/signin">
+        <AuthFrame eyebrow="SIGN IN" title={t('auth.signin')} sub="Pick up where you left off.">
+          <OAuthRow lang={lang} t={t}/>
+          <Divider label={t('auth.orContinueWith')}/>
+          <Field label={t('auth.email')} type="email" placeholder="you@domain.com" value="jh@example.com"/>
+          <Field label={t('auth.password')} type="password" placeholder="••••••••" trailing={<span style={{ cursor: 'pointer' }}>{t('auth.forgot')}</span>}/>
+          <div onClick={() => onNav && onNav('home')} style={{ marginTop: 10 }}>
+            <Btn primary style={{ width: '100%', justifyContent: 'center', padding: '12px 20px' }}>{t('auth.continue')}</Btn>
+          </div>
+          <div style={{ textAlign: 'center', marginTop: 14 }}>
+            <Mono size={11}>{t('auth.magic')} →</Mono>
+          </div>
+          <div style={{ marginTop: 28, textAlign: 'center', fontSize: 13, color: T.mute }}>
+            {t('auth.noAccount')}{' '}
+            <span onClick={() => onNav && onNav('signup')} style={{ color: T.ink, fontWeight: 500, cursor: 'pointer', textDecoration: 'underline', textDecorationColor: T.accent, textUnderlineOffset: 4 }}>
+              {t('auth.signup')}
+            </span>
+          </div>
+        </AuthFrame>
+      </Browser>
+    );
+  }
+
+  function SignUpScreen({ onNav }){
+    const [lang] = i18n.useLang();
+    const t = (k) => i18n.t(k, lang);
+    return (
+      <Browser url="personastudio.app/signup">
+        <AuthFrame eyebrow="CREATE ACCOUNT" title={t('auth.signup')} sub="Start with 3 free simulations a month.">
+          <OAuthRow lang={lang} t={t}/>
+          <Divider label={t('auth.orContinueWith')}/>
+          <Field label={t('auth.email')} type="email" placeholder="you@domain.com"/>
+          <Field label={t('auth.password')} type="password" placeholder="•••••••• (min 8)"/>
+          <div onClick={() => onNav && onNav('onboard')} style={{ marginTop: 10 }}>
+            <Btn accent style={{ width: '100%', justifyContent: 'center', padding: '12px 20px' }}>{t('auth.continue')} →</Btn>
+          </div>
+          <div style={{ marginTop: 14, fontSize: 11, color: T.mute, lineHeight: 1.5 }}>
+            {t('auth.terms')}
+          </div>
+          <div style={{ marginTop: 22, textAlign: 'center', fontSize: 13, color: T.mute }}>
+            {t('auth.haveAccount')}{' '}
+            <span onClick={() => onNav && onNav('signin')} style={{ color: T.ink, fontWeight: 500, cursor: 'pointer' }}>{t('auth.signin')}</span>
+          </div>
+        </AuthFrame>
+      </Browser>
+    );
+  }
+
+  function OnboardScreen({ onNav }){
+    const [lang] = i18n.useLang();
+    const t = (k) => i18n.t(k, lang);
+    const [step, setStep] = useState(0);
+    const [picked, setPicked] = useState(['pg']);
+    const [purpose, setPurpose] = useState('research');
+    const steps = [
+      { key: 'name',    title: t('onboard.name') },
+      { key: 'purpose', title: t('onboard.purpose') },
+      { key: 'seed',    title: t('onboard.seed') },
+    ];
+    const cur = steps[step];
+    const next = () => {
+      if (step < steps.length - 1) setStep(step + 1);
+      else onNav && onNav('library');
+    };
+    return (
+      <Browser url="personastudio.app/onboarding">
+        <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: T.paper, fontFamily: T.fSans }}>
+          {/* Stepper */}
+          <div style={{ padding: '18px 32px', borderBottom: `1px solid ${T.hair}`, display: 'flex', alignItems: 'center', gap: 14 }}>
+            <div style={{ fontWeight: 600, fontSize: 13, display: 'flex', alignItems: 'center', gap: 8 }}>
+              <div style={{ width: 18, height: 18, borderRadius: 5, background: `conic-gradient(from 180deg, ${T.accent}, ${T.cool}, ${T.accent})` }}/>
+              Persona Studio
+            </div>
+            <div style={{ flex: 1, display: 'flex', justifyContent: 'center', gap: 8 }}>
+              {steps.map((s, i) => (
+                <div key={s.key} style={{ width: 40, height: 3, borderRadius: 2, background: i <= step ? T.ink : T.hair }}/>
+              ))}
+            </div>
+            <Mono size={10}>{t('onboard.welcome').toUpperCase()} · {step + 1}/{steps.length}</Mono>
+          </div>
+
+          <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 40 }}>
+            <div style={{ maxWidth: 620, width: '100%' }}>
+              <Eyebrow>STEP {step + 1}</Eyebrow>
+              <div style={{ fontFamily: T.fDisplay, fontWeight: 400, fontSize: 36, letterSpacing: -1, marginTop: 10, color: T.ink }}>
+                {cur.title}
+              </div>
+
+              <div style={{ marginTop: 28 }}>
+                {cur.key === 'name' && (
+                  <>
+                    <Field label={t('auth.email').replace('Email','Name').replace('이메일','이름').replace('メールアドレス','お名前')} placeholder="JH Baek" value="JH Baek"/>
+                    <div style={{ fontSize: 12, color: T.mute }}>We'll use this in transcripts and session summaries.</div>
+                  </>
+                )}
+                {cur.key === 'purpose' && (
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+                    {[
+                      { id: 'research', title: 'Research & learning', body: 'Interview thinkers, stress-test ideas.' },
+                      { id: 'writing',  title: 'Writing & editing',    body: 'Get feedback in distinct voices.' },
+                      { id: 'product',  title: 'Product decisions',    body: 'Run cross-functional debates.' },
+                      { id: 'personal', title: 'Personal journaling',  body: 'Talk through life with trusted voices.' },
+                    ].map(opt => (
+                      <div key={opt.id} onClick={() => setPurpose(opt.id)} style={{
+                        padding: 18, borderRadius: 12, cursor: 'pointer',
+                        border: `1.5px solid ${purpose === opt.id ? T.ink : T.hair}`,
+                        background: purpose === opt.id ? T.paperSoft : '#fff',
+                      }}>
+                        <div style={{ fontWeight: 500, fontSize: 14 }}>{opt.title}</div>
+                        <div style={{ fontSize: 12, color: T.mute, marginTop: 4, lineHeight: 1.4 }}>{opt.body}</div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {cur.key === 'seed' && (
+                  <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 10 }}>
+                    {P.filter(p => p.mode === 'public').map(p => {
+                      const on = picked.includes(p.id);
+                      return (
+                        <div key={p.id} onClick={() => setPicked(on ? picked.filter(x => x !== p.id) : [...picked, p.id])} style={{
+                          padding: 14, borderRadius: 12, cursor: 'pointer', textAlign: 'center',
+                          border: `1.5px solid ${on ? hueBg(p.hue) : T.hair}`,
+                          background: on ? hueSoft(p.hue) : '#fff',
+                        }}>
+                          <Av p={p} size={44}/>
+                          <div style={{ fontSize: 12, fontWeight: 500, marginTop: 8 }}>{p.name}</div>
+                          <Mono size={9}>{p.role}</Mono>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+
+              <div style={{ marginTop: 36, display: 'flex', alignItems: 'center', gap: 12 }}>
+                <div onClick={() => onNav && onNav('library')} style={{ fontSize: 13, color: T.mute, cursor: 'pointer' }}>{t('onboard.skip')}</div>
+                <div style={{ flex: 1 }}/>
+                {step > 0 && <Btn onClick={() => setStep(step - 1)} style={{ cursor: 'pointer' }}>← Back</Btn>}
+                <div onClick={next}>
+                  <Btn primary style={{ cursor: 'pointer' }}>
+                    {step === steps.length - 1 ? t('onboard.finish') : t('onboard.next')} →
+                  </Btn>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Browser>
+    );
+  }
+
+  function PricingCard({ name, price, sub, features, cta, ctaPrimary, highlight, badge }){
+    return (
+      <div style={{
+        padding: 32, borderRadius: 18, background: '#fff',
+        border: `1.5px solid ${highlight ? T.ink : T.hair}`,
+        position: 'relative',
+        boxShadow: highlight ? '0 20px 50px rgba(26,23,20,0.08)' : 'none',
+      }}>
+        {badge && (
+          <div style={{ position: 'absolute', top: -10, right: 24, padding: '3px 10px', background: T.accent, color: '#fff', fontFamily: T.fMono, fontSize: 10, letterSpacing: 1.5, borderRadius: 999 }}>{badge}</div>
+        )}
+        <div style={{ fontSize: 14, fontWeight: 500, color: T.ink }}>{name}</div>
+        <div style={{ marginTop: 10, display: 'flex', alignItems: 'baseline', gap: 8 }}>
+          <div style={{ fontFamily: T.fDisplay, fontSize: 44, fontWeight: 400, letterSpacing: -1.5 }}>{price}</div>
+          <div style={{ color: T.mute, fontSize: 13 }}>{sub}</div>
+        </div>
+        <div style={{ height: 1, background: T.hair, margin: '20px 0' }}/>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {features.map((f, i) => (
+            <div key={i} style={{ display: 'flex', gap: 10, fontSize: 13, color: f.muted ? T.mute : T.inkSoft, textDecoration: f.muted ? 'line-through' : 'none' }}>
+              <span style={{ color: f.muted ? T.mute : T.cool, fontWeight: 600 }}>✓</span>
+              <span>{f.label}</span>
+            </div>
+          ))}
+        </div>
+        <div style={{ marginTop: 24 }}>
+          <Btn primary={ctaPrimary} style={{ width: '100%', justifyContent: 'center', padding: '12px 20px', cursor: 'pointer' }}>{cta}</Btn>
+        </div>
+      </div>
+    );
+  }
+
+  function PricingScreen({ onNav }){
+    const [lang] = i18n.useLang();
+    const t = (k) => i18n.t(k, lang);
+    const [cycle, setCycle] = useState('month');
+    const isMonth = cycle === 'month';
+    return (
+      <Browser url="personastudio.app/pricing">
+        <AppNav active="home" onNav={onNav}/>
+        <div style={{ flex: 1, padding: '56px 72px', background: T.paper, overflow: 'auto' }}>
+          <div style={{ textAlign: 'center', maxWidth: 680, margin: '0 auto 44px' }}>
+            <Eyebrow>{t('pricing.title').toUpperCase()}</Eyebrow>
+            <div style={{ fontFamily: T.fDisplay, fontStyle: 'italic', fontWeight: 300, fontSize: 48, letterSpacing: -1.5, marginTop: 10, lineHeight: 1.05 }}>
+              {t('pricing.sub')}
+            </div>
+            <div style={{ marginTop: 22, display: 'inline-flex', gap: 2, padding: 3, background: T.paperSoft, borderRadius: 999, border: `1px solid ${T.hair}` }}>
+              {[['month','Monthly'],['year','Yearly · save 20%']].map(([k,l]) => (
+                <div key={k} onClick={() => setCycle(k)} style={{
+                  padding: '6px 14px', borderRadius: 999, fontSize: 12, cursor: 'pointer',
+                  background: cycle === k ? T.ink : 'transparent',
+                  color: cycle === k ? '#fff' : T.inkSoft,
+                }}>{l}</div>
+              ))}
+            </div>
+          </div>
+          <div style={{ maxWidth: 900, margin: '0 auto', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>
+            <PricingCard
+              name={t('pricing.free')}
+              price="$0"
+              sub={t('pricing.month')}
+              features={[
+                { label: '3 simulations / month' },
+                { label: '2 personas at a time' },
+                { label: 'Public personas only' },
+                { label: 'Unlimited personas', muted: true },
+                { label: 'Private personas from your files', muted: true },
+              ]}
+              cta={t('pricing.cta.free')}
+            />
+            <PricingCard
+              name={t('pricing.pro')}
+              price={isMonth ? '$18' : '$14'}
+              sub={isMonth ? t('pricing.month') : t('pricing.month') + ' · billed yearly'}
+              features={[
+                { label: 'Unlimited simulations' },
+                { label: 'Up to 8 personas at a table' },
+                { label: 'Private personas (bring your own files)' },
+                { label: 'Export transcripts + Ralph scores' },
+                { label: 'Priority inference' },
+              ]}
+              cta={t('pricing.cta.pro')}
+              ctaPrimary
+              highlight
+              badge="POPULAR"
+            />
+          </div>
+          <div style={{ maxWidth: 900, margin: '44px auto 0', padding: 24, background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 14, display: 'flex', alignItems: 'center', gap: 18 }}>
+            <div style={{ width: 38, height: 38, borderRadius: 10, background: T.accentSoft, color: T.accent, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: T.fDisplay, fontSize: 18 }}>★</div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 13, fontWeight: 500 }}>Team workspaces are coming soon.</div>
+              <div style={{ fontSize: 12, color: T.mute, marginTop: 2 }}>Invite colleagues, share persona libraries, and collaborate on simulations. <span style={{ color: T.ink, textDecoration: 'underline', textDecorationColor: T.hair, textUnderlineOffset: 3 }}>Join the waitlist →</span></div>
+            </div>
+          </div>
+        </div>
+      </Browser>
+    );
+  }
+
+  function UpgradeModal({ onNav }){
+    const [lang] = i18n.useLang();
+    const t = (k) => i18n.t(k, lang);
+    // Render underneath: a peek of library + centered modal
+    return (
+      <Browser url="personastudio.app/library">
+        <AppNav active="library" onNav={onNav}/>
+        <div style={{ flex: 1, position: 'relative', background: T.paper, overflow: 'hidden' }}>
+          {/* dim backdrop */}
+          <div style={{ position: 'absolute', inset: 0, background: 'rgba(26,23,20,0.45)', backdropFilter: 'blur(4px)' }}/>
+          {/* fake library peeking through */}
+          <div style={{ padding: 40, opacity: 0.4 }}>
+            <div style={{ fontFamily: T.fDisplay, fontSize: 32, fontWeight: 400 }}>Library</div>
+            <div style={{ marginTop: 20, display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 16 }}>
+              {P.slice(0, 4).map(p => (
+                <div key={p.id} style={{ padding: 20, background: '#fff', borderRadius: 12, border: `1px solid ${T.hair}` }}>
+                  <Av p={p} size={48}/>
+                  <div style={{ marginTop: 10, fontWeight: 500 }}>{p.name}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+          {/* modal */}
+          <div style={{
+            position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)',
+            width: 480, padding: 36, background: '#fff', borderRadius: 20,
+            boxShadow: '0 30px 80px rgba(0,0,0,0.2)',
+            fontFamily: T.fSans,
+          }}>
+            <div style={{ width: 44, height: 44, borderRadius: 12, background: T.accentSoft, color: T.accent, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: T.fDisplay, fontSize: 22, fontWeight: 400 }}>★</div>
+            <div style={{ fontFamily: T.fDisplay, fontSize: 26, fontWeight: 400, letterSpacing: -0.5, marginTop: 16, lineHeight: 1.2 }}>{t('upgrade.title')}</div>
+            <div style={{ fontSize: 14, color: T.mute, marginTop: 10, lineHeight: 1.5 }}>{t('upgrade.body')}</div>
+            <div style={{ marginTop: 20, padding: 14, background: T.paperSoft, borderRadius: 10, display: 'flex', alignItems: 'center', gap: 12 }}>
+              <div style={{ fontFamily: T.fDisplay, fontSize: 22 }}>$18</div>
+              <div>
+                <div style={{ fontSize: 12, fontWeight: 500 }}>Pro · monthly</div>
+                <div style={{ fontSize: 11, color: T.mute }}>Cancel anytime</div>
+              </div>
+              <div style={{ flex: 1 }}/>
+              <Mono size={10} color={T.cool}>UNLIMITED SIMS</Mono>
+            </div>
+            <div style={{ marginTop: 22, display: 'flex', gap: 10 }}>
+              <div onClick={() => onNav && onNav('library')} style={{ flex: 1 }}>
+                <Btn style={{ width: '100%', justifyContent: 'center', cursor: 'pointer' }}>{t('upgrade.later')}</Btn>
+              </div>
+              <div onClick={() => onNav && onNav('pricing')} style={{ flex: 2 }}>
+                <Btn accent style={{ width: '100%', justifyContent: 'center', cursor: 'pointer' }}>{t('upgrade.cta')} →</Btn>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Browser>
+    );
+  }
+
+  function SettingsScreen({ onNav }){
+    const [lang, setLang] = i18n.useLang();
+    const t = (k) => i18n.t(k, lang);
+    const [tab, setTab] = useState('account');
+    const tabs = [
+      ['account',  'Data'],
+      ['billing',  'Cloud'],
+      ['language', t('settings.language')],
+      ['about',    'About'],
+    ];
+    return (
+      <Browser url="personastudio.app/settings">
+        <AppNav active="home" onNav={onNav}/>
+        <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '240px 1fr', background: T.paper, minHeight: 0 }}>
+          <div style={{ borderRight: `1px solid ${T.hair}`, padding: 24, background: T.paperSoft }}>
+            <Eyebrow>{t('settings.title').toUpperCase()}</Eyebrow>
+            <div style={{ marginTop: 18, display: 'flex', flexDirection: 'column', gap: 2 }}>
+              {tabs.map(([k, l]) => (
+                <div key={k} onClick={() => setTab(k)} style={{
+                  padding: '10px 14px', borderRadius: 8, cursor: 'pointer', fontSize: 13,
+                  background: tab === k ? '#fff' : 'transparent',
+                  border: tab === k ? `1px solid ${T.hair}` : '1px solid transparent',
+                  fontWeight: tab === k ? 500 : 400,
+                }}>{l}</div>
+              ))}
+            </div>
+          </div>
+          <div style={{ padding: 40, overflow: 'auto' }}>
+            {tab === 'account' && (
+              <div style={{ maxWidth: 640 }}>
+                <div style={{ fontFamily: T.fDisplay, fontSize: 28, fontWeight: 400, letterSpacing: -0.5 }}>Data</div>
+                <div style={{ marginTop: 6, fontSize: 13, color: T.mute, lineHeight: 1.5 }}>
+                  You're in <b style={{ color: T.ink }}>guest mode</b>. Everything lives in your browser — no server, no account. Back up to JSON anytime.
+                </div>
+
+                <div style={{ marginTop: 24, padding: 20, background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 12 }}>
+                  <Mono size={10}>LOCAL STORAGE</Mono>
+                  <div style={{ marginTop: 14, display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 20 }}>
+                    {[
+                      ['Avatars',     '7',  'IndexedDB'],
+                      ['Simulations', '12', 'IndexedDB'],
+                      ['Preferences', '4',  'localStorage'],
+                    ].map(([l, n, where]) => (
+                      <div key={l}>
+                        <div style={{ fontFamily: T.fDisplay, fontSize: 28, fontWeight: 400, letterSpacing: -0.5 }}>{n}</div>
+                        <div style={{ fontSize: 13, marginTop: 2 }}>{l}</div>
+                        <Mono size={10} style={{ marginTop: 2 }}>{where}</Mono>
+                      </div>
+                    ))}
+                  </div>
+                  <div style={{ marginTop: 18, height: 6, borderRadius: 3, background: T.paperSoft, overflow: 'hidden' }}>
+                    <div style={{ width: '18%', height: '100%', background: T.cool }}/>
+                  </div>
+                  <div style={{ marginTop: 6, display: 'flex', justifyContent: 'space-between' }}>
+                    <Mono size={10}>8.4 MB / 50 MB used</Mono>
+                    <Mono size={10}>BROWSER QUOTA</Mono>
+                  </div>
+                </div>
+
+                <div style={{ marginTop: 20, padding: 20, background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 12 }}>
+                  <Mono size={10}>BACKUP & RESTORE</Mono>
+                  <div style={{ marginTop: 12, fontSize: 13, color: T.inkSoft, lineHeight: 1.5 }}>
+                    Export a JSON snapshot of everything — avatars, sims, preferences. Move it to another browser, or check it into git.
+                  </div>
+                  <div style={{ marginTop: 16, display: 'flex', gap: 10 }}>
+                    <Btn primary style={{ cursor: 'pointer' }}>↓ Export all (.json)</Btn>
+                    <Btn style={{ cursor: 'pointer' }}>↑ Import</Btn>
+                    <div style={{ flex: 1 }}/>
+                    <Mono size={10}>LAST BACKUP · NEVER</Mono>
+                  </div>
+                </div>
+
+                <div style={{ marginTop: 20, padding: 20, background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 12 }}>
+                  <Mono size={10}>MODEL PROVIDER</Mono>
+                  <div style={{ marginTop: 12, display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 10 }}>
+                    {[
+                      ['Anthropic', 'claude-sonnet-4.5', true],
+                      ['OpenAI',    'gpt-4o',            false],
+                      ['Ollama',    'llama3.1 · local',  false],
+                    ].map(([name, model, active]) => (
+                      <div key={name} style={{
+                        padding: 14, borderRadius: 10, cursor: 'pointer',
+                        border: `1.5px solid ${active ? T.ink : T.hair}`,
+                        background: active ? T.paperSoft : '#fff',
+                      }}>
+                        <div style={{ fontSize: 13, fontWeight: 500 }}>{name}</div>
+                        <Mono size={10} style={{ marginTop: 4 }}>{model}</Mono>
+                      </div>
+                    ))}
+                  </div>
+                  <div style={{ marginTop: 12, fontSize: 12, color: T.mute }}>
+                    API keys are stored in your browser. They never leave your machine except to call the provider directly.
+                  </div>
+                </div>
+
+                <div style={{ marginTop: 28, paddingTop: 20, borderTop: `1px solid ${T.hair}`, display: 'flex', gap: 10 }}>
+                  <div style={{ flex: 1 }}/>
+                  <div style={{ padding: '10px 20px', borderRadius: 999, fontSize: 13, color: '#b84a3a', border: '1px solid #f4d4cd', cursor: 'pointer' }}>Clear all local data</div>
+                </div>
+              </div>
+            )}
+            {tab === 'billing' && (
+              <div style={{ maxWidth: 640 }}>
+                <div style={{ fontFamily: T.fDisplay, fontSize: 28, fontWeight: 400, letterSpacing: -0.5 }}>Cloud</div>
+                <div style={{ marginTop: 6, fontSize: 13, color: T.mute, lineHeight: 1.5 }}>
+                  A hosted version of Persona Studio is in the works — team libraries, shared simulations, SSO. Not needed for solo use.
+                </div>
+                <div style={{ marginTop: 24, padding: 28, background: T.ink, color: '#fff', borderRadius: 14, position: 'relative', overflow: 'hidden' }}>
+                  <div style={{ position: 'absolute', inset: 0, background: `radial-gradient(ellipse 500px 300px at 90% -20%, rgba(201,100,66,0.25), transparent 60%)`, pointerEvents: 'none' }}/>
+                  <div style={{ position: 'relative' }}>
+                    <Mono size={10} color="rgba(255,255,255,0.5)">CLOUD · COMING SOON</Mono>
+                    <div style={{ fontFamily: T.fDisplay, fontStyle: 'italic', fontWeight: 300, fontSize: 30, letterSpacing: -0.8, marginTop: 10, lineHeight: 1.15 }}>
+                      Same software, less plumbing.
+                    </div>
+                    <div style={{ marginTop: 14, fontSize: 13, color: 'rgba(255,255,255,0.75)', lineHeight: 1.5, maxWidth: 460 }}>
+                      Self-hosting is great until it isn't. We'll run it for you — hosted inference, team workspace, SSO, audit logs. The OSS build stays OSS, forever.
+                    </div>
+                    <div style={{ marginTop: 22, display: 'flex', gap: 10 }}>
+                      <div style={{ padding: '10px 18px', borderRadius: 999, background: '#fff', color: T.ink, fontSize: 13, fontWeight: 500, cursor: 'pointer' }}>Join the waitlist →</div>
+                      <div style={{ padding: '10px 18px', borderRadius: 999, border: '1px solid rgba(255,255,255,0.25)', fontSize: 13, cursor: 'pointer' }}>Read the plan</div>
+                    </div>
+                  </div>
+                </div>
+                <div style={{ marginTop: 18, padding: 18, background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 12 }}>
+                  <Mono size={10}>SELF-HOSTING</Mono>
+                  <div style={{ fontSize: 13, color: T.inkSoft, marginTop: 8, lineHeight: 1.5 }}>
+                    Prefer to run it yourself? The full stack is on GitHub. Docker image, Helm chart, and a one-line installer.
+                  </div>
+                  <div style={{ marginTop: 12, padding: '10px 14px', borderRadius: 8, background: T.paperSoft, fontFamily: T.fMono, fontSize: 12, color: T.ink }}>
+                    $ curl -fsSL get.persona-studio.dev | sh
+                  </div>
+                </div>
+              </div>
+            )}
+            {tab === 'about' && (
+              <div style={{ maxWidth: 640 }}>
+                <div style={{ fontFamily: T.fDisplay, fontSize: 28, fontWeight: 400, letterSpacing: -0.5 }}>About</div>
+                <div style={{ marginTop: 18, padding: 22, background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 12 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+                    <div style={{ width: 44, height: 44, borderRadius: 10, background: `conic-gradient(from 180deg, ${T.accent}, ${T.cool}, ${T.accent})` }}/>
+                    <div>
+                      <div style={{ fontWeight: 500, fontSize: 15 }}>Persona Studio</div>
+                      <Mono size={11}>v0.5.3-alpha · build 2026.04.21</Mono>
+                    </div>
+                    <div style={{ flex: 1 }}/>
+                    <Mono size={10} style={{ padding: '3px 8px', background: T.coolSoft, color: T.cool, borderRadius: 4, letterSpacing: 1 }}>ELv2</Mono>
+                  </div>
+                </div>
+
+                <div style={{ marginTop: 16, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+                  {[
+                    ['★ GitHub',        'github.com/persona-studio'],
+                    ['Discord',         'discord.gg/persona-studio'],
+                    ['Docs',            'persona-studio.dev/docs'],
+                    ['Changelog',       'persona-studio.dev/changelog'],
+                    ['License (ELv2)',  'elastic.co/licensing/elastic-license'],
+                    ['Report an issue', 'github.com/.../issues/new'],
+                  ].map(([l, url]) => (
+                    <div key={l} style={{ padding: 14, background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 10, cursor: 'pointer' }}>
+                      <div style={{ fontSize: 13, fontWeight: 500 }}>{l}</div>
+                      <Mono size={10} style={{ marginTop: 3 }}>{url} ↗</Mono>
+                    </div>
+                  ))}
+                </div>
+
+                <div style={{ marginTop: 18, padding: 18, background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 12 }}>
+                  <Mono size={10}>CONTRIBUTORS · 43</Mono>
+                  <div style={{ marginTop: 10, display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                    {P.concat(P).concat(P.slice(0,4)).map((p,i) => (
+                      <div key={i} style={{ width: 26, height: 26, borderRadius: '50%', background: hueBg(p.hue), border: `2px solid ${T.paper}` }}/>
+                    ))}
+                  </div>
+                  <div style={{ marginTop: 14, fontSize: 12, color: T.mute, lineHeight: 1.5 }}>
+                    Built in the open. PRs, issues, and show-and-tell welcome.
+                  </div>
+                </div>
+              </div>
+            )}
+            {tab === 'language' && (
+              <div style={{ maxWidth: 560 }}>
+                <div style={{ fontFamily: T.fDisplay, fontSize: 28, fontWeight: 400, letterSpacing: -0.5 }}>{t('settings.language')}</div>
+                <div style={{ marginTop: 18, fontSize: 13, color: T.mute }}>
+                  {t('lang.current')}: <b style={{ color: T.ink }}>{i18n.LANGS.find(l => l.code === lang)?.name}</b>
+                </div>
+                <div style={{ marginTop: 22 }}>
+                  <Mono size={10}>{t('lang.interface').toUpperCase()}</Mono>
+                  <div style={{ marginTop: 10, display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 10 }}>
+                    {i18n.LANGS.map(L => (
+                      <div key={L.code} onClick={() => setLang(L.code)} style={{
+                        padding: 16, borderRadius: 12, cursor: 'pointer',
+                        border: `1.5px solid ${lang === L.code ? T.ink : T.hair}`,
+                        background: lang === L.code ? T.paperSoft : '#fff',
+                        display: 'flex', flexDirection: 'column', gap: 4,
+                      }}>
+                        <Mono size={10} color={lang === L.code ? T.accent : T.mute}>{L.short}</Mono>
+                        <div style={{ fontWeight: 500 }}>{L.name}</div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div style={{ marginTop: 28, padding: 18, background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 12 }}>
+                  <Mono size={10}>{t('lang.persona').toUpperCase()}</Mono>
+                  <div style={{ fontSize: 13, color: T.inkSoft, marginTop: 8, lineHeight: 1.5 }}>
+                    Personas reply in their native language by default. You can override per-simulation from the setup screen.
+                  </div>
+                  <div style={{ marginTop: 12, display: 'flex', alignItems: 'center', gap: 10 }}>
+                    <div style={{ width: 32, height: 18, borderRadius: 999, background: T.ink, position: 'relative' }}>
+                      <div style={{ position: 'absolute', top: 2, right: 2, width: 14, height: 14, borderRadius: '50%', background: '#fff' }}/>
+                    </div>
+                    <div style={{ fontSize: 13 }}>Auto-detect from the question</div>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </Browser>
+    );
+  }
+
+  window.HF_Auth = { SignInScreen, SignUpScreen, OnboardScreen, PricingScreen, UpgradeModal, SettingsScreen };
+})();

--- a/web/hifi-avatars.jsx
+++ b/web/hifi-avatars.jsx
@@ -1,0 +1,89 @@
+// hifi-avatars.jsx — exploration of 3 avatar treatments side-by-side
+
+(function(){
+  const { tokens: T, PEOPLE: P, PhotoAv, InitialsAv, IllusAv, Kalam, Mono, Eyebrow, hueBg, hueSoft, hueDeep } = window.HF;
+
+  function AvatarExplorations(){
+    const people = P.slice(0, 4);
+    return (
+      <div style={{ padding: 48, background: T.paper, height: '100%', fontFamily: T.fSans, color: T.ink }}>
+        <Eyebrow>AVATAR TREATMENT · 3 DIRECTIONS</Eyebrow>
+        <div style={{ fontFamily: T.fDisplay, fontSize: 38, letterSpacing: -1.2, fontWeight: 400, marginTop: 10, marginBottom: 8 }}>
+          How should faces <span style={{ fontStyle: 'italic', fontWeight: 300 }}>feel?</span>
+        </div>
+        <div style={{ fontSize: 14, color: T.mute, marginBottom: 36, maxWidth: 560, lineHeight: 1.5 }}>
+          Placeholders below — real photos drop into the same slots. The choice sets the whole product's temperature.
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 24 }}>
+          {/* A · Duotone photo placeholder */}
+          <div style={{ padding: 28, background: '#fff', borderRadius: 18, border: `1.5px solid ${T.ink}` }}>
+            <Mono size={10} color={T.accent} style={{ letterSpacing: 2 }}>A · DUOTONE PHOTO</Mono>
+            <div style={{ fontFamily: T.fDisplay, fontSize: 24, letterSpacing: -0.6, marginTop: 8, marginBottom: 20 }}>Cinematic. Moody.</div>
+            <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+              {people.map(p => (
+                <div key={p.id} style={{ textAlign: 'center' }}>
+                  <PhotoAv p={p} size={84}/>
+                  <Mono size={10} style={{ marginTop: 8, display: 'block' }}>{p.name.split(' ')[0]}</Mono>
+                </div>
+              ))}
+            </div>
+            <div style={{ fontSize: 12, color: T.mute, marginTop: 20, lineHeight: 1.5 }}>
+              Per-person hue as the mid-tone. Real headshots drop in at publication time; same mask applied for consistency.
+            </div>
+            <Kalam size={13} style={{ marginTop: 14, display: 'block' }}>← recommended</Kalam>
+          </div>
+
+          {/* B · Soft watercolor illustrated */}
+          <div style={{ padding: 28, background: '#fff', borderRadius: 18, border: `1px solid ${T.hair}` }}>
+            <Mono size={10} style={{ letterSpacing: 2 }}>B · ILLUSTRATED INITIAL</Mono>
+            <div style={{ fontFamily: T.fDisplay, fontSize: 24, letterSpacing: -0.6, marginTop: 8, marginBottom: 20 }}>Editorial. Calm.</div>
+            <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+              {people.map(p => (
+                <div key={p.id} style={{ textAlign: 'center' }}>
+                  <IllusAv p={p} size={84}/>
+                  <Mono size={10} style={{ marginTop: 8, display: 'block' }}>{p.name.split(' ')[0]}</Mono>
+                </div>
+              ))}
+            </div>
+            <div style={{ fontSize: 12, color: T.mute, marginTop: 20, lineHeight: 1.5 }}>
+              Serif italic initials on a pale wash. Good for product without any photos; feels like a book title page.
+            </div>
+          </div>
+
+          {/* C · Solid chip initials */}
+          <div style={{ padding: 28, background: '#fff', borderRadius: 18, border: `1px solid ${T.hair}` }}>
+            <Mono size={10} style={{ letterSpacing: 2 }}>C · SOLID CHIP</Mono>
+            <div style={{ fontFamily: T.fDisplay, fontSize: 24, letterSpacing: -0.6, marginTop: 8, marginBottom: 20 }}>Utility. Snappy.</div>
+            <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+              {people.map(p => (
+                <div key={p.id} style={{ textAlign: 'center' }}>
+                  <InitialsAv p={p} size={84}/>
+                  <Mono size={10} style={{ marginTop: 8, display: 'block' }}>{p.name.split(' ')[0]}</Mono>
+                </div>
+              ))}
+            </div>
+            <div style={{ fontSize: 12, color: T.mute, marginTop: 20, lineHeight: 1.5 }}>
+              Today's wireframe default. Honest, fast, no pretension — but fights the premium typography.
+            </div>
+          </div>
+        </div>
+
+        {/* Size ladder */}
+        <div style={{ marginTop: 40, padding: 28, background: T.paperSoft, borderRadius: 18 }}>
+          <Eyebrow>SIZE LADDER · DUOTONE (A)</Eyebrow>
+          <div style={{ marginTop: 18, display: 'flex', alignItems: 'flex-end', gap: 24 }}>
+            {[28, 40, 56, 80, 120, 180].map(s => (
+              <div key={s} style={{ textAlign: 'center' }}>
+                <PhotoAv p={P[0]} size={s}/>
+                <Mono size={9} style={{ marginTop: 8, display: 'block' }}>{s}px</Mono>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  window.HF_Avatars = { AvatarExplorations };
+})();

--- a/web/hifi-home.jsx
+++ b/web/hifi-home.jsx
@@ -1,0 +1,238 @@
+// hifi-home.jsx — 3 Apple-ish hi-fi directions for Home
+
+(function(){
+  const { tokens: T, PEOPLE: P, InitialsAv: PhotoAv, IllusAv, AppNav, Browser, Note, Kalam, Mono, Display, Btn, Eyebrow, hueBg, hueSoft } = window.HF;
+
+  // A · QUIET HERO — Apple.com product page. One huge statement + ambient cast.
+  function HomeA(){
+    return (
+      <Browser>
+        <AppNav active="home"/>
+        <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
+          {/* soft radial backdrop */}
+          <div style={{ position: 'absolute', inset: 0, background: `radial-gradient(ellipse 900px 500px at 70% 10%, ${T.accentSoft} 0%, transparent 60%), radial-gradient(ellipse 700px 400px at 15% 90%, ${T.coolSoft} 0%, transparent 55%)`, pointerEvents:'none' }}/>
+
+          <div style={{ position: 'relative', padding: '96px 120px 0', maxWidth: 1100 }}>
+            <Eyebrow>Persona Studio · v0.5</Eyebrow>
+            <Display size={88} weight={500} style={{ marginTop: 20, marginBottom: 24, letterSpacing: -3.5 }}>
+              Rehearse tomorrow's <br/>
+              meeting <span style={{ fontFamily: T.fDisplay, fontStyle: 'italic', fontWeight: 300, letterSpacing: -2 }}>today.</span>
+            </Display>
+            <div style={{ fontSize: 20, color: T.mute, lineHeight: 1.45, maxWidth: 620, marginBottom: 44, letterSpacing: -0.2 }}>
+              Build AI avatars of the people who'll be in the room — then listen in as they argue it out.
+            </div>
+            <div style={{ display: 'flex', gap: 12 }}>
+              <Btn primary size="lg">Start a simulation  <span style={{ fontSize: 12, opacity:.7 }}>⌘↵</span></Btn>
+              <Btn size="lg">Build an avatar →</Btn>
+            </div>
+          </div>
+
+          {/* Ambient cast strip (fills bottom) */}
+          <div style={{ position: 'absolute', bottom: 56, left: 0, right: 0, padding: '28px 120px 24px', display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', gap: 40 }}>
+            <div>
+              <Mono size={10} style={{ letterSpacing: 2, textTransform: 'uppercase' }}>YOUR CAST · 7 AVATARS</Mono>
+              <div style={{ display: 'flex', marginTop: 16 }}>
+                {P.slice(0,6).map((p,i) => (
+                  <div key={p.id} style={{ marginLeft: i === 0 ? 0 : -14, zIndex: 10 - i }}>
+                    <PhotoAv p={p} size={52} ring/>
+                  </div>
+                ))}
+                <div style={{ marginLeft: -14, width: 52, height: 52, borderRadius: '50%', background: T.paperSoft, border: `2px solid ${T.paper}`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, color: T.mute, fontFamily: T.fMono }}>+1</div>
+              </div>
+            </div>
+
+            <div style={{ textAlign: 'right' }}>
+              <Mono size={10} style={{ letterSpacing: 2, textTransform: 'uppercase' }}>LAST RUN · 12H AGO</Mono>
+              <div style={{ fontSize: 17, marginTop: 8, letterSpacing: -0.2 }}>
+                "Should we ship the beta?" <span style={{ color: T.mute }}>— 3 rounds</span>
+              </div>
+              <div style={{ marginTop: 6, display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+                <div style={{ width: 6, height: 6, borderRadius: 3, background: T.cool }}/>
+                <Mono size={11} color={T.cool}>Ralph 8.1 · passed</Mono>
+              </div>
+            </div>
+          </div>
+
+          {/* OSS footer strip — restrained, technical, pinned to bottom */}
+          <div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, padding: '14px 120px', borderTop: `1px solid ${T.hair}`, background: 'rgba(251,250,247,0.85)', backdropFilter: 'blur(8px)', display: 'flex', alignItems: 'center', gap: 22, height: 48 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 13 }}>★</span>
+              <Mono size={11} color={T.ink} style={{ letterSpacing: 0.5 }}>github.com/persona-studio/persona-studio</Mono>
+              <Mono size={10} style={{ padding: '2px 7px', background: T.paperSoft, borderRadius: 3 }}>2.4k</Mono>
+            </div>
+            <div style={{ width: 1, height: 14, background: T.hair }}/>
+            <Mono size={10} style={{ letterSpacing: 1.2 }}>ELASTIC LICENSE 2.0</Mono>
+            <div style={{ width: 1, height: 14, background: T.hair }}/>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <Mono size={10} style={{ letterSpacing: 1.2 }}>CONTRIBUTORS</Mono>
+              <div style={{ display: 'flex', marginLeft: 4 }}>
+                {P.slice(0,5).map((p,i) => (
+                  <div key={p.id} style={{ marginLeft: i === 0 ? 0 : -6, width: 20, height: 20, borderRadius: '50%', background: hueBg(p.hue), border: `1.5px solid ${T.paper}` }}/>
+                ))}
+                <Mono size={10} style={{ marginLeft: 8, alignSelf: 'center' }}>+38</Mono>
+              </div>
+            </div>
+            <div style={{ flex: 1 }}/>
+            <Mono size={11} color={T.inkSoft}>Discord</Mono>
+            <Mono size={11} color={T.inkSoft}>Docs</Mono>
+            <Mono size={11} color={T.inkSoft}>Changelog</Mono>
+            <div style={{ padding: '5px 11px', borderRadius: 6, background: T.ink, color: '#fff', fontSize: 11, fontFamily: T.fMono, letterSpacing: 0.5, cursor: 'pointer' }}>
+              pnpm i persona-studio
+            </div>
+          </div>
+        </div>
+
+        <Note top={140} right={64} rot={4} w={170} arrow>
+          one statement.<br/>one breath of air.<br/>like apple.com
+        </Note>
+      </Browser>
+    );
+  }
+
+  // B · ROOM OF FACES — warm, editorial, real-photo avatars front and center
+  function HomeB(){
+    return (
+      <Browser>
+        <AppNav active="home"/>
+        <div style={{ flex: 1, padding: '56px 80px', overflow: 'auto' }}>
+          <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 36 }}>
+            <div>
+              <Kalam size={26} color={T.ink} style={{ fontFamily: T.fHand }}>Good afternoon, JH.</Kalam>
+              <Display size={48} weight={500} style={{ letterSpacing: -1.5, marginTop: 4 }}>
+                Who do you want to <span style={{ fontFamily: T.fDisplay, fontStyle: 'italic', fontWeight: 300 }}>hear from?</span>
+              </Display>
+            </div>
+            <Btn>⌘K</Btn>
+          </div>
+
+          {/* Hero cast — 4 big photo cards */}
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 16, marginBottom: 24 }}>
+            {P.slice(0,4).map((p,i) => (
+              <div key={p.id} style={{
+                background: '#fff', borderRadius: 18, padding: 22, border: `1px solid ${T.hair}`,
+                position: 'relative', overflow: 'hidden',
+              }}>
+                <PhotoAv p={p} size={72}/>
+                <div style={{ fontSize: 17, fontWeight: 500, marginTop: 14, letterSpacing: -0.3 }}>{p.name}</div>
+                <div style={{ fontSize: 12, color: T.mute, marginTop: 2 }}>{p.role}</div>
+                <div style={{ marginTop: 16, paddingTop: 14, borderTop: `1px solid ${T.hair}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <Mono size={10}>{p.corpus} tokens</Mono>
+                  <div style={{ fontSize: 18, color: T.accent }}>→</div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1.3fr 1fr', gap: 16 }}>
+            <div style={{ background: T.ink, color: '#fff', borderRadius: 18, padding: 32, position: 'relative', overflow: 'hidden' }}>
+              <Eyebrow color="rgba(255,255,255,0.5)">QUICKSTART</Eyebrow>
+              <div style={{ fontFamily: T.fDisplay, fontStyle: 'italic', fontWeight: 300, fontSize: 32, letterSpacing: -1, lineHeight: 1.15, marginTop: 14, maxWidth: 420 }}>
+                Start from three thinkers who disagree.
+              </div>
+              <div style={{ display: 'flex', marginTop: 24, alignItems: 'center', gap: 12 }}>
+                <div style={{ display: 'flex' }}>
+                  {P.slice(0,3).map((p,i) => (
+                    <div key={p.id} style={{ marginLeft: i === 0 ? 0 : -10 }}>
+                      <PhotoAv p={p} size={36} ring/>
+                    </div>
+                  ))}
+                </div>
+                <Mono size={11} color="rgba(255,255,255,0.6)">pg · naval · dhh</Mono>
+                <div style={{ marginLeft: 'auto', padding: '10px 18px', borderRadius: 999, background: '#fff', color: T.ink, fontSize: 13, fontWeight: 500 }}>Begin →</div>
+              </div>
+            </div>
+
+            <div style={{ background: T.paperSoft, borderRadius: 18, padding: 28 }}>
+              <Eyebrow>RECENT SIMULATIONS</Eyebrow>
+              {[
+                ['Should we ship the beta?', '12h ago · Ralph 8.1'],
+                ['Mobile vs web first', '2d ago · Ralph 6.4'],
+                ['Panel: hiring round 2', '5d ago · 3 iters'],
+              ].map(([t, s], i) => (
+                <div key={i} style={{ marginTop: 14, paddingTop: 14, borderTop: i === 0 ? 'none' : `1px solid ${T.hair}` }}>
+                  <div style={{ fontSize: 14, fontWeight: 500 }}>{t}</div>
+                  <Mono size={11} style={{ marginTop: 2 }}>{s}</Mono>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+        <Note top={44} right={28} rot={-3} w={140}>
+          real faces in<br/>real light.<br/>feels warm.
+        </Note>
+      </Browser>
+    );
+  }
+
+  // C · DARK COMMAND — keyboard-first, for power users
+  function HomeC(){
+    return (
+      <Browser dark url="localhost:7777 · ⌘K">
+        <AppNav active="home" dark/>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 60, background: T.ink, color: '#fff', position: 'relative' }}>
+          <div style={{ position: 'absolute', inset: 0, background: `radial-gradient(ellipse 800px 500px at 50% 40%, rgba(201,100,66,0.12) 0%, transparent 60%)`, pointerEvents:'none' }}/>
+
+          <div style={{ position: 'relative', width: 760 }}>
+            <Eyebrow color="rgba(255,255,255,0.45)">PERSONA STUDIO · PRESS ⌘K</Eyebrow>
+            <Display size={52} weight={400} color="#fff" style={{ marginTop: 18, marginBottom: 40, letterSpacing: -1.8 }}>
+              What would you like <br/>
+              to <span style={{ fontFamily: T.fDisplay, fontStyle: 'italic', fontWeight: 300, color: T.accent }}>simulate?</span>
+            </Display>
+
+            <div style={{
+              padding: '18px 22px', borderRadius: 14,
+              background: 'rgba(255,255,255,0.06)', border: `1px solid rgba(255,255,255,0.1)`,
+              display: 'flex', alignItems: 'center', gap: 14, backdropFilter: 'blur(8px)',
+            }}>
+              <span style={{ fontFamily: T.fMono, color: T.accent }}>›</span>
+              <div style={{ fontSize: 17, letterSpacing: -0.2 }}>
+                Simulate <span style={{ color: 'rgba(255,255,255,0.45)' }}>a meeting with</span>{' '}
+                <span style={{ background: T.accent, color: '#fff', padding: '2px 8px', borderRadius: 5, fontSize: 14 }}>paul_graham</span>{' '}
+                <span style={{ background: T.accent, color: '#fff', padding: '2px 8px', borderRadius: 5, fontSize: 14 }}>naval</span>{' '}
+                <span style={{ color: 'rgba(255,255,255,0.45)' }}>about</span>{' '}
+                <span style={{ borderBottom: `1px dashed rgba(255,255,255,0.3)` }}>raising a seed</span>
+              </div>
+              <div style={{ marginLeft: 'auto', width: 1.5, height: 20, background: T.accent, animation: 'blink 1s infinite' }}/>
+            </div>
+
+            <div style={{ marginTop: 32 }}>
+              {[
+                ['Simulate meeting', 'paul_graham, naval_ravikant, dhh · Should we raise?', '↵', true],
+                ['Simulate debate',  'jh-baek, wes-bailey · Monolith vs microservices',     '↑↵'],
+                ['Create avatar',    'from podcast + linkedin',                              '⌘N'],
+                ['Browse library',   '7 avatars · local',                                    '⌘L'],
+              ].map(([t, s, k, active], i) => (
+                <div key={i} style={{
+                  display: 'flex', alignItems: 'center', gap: 14, padding: '14px 18px',
+                  borderRadius: 10, marginTop: 4,
+                  background: active ? 'rgba(201,100,66,0.12)' : 'transparent',
+                  border: active ? `1px solid rgba(201,100,66,0.3)` : '1px solid transparent',
+                }}>
+                  <div style={{ width: 24, height: 24, borderRadius: 7, background: active ? T.accent : 'rgba(255,255,255,0.08)' }}/>
+                  <div>
+                    <div style={{ fontSize: 14, fontWeight: 500 }}>{t}</div>
+                    <div style={{ fontSize: 12, color: 'rgba(255,255,255,0.5)', marginTop: 2 }}>{s}</div>
+                  </div>
+                  <Mono size={11} color="rgba(255,255,255,0.5)" style={{ marginLeft: 'auto' }}>{k}</Mono>
+                </div>
+              ))}
+            </div>
+
+            <div style={{ marginTop: 40, display: 'flex', gap: 24, alignItems: 'center', color: 'rgba(255,255,255,0.4)' }}>
+              <Mono size={10}>7 avatars ready</Mono>
+              <Mono size={10}>·</Mono>
+              <Mono size={10}>claude-sonnet-4.5</Mono>
+              <Mono size={10}>·</Mono>
+              <Mono size={10}>last run 12h ago</Mono>
+            </div>
+          </div>
+        </div>
+        <Note top={60} right={40} rot={3} w={150} arrow>
+          dark variant.<br/>engineers will<br/>live in ⌘K.
+        </Note>
+      </Browser>
+    );
+  }
+
+  window.HF_Home = { HomeA, HomeB, HomeC };
+})();

--- a/web/hifi-library.jsx
+++ b/web/hifi-library.jsx
@@ -1,0 +1,313 @@
+// hifi-library.jsx — 2 takes on the Library/Cast
+
+(function(){
+  const { tokens: T, PEOPLE: P, InitialsAv: PhotoAv, AppNav, Browser, Note, Kalam, Mono, Display, Btn, Eyebrow, hueBg, hueSoft, hueDeep } = window.HF;
+  const { useState } = React;
+
+  // ── Import modal ──────────────────────────────────────────────────────────
+  // Three ingestion paths: URL (blogs, feeds), File (txt/md/pdf/chat export),
+  // Clipboard (paste raw text). Same detection/preview steps for all.
+  function ImportModal({ onClose }){
+    const [tab, setTab] = useState('url');
+    const [url, setUrl] = useState('https://paulgraham.com/articles.html');
+    const [stage, setStage] = useState('input'); // input | detecting | preview
+    const detect = () => {
+      setStage('detecting');
+      setTimeout(() => setStage('preview'), 1200);
+    };
+    const tabs = [
+      ['url',  'URL / RSS',       '🔗'],
+      ['file', 'Files',           '↑'],
+      ['clip', 'Paste text',      '⌘V'],
+    ];
+    return (
+      <div style={{ position: 'absolute', inset: 0, zIndex: 50, background: 'rgba(26,23,20,0.45)', backdropFilter: 'blur(4px)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 40 }}>
+        <div style={{ width: 720, maxHeight: '90%', background: '#fff', borderRadius: 18, boxShadow: '0 30px 80px rgba(0,0,0,0.25)', display: 'flex', flexDirection: 'column', overflow: 'hidden', fontFamily: T.fSans }}>
+          {/* Header */}
+          <div style={{ padding: '20px 28px', borderBottom: `1px solid ${T.hair}`, display: 'flex', alignItems: 'center', gap: 14 }}>
+            <Eyebrow>IMPORT AVATAR</Eyebrow>
+            <div style={{ flex: 1 }}/>
+            <Mono size={10} style={{ padding: '3px 8px', background: T.paperSoft, borderRadius: 4 }}>LOCAL · NEVER UPLOADED</Mono>
+            <div onClick={onClose} style={{ width: 28, height: 28, borderRadius: 8, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', fontSize: 16, color: T.mute }}>×</div>
+          </div>
+
+          {/* Tabs */}
+          <div style={{ padding: '0 28px', display: 'flex', gap: 2, borderBottom: `1px solid ${T.hair}` }}>
+            {tabs.map(([k, l, i]) => (
+              <div key={k} onClick={() => { setTab(k); setStage('input'); }} style={{
+                padding: '14px 18px', fontSize: 13, cursor: 'pointer',
+                borderBottom: tab === k ? `2px solid ${T.ink}` : '2px solid transparent',
+                color: tab === k ? T.ink : T.mute,
+                fontWeight: tab === k ? 500 : 400,
+                marginBottom: -1, display: 'flex', alignItems: 'center', gap: 8,
+              }}>
+                <span style={{ fontFamily: T.fMono, fontSize: 11 }}>{i}</span>
+                {l}
+              </div>
+            ))}
+          </div>
+
+          {/* Body */}
+          <div style={{ padding: 28, flex: 1, overflow: 'auto' }}>
+            {stage === 'input' && tab === 'url' && (
+              <div>
+                <div style={{ fontFamily: T.fDisplay, fontSize: 22, letterSpacing: -0.5 }}>Paste a URL or RSS feed</div>
+                <div style={{ fontSize: 13, color: T.mute, marginTop: 6, lineHeight: 1.5 }}>
+                  We'll crawl the site, parse essays, and build a persona from the writing. Works with blogs, Substack, Medium exports, RSS/Atom.
+                </div>
+                <div style={{ marginTop: 18, display: 'flex', gap: 8 }}>
+                  <div style={{ flex: 1, padding: '12px 14px', border: `1px solid ${T.hair}`, borderRadius: 10, display: 'flex', alignItems: 'center', gap: 10, background: T.paperSoft }}>
+                    <span style={{ fontFamily: T.fMono, color: T.mute }}>🔗</span>
+                    <input value={url} onChange={e => setUrl(e.target.value)} style={{ flex: 1, border: 0, background: 'transparent', fontSize: 14, color: T.ink, outline: 'none', fontFamily: T.fMono }}/>
+                  </div>
+                  <div onClick={detect}>
+                    <Btn primary style={{ cursor: 'pointer', padding: '12px 20px' }}>Detect →</Btn>
+                  </div>
+                </div>
+                <div style={{ marginTop: 20 }}>
+                  <Mono size={10}>TRY THESE</Mono>
+                  <div style={{ marginTop: 10, display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                    {[
+                      'paulgraham.com/articles.html',
+                      'nav.al/rss',
+                      'world.hey.com/dhh',
+                      'stratechery.com/feed',
+                    ].map(s => (
+                      <div key={s} onClick={() => setUrl('https://' + s)} style={{ padding: '6px 11px', borderRadius: 999, border: `1px solid ${T.hair}`, fontFamily: T.fMono, fontSize: 11, color: T.inkSoft, cursor: 'pointer', background: '#fff' }}>
+                        {s}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {stage === 'input' && tab === 'file' && (
+              <div>
+                <div style={{ fontFamily: T.fDisplay, fontSize: 22, letterSpacing: -0.5 }}>Drop files or a folder</div>
+                <div style={{ fontSize: 13, color: T.mute, marginTop: 6, lineHeight: 1.5 }}>
+                  Markdown, plain text, PDF, or chat exports (Slack, iMessage, WhatsApp JSON). Everything is parsed locally.
+                </div>
+                <div style={{ marginTop: 18, padding: 40, border: `2px dashed ${T.hair}`, borderRadius: 14, textAlign: 'center', background: T.paperSoft }}>
+                  <div style={{ fontSize: 36, color: T.accent, lineHeight: 1 }}>↑</div>
+                  <div style={{ marginTop: 12, fontSize: 14, fontWeight: 500 }}>Drop files here</div>
+                  <Mono size={11} style={{ marginTop: 6 }}>OR CLICK TO BROWSE · .MD .TXT .PDF .JSON .ZIP</Mono>
+                  <div onClick={detect} style={{ marginTop: 18, display: 'inline-block' }}>
+                    <Btn primary style={{ cursor: 'pointer' }}>Choose files</Btn>
+                  </div>
+                </div>
+                <div style={{ marginTop: 16, fontSize: 12, color: T.mute, display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ width: 6, height: 6, borderRadius: 3, background: T.green }}/>
+                  Files stay on your machine. Parsing happens in your browser.
+                </div>
+              </div>
+            )}
+
+            {stage === 'input' && tab === 'clip' && (
+              <div>
+                <div style={{ fontFamily: T.fDisplay, fontSize: 22, letterSpacing: -0.5 }}>Paste raw text</div>
+                <div style={{ fontSize: 13, color: T.mute, marginTop: 6, lineHeight: 1.5 }}>
+                  Tweets, transcripts, notes, a single great email. Good for quick one-off personas.
+                </div>
+                <textarea placeholder="Paste anything here — essays, tweets, transcripts, chat logs…" style={{
+                  width: '100%', marginTop: 14, minHeight: 180, padding: 14, borderRadius: 10,
+                  border: `1px solid ${T.hair}`, background: T.paperSoft, resize: 'vertical',
+                  fontFamily: T.fMono, fontSize: 12.5, color: T.ink, outline: 'none', lineHeight: 1.5,
+                }}/>
+                <div style={{ marginTop: 14, display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <Mono size={10}>0 WORDS · 0 TOKENS</Mono>
+                  <div style={{ flex: 1 }}/>
+                  <div onClick={detect}>
+                    <Btn primary style={{ cursor: 'pointer' }}>Build avatar →</Btn>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {stage === 'detecting' && (
+              <div style={{ padding: '40px 20px', textAlign: 'center' }}>
+                <Mono size={11} color={T.accent}>ANALYZING</Mono>
+                <div style={{ fontFamily: T.fDisplay, fontSize: 26, letterSpacing: -0.6, marginTop: 10 }}>
+                  Reading the writing…
+                </div>
+                <div style={{ marginTop: 28, maxWidth: 360, margin: '28px auto 0' }}>
+                  {[
+                    ['Fetching source',    'done'],
+                    ['Parsing 184 essays', 'done'],
+                    ['Extracting voice',   'running'],
+                    ['Building corpus',    'queued'],
+                  ].map(([l, s], i) => (
+                    <div key={i} style={{ padding: '10px 14px', display: 'flex', alignItems: 'center', gap: 12, borderBottom: i === 3 ? 'none' : `1px solid ${T.hair}`, fontSize: 13 }}>
+                      <div style={{
+                        width: 14, height: 14, borderRadius: '50%',
+                        background: s === 'done' ? T.cool : s === 'running' ? T.accent : T.paperSoft,
+                        border: s === 'queued' ? `1px solid ${T.hair}` : 'none',
+                      }}/>
+                      <div style={{ flex: 1, textAlign: 'left', color: s === 'queued' ? T.mute : T.ink }}>{l}</div>
+                      <Mono size={10} color={s === 'done' ? T.cool : T.mute}>{s.toUpperCase()}</Mono>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {stage === 'preview' && (
+              <div>
+                <Mono size={10} color={T.cool}>READY TO ADD</Mono>
+                <div style={{ marginTop: 14, display: 'grid', gridTemplateColumns: '140px 1fr', gap: 24, alignItems: 'center' }}>
+                  <div style={{ width: 140, height: 140, borderRadius: 16, background: `linear-gradient(180deg, ${hueSoft(28)} 0%, ${hueBg(28)}33 100%)`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <PhotoAv p={{ id: 'pg', name: 'Paul Graham', hue: 28 }} size={90}/>
+                  </div>
+                  <div>
+                    <div style={{ fontFamily: T.fDisplay, fontSize: 30, letterSpacing: -0.8 }}>Paul Graham</div>
+                    <div style={{ fontSize: 13, color: T.mute, marginTop: 4 }}>Essayist · Y Combinator · paulgraham.com</div>
+                    <div style={{ marginTop: 14, display: 'flex', gap: 18 }}>
+                      {[
+                        ['184', 'essays'],
+                        ['84k', 'tokens'],
+                        ['2004–2025', 'span'],
+                      ].map(([n, l]) => (
+                        <div key={l}>
+                          <div style={{ fontFamily: T.fDisplay, fontSize: 22 }}>{n}</div>
+                          <Mono size={10}>{l.toUpperCase()}</Mono>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+                <div style={{ marginTop: 22, padding: 14, background: T.paperSoft, borderRadius: 10 }}>
+                  <Mono size={10}>VOICE SAMPLE (FIRST 20 WORDS)</Mono>
+                  <div style={{ fontFamily: T.fDisplay, fontStyle: 'italic', fontSize: 16, color: T.ink, marginTop: 6, lineHeight: 1.4 }}>
+                    "The essays on this site try to figure out things that I didn't already know. That's what essays are for…"
+                  </div>
+                </div>
+                <div style={{ marginTop: 18, display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: T.inkSoft, cursor: 'pointer' }}>
+                    <div style={{ width: 16, height: 16, borderRadius: 4, border: `1.5px solid ${T.ink}`, background: T.ink, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#fff', fontSize: 10 }}>✓</div>
+                    Public persona
+                  </label>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: T.inkSoft, cursor: 'pointer' }}>
+                    <div style={{ width: 16, height: 16, borderRadius: 4, border: `1.5px solid ${T.hair}` }}/>
+                    Share with my library
+                  </label>
+                  <div style={{ flex: 1 }}/>
+                  <Btn style={{ cursor: 'pointer' }} onClick={() => setStage('input')}>← Back</Btn>
+                  <div onClick={onClose}>
+                    <Btn accent style={{ cursor: 'pointer' }}>Add to library →</Btn>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // A · EDITORIAL GRID — feels like a masthead of contributors
+  function LibraryA(){
+    const [importOpen, setImportOpen] = useState(false);
+    return (
+      <Browser>
+        <AppNav active="library"/>
+        <div style={{ flex: 1, overflow: 'auto', padding: '48px 72px', position: 'relative' }}>
+          <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 40 }}>
+            <div>
+              <Eyebrow>THE CAST · 7</Eyebrow>
+              <div style={{ fontFamily: T.fDisplay, fontWeight: 400, fontSize: 56, letterSpacing: -2, lineHeight: 1, marginTop: 10 }}>
+                Seven voices, <span style={{ fontStyle: 'italic', fontWeight: 300 }}>ready.</span>
+              </div>
+            </div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              {['All','Local 4','Global 3','Private'].map((t,i) => (
+                <div key={t} style={{ padding: '8px 14px', borderRadius: 999, fontSize: 12, background: i === 0 ? T.ink : 'transparent', color: i === 0 ? '#fff' : T.inkSoft, border: i === 0 ? 'none' : `1px solid ${T.hair}` }}>{t}</div>
+              ))}
+              <div onClick={() => setImportOpen(true)} style={{ cursor: 'pointer', marginLeft: 12 }}>
+                <Btn primary>+ New avatar</Btn>
+              </div>
+            </div>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 20 }}>
+            {P.map((p, i) => (
+              <div key={p.id} style={{ background: '#fff', borderRadius: 18, overflow: 'hidden', border: `1px solid ${T.hair}` }}>
+                {/* Portrait header */}
+                <div style={{ position: 'relative', height: 220, background: `linear-gradient(180deg, ${hueSoft(p.hue)} 0%, ${hueBg(p.hue)}33 100%)`, display: 'flex', alignItems: 'flex-end', justifyContent: 'center', paddingBottom: 16 }}>
+                  <PhotoAv p={p} size={130}/>
+                  <div style={{ position: 'absolute', top: 14, left: 14 }}>
+                    <Mono size={9} color={hueDeep(p.hue)} style={{ padding: '3px 8px', background: '#fff', borderRadius: 4, letterSpacing: 1.5 }}>
+                      {p.mode === 'private' ? '· PRIVATE' : '· PUBLIC'}
+                    </Mono>
+                  </div>
+                </div>
+                <div style={{ padding: 18 }}>
+                  <div style={{ fontFamily: T.fDisplay, fontSize: 22, fontWeight: 400, letterSpacing: -0.5, lineHeight: 1.1 }}>{p.name}</div>
+                  <div style={{ fontSize: 12, color: T.mute, marginTop: 4 }}>{p.role}</div>
+                  <div style={{ marginTop: 14, paddingTop: 14, borderTop: `1px solid ${T.hair}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <Mono size={10}>b.{p.born} · {p.corpus}</Mono>
+                    <div style={{ fontSize: 13, color: T.accent }}>→</div>
+                  </div>
+                </div>
+              </div>
+            ))}
+            {/* Add card */}
+            <div onClick={() => setImportOpen(true)} style={{ borderRadius: 18, border: `1.5px dashed ${T.hair}`, display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: 340, color: T.mute, fontSize: 13, background: 'transparent', cursor: 'pointer' }}>
+              <div style={{ textAlign: 'center' }}>
+                <div style={{ fontSize: 28, marginBottom: 8, color: T.accent }}>+</div>
+                <Kalam size={14} color={T.mute}>add a voice</Kalam>
+              </div>
+            </div>
+          </div>
+          {importOpen && <ImportModal onClose={() => setImportOpen(false)}/>}
+        </div>
+        <Note top={70} right={40} rot={3} w={140} arrow>
+          portraits as<br/>big as the names.<br/>people first.
+        </Note>
+      </Browser>
+    );
+  }
+
+  // B · MUSEUM ROW — editorial horizontal scroll
+  function LibraryB(){
+    return (
+      <Browser>
+        <AppNav active="library"/>
+        <div style={{ flex: 1, overflow: 'hidden', padding: '60px 72px 0' }}>
+          <Eyebrow>THE CAST</Eyebrow>
+          <div style={{ fontFamily: T.fDisplay, fontWeight: 400, fontSize: 64, letterSpacing: -2.2, lineHeight: 1, marginTop: 14, marginBottom: 40 }}>
+            Seven voices, <span style={{ fontStyle: 'italic', fontWeight: 300 }}>ready to argue.</span>
+          </div>
+          <div style={{ display: 'flex', gap: 28, alignItems: 'flex-end', overflowX: 'auto', paddingBottom: 32 }}>
+            {P.map((p, i) => {
+              const rot = (i % 2 ? 1 : -1) * (0.4 + (i % 3) * 0.3);
+              return (
+                <div key={p.id} style={{ flex: '0 0 auto', width: 200, textAlign: 'center' }}>
+                  <div style={{
+                    width: 200, height: 280, borderRadius: 10,
+                    background: `linear-gradient(180deg, ${hueSoft(p.hue)} 0%, ${hueBg(p.hue)}22 100%)`,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    transform: `rotate(${rot}deg)`,
+                    boxShadow: `0 20px 40px ${T.paperDeep}40`,
+                  }}>
+                    <PhotoAv p={p} size={140}/>
+                  </div>
+                  <div style={{ fontFamily: T.fDisplay, fontSize: 18, fontWeight: 400, letterSpacing: -0.4, marginTop: 18 }}>{p.name}</div>
+                  <Mono size={10} style={{ marginTop: 4 }}>{p.role}</Mono>
+                </div>
+              );
+            })}
+          </div>
+          <div style={{ marginTop: 20, display: 'flex', alignItems: 'center', gap: 20 }}>
+            <Btn primary size="lg">+ Add new voice</Btn>
+            <Kalam size={14} color={T.mute}>or drag a folder here to build one automatically</Kalam>
+          </div>
+        </div>
+        <Note top={50} right={40} rot={-3} w={150}>
+          editorial / museum.<br/>risky. memorable.
+        </Note>
+      </Browser>
+    );
+  }
+
+  window.HF_Library = { LibraryA, LibraryB };
+})();

--- a/web/hifi-live-animated.jsx
+++ b/web/hifi-live-animated.jsx
@@ -1,0 +1,561 @@
+// hifi-live-animated.jsx — animated Round Table simulation
+// Auto-cycles through speakers with typing, ring pulse, and transcript build-up.
+// Speech bubbles are rectangular "notecards" that dock around the table,
+// with placement/size adaptive to the participant count (2 → 8+).
+// Exposes window.HF_LiveAnimated = { LiveBAnimated }
+
+(function(){
+  const { tokens: T, PEOPLE: P, InitialsAv: Av, AppNav, Browser, Note, Kalam, Mono, Wave, Btn, Eyebrow, hueBg, hueSoft, hueDeep } = window.HF;
+  const { useState, useEffect, useRef } = React;
+
+  // Expanded pool of lines so we can drive any N-person scene. We select by
+  // speaker id from this bank and fall back to a generic line for unknown P.
+  const LINES_BY_ID = {
+    pg:  [
+      '"Most of what sounds sophisticated about mobile-first is just imitation. If two of you can\'t ship a web app in a weekend, two of you can\'t ship an iOS app in a month."',
+      '"Build where friction is lowest, not where fashion is highest. Default to the web."',
+    ],
+    nv:  [
+      '"But distribution matters. The web compounds — an app store doesn\'t."',
+      '"Leverage is the point. Web = broader surface. Easier to find the thing that works."',
+    ],
+    dhh: [
+      '"Monoliths ship. Whatever the form. Start."',
+      '"Fine. But ship the boring one. Don\'t pick based on what reads well on Twitter."',
+    ],
+    jhb: [
+      '"On mobile the install step is the tax. Most of our users never pay it."',
+    ],
+    dv:  [
+      '"Push notifications are the only thing I miss on web — and even that\'s partly solved."',
+    ],
+    wb:  [
+      '"From a product angle: faster iteration on web beats a slightly better mobile UX."',
+    ],
+    sp:  [
+      '"내부 툴이면 웹이 맞다. 모바일 먼저는 과하다."',
+    ],
+  };
+  const GENERIC_LINE = '"Agree on the constraint first — then the form follows."';
+  const SPEEDS = [24, 28, 30, 32];
+
+  // Build a script for a given roster (array of people). Rotates through
+  // speakers and picks the next line from their bank.
+  function buildScript(roster, turns){
+    const perIdCursor = {};
+    const out = [];
+    for (let i = 0; i < turns; i++){
+      const speaker = i % roster.length;
+      const p = roster[speaker];
+      const bank = LINES_BY_ID[p.id] || [GENERIC_LINE];
+      const c = (perIdCursor[p.id] || 0) % bank.length;
+      perIdCursor[p.id] = (perIdCursor[p.id] || 0) + 1;
+      out.push({ speaker, text: bank[c], speed: SPEEDS[i % SPEEDS.length] });
+    }
+    return out;
+  }
+
+  const THINKING_MS = 1200;
+  const LINGER_MS = 800;
+
+  function useTyped(text, speed, enabled, onDone){
+    const [out, setOut] = useState('');
+    const doneRef = useRef(false);
+    useEffect(() => {
+      if (!enabled) { setOut(''); doneRef.current = false; return; }
+      setOut('');
+      doneRef.current = false;
+      let i = 0;
+      const tick = () => {
+        i += 1;
+        setOut(text.slice(0, i));
+        if (i >= text.length) {
+          if (!doneRef.current) { doneRef.current = true; onDone && onDone(); }
+          return;
+        }
+        t = setTimeout(tick, speed);
+      };
+      let t = setTimeout(tick, speed);
+      return () => clearTimeout(t);
+    }, [text, enabled]);
+    return out;
+  }
+
+  // ── Seat geometry ─────────────────────────────────────────────────────────
+  // Given N seats, return { seat, bubble } pairs in absolute % coordinates
+  // inside the stage. Seats sit on an ellipse around the table; bubbles dock
+  // OUTSIDE the seat so they don't collide with the table or each other.
+  //
+  // Each slot:
+  //   seat:   { x, y }                        center of avatar, in %
+  //   anchor: 'top'|'bottom'|'left'|'right'   which side the bubble docks to
+  //   bubbleW: px                             bubble width, scales with N
+  //
+  function slotsFor(n){
+    // table ellipse — we scale it down as N grows so the ring grows
+    // bubbleW also shrinks with N, never below 180px
+    const bubbleW = Math.max(180, 340 - (n - 2) * 22);
+
+    // Anchor semantics: which SIDE of the avatar the bubble docks on.
+    // Bubbles face INTO the table (toward center), so top-row seats get
+    // anchor 'bottom' (bubble below avatar, toward center), and vice versa.
+
+    if (n <= 2) {
+      // 1:1 — sit across the table, bubbles float toward the center.
+      return [
+        { x: 22, y: 50, anchor: 'right',  bubbleW },
+        { x: 78, y: 50, anchor: 'left',   bubbleW },
+      ].slice(0, n);
+    }
+
+    if (n === 3) {
+      return [
+        { x: 50, y: 20, anchor: 'bottom', bubbleW },
+        { x: 22, y: 74, anchor: 'top',    bubbleW },
+        { x: 78, y: 74, anchor: 'top',    bubbleW },
+      ];
+    }
+
+    if (n === 4) {
+      return [
+        { x: 28, y: 22, anchor: 'bottom', bubbleW },
+        { x: 72, y: 22, anchor: 'bottom', bubbleW },
+        { x: 28, y: 78, anchor: 'top',    bubbleW },
+        { x: 72, y: 78, anchor: 'top',    bubbleW },
+      ];
+    }
+
+    if (n === 5) {
+      return [
+        { x: 50, y: 18, anchor: 'bottom', bubbleW },
+        { x: 20, y: 42, anchor: 'right',  bubbleW },
+        { x: 80, y: 42, anchor: 'left',   bubbleW },
+        { x: 30, y: 80, anchor: 'top',    bubbleW },
+        { x: 70, y: 80, anchor: 'top',    bubbleW },
+      ];
+    }
+    if (n === 6) {
+      return [
+        { x: 28, y: 20, anchor: 'bottom', bubbleW },
+        { x: 72, y: 20, anchor: 'bottom', bubbleW },
+        { x: 16, y: 50, anchor: 'right',  bubbleW },
+        { x: 84, y: 50, anchor: 'left',   bubbleW },
+        { x: 28, y: 80, anchor: 'top',    bubbleW },
+        { x: 72, y: 80, anchor: 'top',    bubbleW },
+      ];
+    }
+    if (n === 7) {
+      return [
+        { x: 50, y: 20, anchor: 'bottom', bubbleW },
+        { x: 22, y: 30, anchor: 'bottom', bubbleW },
+        { x: 78, y: 30, anchor: 'bottom', bubbleW },
+        { x: 16, y: 60, anchor: 'right',  bubbleW },
+        { x: 84, y: 60, anchor: 'left',   bubbleW },
+        { x: 32, y: 80, anchor: 'top',    bubbleW },
+        { x: 68, y: 80, anchor: 'top',    bubbleW },
+      ];
+    }
+    // 8: balanced oval ring, vertical spread 20–80%, all bubbles face center.
+    const slots8 = [
+      { x: 28, y: 22, anchor: 'bottom' },
+      { x: 50, y: 18, anchor: 'bottom' },
+      { x: 72, y: 22, anchor: 'bottom' },
+      { x: 14, y: 50, anchor: 'right'  },
+      { x: 86, y: 50, anchor: 'left'   },
+      { x: 28, y: 78, anchor: 'top'    },
+      { x: 50, y: 82, anchor: 'top'    },
+      { x: 72, y: 78, anchor: 'top'    },
+    ];
+    return slots8.slice(0, n).map(s => ({ ...s, bubbleW: Math.max(180, 280 - (n - 8) * 10) }));
+  }
+
+  function LiveTopBar({ elapsed, turn, turns, onRestart, paused, onTogglePause, title, nPeople, setNPeople }){
+    const min = Math.floor(elapsed / 60);
+    const sec = String(Math.floor(elapsed) % 60).padStart(2, '0');
+    return (
+      <div style={{ padding: '16px 32px', borderBottom: `1px solid ${T.hair}`, display: 'flex', alignItems: 'center', gap: 20, background: T.paper }}>
+        <div>
+          <div style={{ fontSize: 15, fontWeight: 500, letterSpacing: -0.2 }}>{title}</div>
+          <div style={{ fontFamily: T.fMono, fontSize: 10, color: T.mute, marginTop: 3, letterSpacing: 1 }}>
+            MEETING · ITER 1/3 · TURN {turn + 1}/{turns} · {min}:{sec}
+          </div>
+        </div>
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 10 }}>
+          {/* Seat-count tweaker lives in the top bar so it never collides
+              with on-stage seats/bubbles. */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 999, padding: 3 }}>
+            <span style={{ padding: '0 8px', fontFamily: T.fMono, fontSize: 9, color: T.mute, letterSpacing: 1.2 }}>SEATS</span>
+            {[2,3,4,6,8].map(n => (
+              <div key={n} onClick={() => setNPeople(n)} style={{
+                padding: '3px 9px', borderRadius: 999, cursor: 'pointer',
+                fontFamily: T.fMono, fontSize: 11,
+                background: nPeople === n ? T.ink : 'transparent',
+                color: nPeople === n ? '#fff' : T.inkSoft,
+                fontWeight: nPeople === n ? 500 : 400,
+              }}>{n}</div>
+            ))}
+          </div>
+          <div onClick={onTogglePause} style={{ cursor: 'pointer', padding: '6px 14px', borderRadius: 999, fontSize: 12, color: T.mute, fontFamily: T.fMono, letterSpacing: 1 }}>
+            {paused ? '▶ RESUME' : '❚❚ PAUSE'}
+          </div>
+          <div onClick={onRestart} style={{ cursor: 'pointer', padding: '6px 14px', borderRadius: 999, fontSize: 12, fontFamily: T.fMono, letterSpacing: 1, color: T.mute }}>
+            ↻ REPLAY
+          </div>
+          <div style={{ padding: '8px 16px', borderRadius: 999, fontSize: 13, background: T.ink, color: '#fff', fontWeight: 500 }}>
+            End →
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Rectangular speech notecard ───────────────────────────────────────────
+  // Shape: wide rectangle with a slim colored header strip (name + role),
+  // a generous body for the quoted line, and a small pointer (triangle or
+  // short connector line) aimed at the speaker's avatar. This reads more
+  // like a printed attribution card than a chat bubble — which keeps it
+  // legible even at small widths when there are many people at the table.
+  function SpeechCard({ person, text, anchor, width, active }){
+    const hue = hueBg(person.hue);
+    const deep = hueDeep(person.hue);
+    // Pointer lives on the side facing the avatar.
+    const pointerSide = {
+      top:    { bottom: -7, left: '50%', mx: '-50%', rot: 45,  borderSides: 'rb' }, // bubble above avatar, pointer below
+      bottom: { top: -7,    left: '50%', mx: '-50%', rot: 45,  borderSides: 'lt' }, // bubble below avatar, pointer above
+      left:   { right: -7,  top: '50%',  my: '-50%', rot: 45,  borderSides: 'rt' }, // bubble left of avatar, pointer right
+      right:  { left: -7,   top: '50%',  my: '-50%', rot: 45,  borderSides: 'lb' }, // bubble right of avatar, pointer left
+    }[anchor];
+    const bSides = pointerSide.borderSides;
+    return (
+      <div style={{
+        width, background: '#fff',
+        border: `1.5px solid ${hue}`, borderRadius: 6,
+        boxShadow: active ? `0 14px 36px ${hue}33, 0 2px 6px rgba(0,0,0,0.04)` : `0 4px 14px ${hue}18`,
+        position: 'relative',
+        animation: 'fadeUp 280ms cubic-bezier(.2,.7,.3,1)',
+        overflow: 'visible',
+      }}>
+        {/* header strip */}
+        <div style={{
+          padding: '7px 12px', borderBottom: `1px solid ${hue}55`,
+          background: hueSoft(person.hue),
+          display: 'flex', alignItems: 'center', gap: 8,
+          borderRadius: '5px 5px 0 0',
+          fontFamily: T.fMono, fontSize: 9, letterSpacing: 1.2, color: deep,
+        }}>
+          <span style={{ width: 5, height: 5, borderRadius: '50%', background: deep }}/>
+          <span style={{ textTransform: 'uppercase', fontWeight: 500 }}>{person.name}</span>
+          <span style={{ marginLeft: 'auto', opacity: 0.7 }}>SPEAKING</span>
+        </div>
+        {/* body — quoted line */}
+        <div style={{
+          padding: '11px 14px 13px',
+          fontFamily: T.fDisplay, fontWeight: 300, fontSize: 14, lineHeight: 1.42,
+          letterSpacing: -0.15, color: T.ink,
+          textWrap: 'pretty',
+        }}>
+          {text}
+          <span style={{
+            display: 'inline-block', width: 2, height: 13, background: deep,
+            verticalAlign: '-2px', marginLeft: 2, animation: 'blink .9s infinite',
+          }}/>
+        </div>
+        {/* pointer: a small square rotated 45° that sits on the bubble edge
+            closest to the avatar. We hide two of its borders so it reads as
+            a triangle continuous with the bubble outline. */}
+        <div style={{
+          position: 'absolute',
+          top: pointerSide.top, bottom: pointerSide.bottom,
+          left: pointerSide.left, right: pointerSide.right,
+          transform: `translate(${pointerSide.mx || 0}, ${pointerSide.my || 0}) rotate(${pointerSide.rot}deg)`,
+          width: 11, height: 11, background: '#fff',
+          borderTop: bSides.includes('t') ? `1.5px solid ${hue}` : 'none',
+          borderBottom: bSides.includes('b') ? `1.5px solid ${hue}` : 'none',
+          borderLeft: bSides.includes('l') ? `1.5px solid ${hue}` : 'none',
+          borderRight: bSides.includes('r') ? `1.5px solid ${hue}` : 'none',
+        }}/>
+      </div>
+    );
+  }
+
+  // Offset from the avatar center to the bubble edge (in px), so pointer
+  // meets the avatar cleanly. We keep a small gap.
+  const AVATAR_PAD = 40;
+
+  function LiveBAnimated(){
+    // Tweakable roster size so user can see bubble behavior across counts.
+    const [nPeople, setNPeople] = useState(() => {
+      try { return parseInt(localStorage.getItem('ps_live_n') || '4', 10); } catch { return 4; }
+    });
+    const roster = P.slice(0, nPeople);
+    const script = React.useMemo(() => buildScript(roster, Math.max(6, nPeople * 2)), [nPeople]);
+
+    const [turnIdx, setTurnIdx] = useState(0);
+    const [phase, setPhase] = useState('thinking');
+    const [elapsed, setElapsed] = useState(0);
+    const [paused, setPaused] = useState(false);
+    const [transcript, setTranscript] = useState([]);
+    const [nonce, setNonce] = useState(0);
+
+    // Reset when roster changes
+    useEffect(() => {
+      setTurnIdx(0); setPhase('thinking'); setElapsed(0); setTranscript([]); setNonce(n => n + 1);
+      try { localStorage.setItem('ps_live_n', String(nPeople)); } catch {}
+    }, [nPeople]);
+
+    useEffect(() => {
+      if (paused) return;
+      const id = setInterval(() => setElapsed(e => e + 0.1), 100);
+      return () => clearInterval(id);
+    }, [paused]);
+
+    useEffect(() => {
+      if (paused) return;
+      if (phase === 'thinking') {
+        const t = setTimeout(() => setPhase('speaking'), THINKING_MS);
+        return () => clearTimeout(t);
+      }
+      if (phase === 'linger') {
+        const t = setTimeout(() => {
+          setTranscript(tr => [{ ...script[turnIdx], time: elapsed }, ...tr]);
+          setTurnIdx(i => (i + 1) % script.length);
+          setPhase('thinking');
+        }, LINGER_MS);
+        return () => clearTimeout(t);
+      }
+    }, [phase, paused, turnIdx, script]);
+
+    const current = script[turnIdx] || script[0];
+    const speakingPerson = roster[current.speaker];
+
+    const typed = useTyped(
+      current.text,
+      current.speed,
+      phase === 'speaking' && !paused,
+      () => setPhase('linger')
+    );
+
+    const slots = slotsFor(nPeople);
+
+    const handleRestart = () => {
+      setTurnIdx(0); setPhase('thinking'); setElapsed(0); setTranscript([]); setNonce(n => n + 1);
+    };
+
+    const ralphDraft = Math.min(7.8, 5.2 + (turnIdx * 0.35) + (phase === 'speaking' ? typed.length / current.text.length * 0.3 : 0.3)).toFixed(1);
+
+    // Stage sizing: table ellipse is now PURELY DECORATIVE — bubbles float
+    // above it toward the center. We keep it small-ish so the center has
+    // breathing room for the active speaker's card.
+    const stageTable = (() => {
+      if (nPeople <= 2) return { w: 260, h: 160 };
+      if (nPeople <= 3) return { w: 260, h: 160 };
+      if (nPeople <= 4) return { w: 300, h: 170 };
+      if (nPeople <= 6) return { w: 260, h: 150 };
+      if (nPeople <= 7) return { w: 220, h: 130 };
+      return { w: 200, h: 120 };
+    })();
+
+    // Position the bubble absolute in the stage, offset from the seat by
+    // the bubble's own dimensions + avatar pad. We compute CSS positions
+    // from the seat's %-coords and the bubble anchor.
+    function bubbleStyleFor(slot){
+      const base = { position: 'absolute', pointerEvents: 'auto' };
+      const gap = AVATAR_PAD; // px from avatar center to bubble edge
+      // place bubble relative to seat %. Use calc to combine % with px offsets.
+      if (slot.anchor === 'top') {
+        return { ...base, left: `${slot.x}%`, bottom: `calc(${100 - slot.y}% + ${gap}px)`, transform: 'translateX(-50%)' };
+      }
+      if (slot.anchor === 'bottom') {
+        return { ...base, left: `${slot.x}%`, top: `calc(${slot.y}% + ${gap}px)`, transform: 'translateX(-50%)' };
+      }
+      if (slot.anchor === 'left') {
+        return { ...base, top: `${slot.y}%`, right: `calc(${100 - slot.x}% + ${gap}px)`, transform: 'translateY(-50%)' };
+      }
+      return { ...base, top: `${slot.y}%`, left: `calc(${slot.x}% + ${gap}px)`, transform: 'translateY(-50%)' };
+    }
+
+    return (
+      <Browser>
+        <AppNav active="sim"/>
+        <LiveTopBar
+          elapsed={elapsed}
+          turn={turnIdx}
+          turns={script.length}
+          onRestart={handleRestart}
+          paused={paused}
+          onTogglePause={() => setPaused(p => !p)}
+          nPeople={nPeople}
+          setNPeople={setNPeople}
+          title={nPeople <= 2 ? '1:1 — Mobile vs web first in 2026'
+               : nPeople <= 4 ? 'Mobile vs web first in 2026'
+               : 'Roundtable — Mobile vs web first in 2026'}
+        />
+        <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 380px', minHeight: 0 }}>
+          {/* Stage */}
+          <div style={{ position: 'relative', padding: 24, background: `radial-gradient(ellipse 800px 500px at 50% 50%, ${T.paperSoft} 0%, ${T.paper} 70%)`, overflow: 'hidden' }}>
+            {/* Table ellipse — now sized to leave room for bubbles outside */}
+            <div style={{
+              position: 'absolute', top: '50%', left: '50%',
+              transform: 'translate(-50%, -50%)',
+              width: stageTable.w, height: stageTable.h,
+              borderRadius: stageTable.h,
+              border: `1.5px solid ${T.hair}`, background: '#fff',
+              boxShadow: `0 24px 80px ${T.paperDeep}80`,
+              transition: 'width 350ms, height 350ms',
+            }}>
+              <div style={{ position: 'absolute', inset: 14, borderRadius: stageTable.h, border: `1px dashed ${T.hair}`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <div style={{ textAlign: 'center', padding: 12 }}>
+                  <Kalam size={12} color={T.mute}>the table</Kalam>
+                  <div style={{ fontFamily: T.fDisplay, fontStyle: 'italic', fontWeight: 300, fontSize: nPeople <= 4 ? 18 : 15, letterSpacing: -0.4, marginTop: 2, lineHeight: 1.15 }}>
+                    "Mobile vs web,<br/>2026?"
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Seats (avatars) */}
+            {slots.map((slot, i) => {
+              const p = roster[i];
+              if (!p) return null;
+              const active = p.id === speakingPerson.id && phase === 'speaking';
+              const thinking = p.id === speakingPerson.id && phase === 'thinking';
+              const c = hueBg(p.hue);
+              const avSize = nPeople <= 3 ? 74 : nPeople <= 5 ? 64 : nPeople <= 6 ? 58 : 50;
+              return (
+                <div key={p.id} style={{
+                  position: 'absolute',
+                  left: `${slot.x}%`, top: `${slot.y}%`,
+                  transform: 'translate(-50%, -50%)',
+                  textAlign: 'center',
+                  transition: 'all 350ms cubic-bezier(.2,.7,.3,1)',
+                  zIndex: active ? 10 : 5,
+                }}>
+                  <div style={{ position: 'relative', display: 'inline-block' }}>
+                    <div style={{ transform: active ? 'scale(1.08)' : 'scale(1)', transition: 'transform 400ms cubic-bezier(.2,.7,.3,1)' }}>
+                      <Av p={p} size={avSize} ring={active}/>
+                    </div>
+                    {active && (
+                      <>
+                        <div style={{ position: 'absolute', inset: -8, borderRadius: '50%', border: `1.5px solid ${c}`, animation: 'ring 1.8s ease-out infinite' }}/>
+                        <div style={{ position: 'absolute', inset: -18, borderRadius: '50%', border: `1px solid ${c}66`, animation: 'ring 1.8s ease-out infinite .4s' }}/>
+                      </>
+                    )}
+                    {thinking && (
+                      <div style={{ position: 'absolute', bottom: -4, right: -4, background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 999, padding: '2px 8px', fontFamily: T.fMono, fontSize: 9, color: T.mute, display: 'flex', gap: 3, alignItems: 'center' }}>
+                        <span style={{ display: 'inline-block', width: 3, height: 3, borderRadius: '50%', background: T.accent, animation: 'blink 1s infinite' }}/>
+                        <span style={{ display: 'inline-block', width: 3, height: 3, borderRadius: '50%', background: T.accent, animation: 'blink 1s infinite .2s' }}/>
+                        <span style={{ display: 'inline-block', width: 3, height: 3, borderRadius: '50%', background: T.accent, animation: 'blink 1s infinite .4s' }}/>
+                      </div>
+                    )}
+                  </div>
+                  <div style={{ fontSize: nPeople <= 4 ? 13 : 11, fontWeight: 500, marginTop: 8, opacity: active ? 1 : 0.85 }}>{p.name.split(' ')[0]}{p.name.split(' ')[1] ? ' ' + p.name.split(' ')[1][0] + '.' : ''}</div>
+                  {nPeople <= 5 && (
+                    <Mono size={9} color={active ? hueDeep(p.hue) : thinking ? T.accent : T.mute}>
+                      {active ? '● SPEAKING' : thinking ? '● THINKING' : 'IDLE'}
+                    </Mono>
+                  )}
+                </div>
+              );
+            })}
+
+            {/* Speech card — rendered only for the currently-speaking seat,
+                docked on the side opposite the table center. */}
+            {phase === 'speaking' && (() => {
+              const idx = current.speaker;
+              const slot = slots[idx];
+              if (!slot) return null;
+              return (
+                <div style={{ ...bubbleStyleFor(slot), zIndex: 40 }}>
+                  <SpeechCard
+                    person={roster[idx]}
+                    text={typed}
+                    anchor={slot.anchor}
+                    width={slot.bubbleW}
+                    active
+                  />
+                </div>
+              );
+            })()}
+
+            {/* Facilitator chip */}
+            <div style={{ position: 'absolute', top: 16, left: 16, display: 'flex', alignItems: 'center', gap: 10, padding: '8px 14px 8px 8px', background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 999, boxShadow: '0 2px 8px rgba(0,0,0,0.04)' }}>
+              <div style={{ width: 24, height: 24, borderRadius: '50%', background: `conic-gradient(from 180deg, ${T.accent}, ${T.cool}, ${T.accent})`, animation: 'spin 8s linear infinite' }}/>
+              <Mono size={10}>FACILITATOR · CLAUDE</Mono>
+            </div>
+
+            {/* Ralph draft score */}
+            <div style={{ position: 'absolute', bottom: 16, left: 16, background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 12, padding: '10px 14px', display: 'flex', alignItems: 'center', gap: 12 }}>
+              <div style={{ width: 32, height: 32, borderRadius: '50%', background: T.coolSoft, color: T.cool, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: T.fDisplay, fontSize: 15, fontWeight: 500 }}>
+                {ralphDraft}
+              </div>
+              <div>
+                <Mono size={9} color={T.mute}>RALPH · DRAFT</Mono>
+                <div style={{ fontSize: 11, color: T.mute, marginTop: 2 }}>target ≥ 7.0</div>
+              </div>
+            </div>
+          </div>
+
+          {/* Transcript rail */}
+          <div style={{ borderLeft: `1px solid ${T.hair}`, padding: 24, background: T.paper, overflow: 'auto', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+            <Eyebrow>TRANSCRIPT · LIVE</Eyebrow>
+            <div style={{ marginTop: 20, flex: 1, display: 'flex', flexDirection: 'column', gap: 18, overflow: 'auto' }}>
+              {phase === 'speaking' && (
+                <div style={{ display: 'flex', gap: 12, animation: 'fadeUp 300ms' }}>
+                  <Av p={speakingPerson} size={28}/>
+                  <div style={{ flex: 1 }}>
+                    <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+                      <div style={{ fontSize: 12, fontWeight: 500 }}>{speakingPerson.name.split(' ')[0]}</div>
+                      <Mono size={9} color={hueDeep(speakingPerson.hue)}>● LIVE</Mono>
+                    </div>
+                    <div style={{ fontFamily: T.fDisplay, fontWeight: 300, fontSize: 13, lineHeight: 1.5, letterSpacing: -0.1, marginTop: 4, color: T.ink }}>
+                      {typed}
+                      <span style={{ display: 'inline-block', width: 1.5, height: 12, background: hueBg(speakingPerson.hue), verticalAlign: 'middle', marginLeft: 2, animation: 'blink .9s infinite' }}/>
+                    </div>
+                  </div>
+                </div>
+              )}
+              {transcript.map((m, i) => {
+                const p = roster[m.speaker];
+                if (!p) return null;
+                const min = Math.floor(m.time / 60);
+                const sec = String(Math.floor(m.time) % 60).padStart(2, '0');
+                return (
+                  <div key={nonce + '-' + i} style={{ display: 'flex', gap: 12, opacity: 1 - Math.min(0.5, i * 0.08), animation: 'fadeUp 300ms' }}>
+                    <Av p={p} size={28}/>
+                    <div style={{ flex: 1 }}>
+                      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+                        <div style={{ fontSize: 12, fontWeight: 500 }}>{p.name.split(' ')[0]}</div>
+                        <Mono size={9}>{min}:{sec}</Mono>
+                      </div>
+                      <div style={{ fontFamily: T.fDisplay, fontWeight: 300, fontSize: 13, lineHeight: 1.5, letterSpacing: -0.1, marginTop: 4, color: T.inkSoft }}>
+                        {m.text}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+              {transcript.length === 0 && phase !== 'speaking' && (
+                <div style={{ fontSize: 12, color: T.mute, fontStyle: 'italic', padding: '20px 0' }}>
+                  Waiting for first turn…
+                </div>
+              )}
+            </div>
+            <div style={{ marginTop: 20, paddingTop: 18, borderTop: `1px solid ${T.hair}`, display: 'flex', justifyContent: 'space-between' }}>
+              <Mono size={10}>{transcript.length + (phase === 'speaking' ? 1 : 0)} TURNS · {Math.floor(elapsed * 120)} TOK</Mono>
+              <Mono size={10} color={T.cool}>RALPH {ralphDraft}</Mono>
+            </div>
+          </div>
+        </div>
+
+        <style>{`
+          @keyframes spin { from { transform: rotate(0); } to { transform: rotate(360deg); } }
+          @keyframes blink { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0; } }
+          @keyframes ring { 0% { transform: scale(1); opacity: .7; } 100% { transform: scale(1.4); opacity: 0; } }
+          @keyframes fadeUp { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+        `}</style>
+      </Browser>
+    );
+  }
+
+  window.HF_LiveAnimated = { LiveBAnimated };
+})();

--- a/web/hifi-live-animated.v1.jsx.bak
+++ b/web/hifi-live-animated.v1.jsx.bak
@@ -1,0 +1,314 @@
+// hifi-live-animated.jsx — animated Round Table simulation
+// Auto-cycles through speakers with typing, ring pulse, and transcript build-up.
+// Exposes window.HF_LiveAnimated = { LiveBAnimated }
+
+(function(){
+  const { tokens: T, PEOPLE: P, InitialsAv: Av, AppNav, Browser, Note, Kalam, Mono, Wave, Btn, Eyebrow, hueBg, hueSoft, hueDeep } = window.HF;
+  const { useState, useEffect, useRef } = React;
+
+  // Simulation script — 4 turns across 3 speakers.
+  // Each line: speaker index (into P), text, ms per char (speed)
+  const SCRIPT = [
+    { speaker: 2, text: '"Monoliths ship. Whatever the form. Start."', speed: 35 },
+    { speaker: 1, text: '"But distribution matters. The web compounds — an app store doesn\'t."', speed: 32 },
+    { speaker: 0, text: '"Most of what sounds sophisticated about mobile-first is just imitation. If two of you can\'t ship a web app in a weekend, two of you can\'t ship an iOS app in a month."', speed: 24 },
+    { speaker: 2, text: '"Fine. But ship the boring one. Don\'t pick based on what reads well on Twitter."', speed: 30 },
+    { speaker: 1, text: '"Leverage is the point. Web = broader surface. Easier to find the thing that works."', speed: 30 },
+    { speaker: 0, text: '"Build where friction is lowest, not where fashion is highest. Default to the web."', speed: 28 },
+  ];
+
+  const THINKING_MS = 1400;
+  const LINGER_MS = 900; // how long to hold after finishing a line
+
+  // Typed-text hook: types `text` at `speed` ms/char; calls onDone when complete
+  function useTyped(text, speed, enabled, onDone){
+    const [out, setOut] = useState('');
+    const doneRef = useRef(false);
+    useEffect(() => {
+      if (!enabled) { setOut(''); doneRef.current = false; return; }
+      setOut('');
+      doneRef.current = false;
+      let i = 0;
+      const tick = () => {
+        i += 1;
+        setOut(text.slice(0, i));
+        if (i >= text.length) {
+          if (!doneRef.current) { doneRef.current = true; onDone && onDone(); }
+          return;
+        }
+        t = setTimeout(tick, speed);
+      };
+      let t = setTimeout(tick, speed);
+      return () => clearTimeout(t);
+    }, [text, enabled]);
+    return out;
+  }
+
+  // Top bar with timer + controls
+  function LiveTopBar({ elapsed, turn, onRestart, paused, onTogglePause }){
+    const min = Math.floor(elapsed / 60);
+    const sec = String(Math.floor(elapsed) % 60).padStart(2, '0');
+    return (
+      <div style={{ padding: '16px 32px', borderBottom: `1px solid ${T.hair}`, display: 'flex', alignItems: 'center', gap: 20, background: T.paper }}>
+        <div>
+          <div style={{ fontSize: 15, fontWeight: 500, letterSpacing: -0.2 }}>Mobile vs web first in 2026</div>
+          <div style={{ fontFamily: T.fMono, fontSize: 10, color: T.mute, marginTop: 3, letterSpacing: 1 }}>
+            MEETING · ITER 1/3 · TURN {turn + 1}/{SCRIPT.length} · {min}:{sec}
+          </div>
+        </div>
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 10 }}>
+          <div onClick={onTogglePause} style={{ cursor: 'pointer', padding: '6px 14px', borderRadius: 999, fontSize: 12, color: T.mute, fontFamily: T.fMono, letterSpacing: 1 }}>
+            {paused ? '▶ RESUME' : '❚❚ PAUSE'}
+          </div>
+          <div onClick={onRestart} style={{ cursor: 'pointer', padding: '6px 14px', borderRadius: 999, fontSize: 12, fontFamily: T.fMono, letterSpacing: 1, color: T.mute }}>
+            ↻ REPLAY
+          </div>
+          <div style={{ padding: '8px 16px', borderRadius: 999, fontSize: 13, background: T.ink, color: '#fff', fontWeight: 500 }}>
+            End →
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  function LiveBAnimated(){
+    const [turnIdx, setTurnIdx] = useState(0);       // which SCRIPT line is playing
+    const [phase, setPhase] = useState('thinking');  // 'thinking' | 'speaking' | 'linger'
+    const [elapsed, setElapsed] = useState(0);
+    const [paused, setPaused] = useState(false);
+    const [transcript, setTranscript] = useState([]); // completed lines
+    const [nonce, setNonce] = useState(0);
+
+    // elapsed clock
+    useEffect(() => {
+      if (paused) return;
+      const id = setInterval(() => setElapsed(e => e + 0.1), 100);
+      return () => clearInterval(id);
+    }, [paused]);
+
+    // phase machine: thinking -> speaking -> linger -> next turn
+    useEffect(() => {
+      if (paused) return;
+      if (phase === 'thinking') {
+        const t = setTimeout(() => setPhase('speaking'), THINKING_MS);
+        return () => clearTimeout(t);
+      }
+      // speaking phase is ended by onDone from the typing hook (below)
+      // linger phase:
+      if (phase === 'linger') {
+        const t = setTimeout(() => {
+          // push to transcript, advance or loop
+          setTranscript(tr => [{ ...SCRIPT[turnIdx], time: elapsed }, ...tr]);
+          setTurnIdx(i => (i + 1) % SCRIPT.length);
+          setPhase('thinking');
+        }, LINGER_MS);
+        return () => clearTimeout(t);
+      }
+    }, [phase, paused, turnIdx]);
+
+    const current = SCRIPT[turnIdx];
+    const speakingPerson = P[current.speaker];
+
+    // Typing hook runs only during speaking phase
+    const typed = useTyped(
+      current.text,
+      current.speed,
+      phase === 'speaking' && !paused,
+      () => setPhase('linger')
+    );
+
+    // Seat config — 4 chairs, speakingPerson goes to the "front" seat that
+    // currently shows speaking. We keep seats stable by person id.
+    const seatPersons = [P[0], P[1], P[2], P[3]];
+    const seatPositions = [
+      { top: '8%',   left: '28%' },
+      { top: '8%',   right: '28%' },
+      { bottom: '6%', left: '28%' },
+      { bottom: '6%', right: '28%' },
+    ];
+
+    const handleRestart = () => {
+      setTurnIdx(0);
+      setPhase('thinking');
+      setElapsed(0);
+      setTranscript([]);
+      setNonce(n => n + 1);
+    };
+
+    // Ralph draft score trickles up over time
+    const ralphDraft = Math.min(7.8, 5.2 + (turnIdx * 0.35) + (phase === 'speaking' ? typed.length / current.text.length * 0.3 : 0.3)).toFixed(1);
+
+    return (
+      <Browser>
+        <AppNav active="sim"/>
+        <LiveTopBar
+          elapsed={elapsed}
+          turn={turnIdx}
+          onRestart={handleRestart}
+          paused={paused}
+          onTogglePause={() => setPaused(p => !p)}
+        />
+        <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 380px', minHeight: 0 }}>
+          {/* Stage */}
+          <div style={{ position: 'relative', padding: 40, background: `radial-gradient(ellipse 800px 500px at 50% 50%, ${T.paperSoft} 0%, ${T.paper} 70%)`, display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}>
+            {/* the table ellipse */}
+            <div style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', width: 420, height: 220, borderRadius: 220, border: `1.5px solid ${T.hair}`, background: '#fff', boxShadow: `0 24px 80px ${T.paperDeep}80` }}>
+              <div style={{ position: 'absolute', inset: 18, borderRadius: 200, border: `1px dashed ${T.hair}`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <div style={{ textAlign: 'center' }}>
+                  <Kalam size={13} color={T.mute}>the table</Kalam>
+                  <div style={{ fontFamily: T.fDisplay, fontStyle: 'italic', fontWeight: 300, fontSize: 19, letterSpacing: -0.4, marginTop: 2, lineHeight: 1.15 }}>
+                    "Mobile vs web,<br/>2026?"
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Seats */}
+            {seatPersons.map((p, i) => {
+              const active = p.id === speakingPerson.id && phase === 'speaking';
+              const thinking = p.id === speakingPerson.id && phase === 'thinking';
+              const pos = seatPositions[i];
+              const isTop = pos.top !== undefined;
+              const c = hueBg(p.hue);
+              return (
+                <div key={p.id} style={{
+                  position: 'absolute',
+                  ...pos,
+                  left: pos.left ?? undefined,
+                  right: pos.right ?? undefined,
+                  transform: pos.left ? 'translate(-50%, 0)' : pos.right ? 'translate(50%, 0)' : 'none',
+                  textAlign: 'center', width: 150,
+                  transition: 'all 350ms cubic-bezier(.2,.7,.3,1)',
+                }}>
+                  <div style={{ position: 'relative', display: 'inline-block', transition: 'transform 350ms' }}>
+                    <div style={{ transform: active ? 'scale(1.08)' : 'scale(1)', transition: 'transform 400ms cubic-bezier(.2,.7,.3,1)' }}>
+                      <Av p={p} size={active ? 78 : 62} ring={active}/>
+                    </div>
+                    {active && (
+                      <>
+                        <div style={{ position: 'absolute', inset: -10, borderRadius: '50%', border: `1.5px solid ${c}`, animation: 'ring 1.8s ease-out infinite' }}/>
+                        <div style={{ position: 'absolute', inset: -20, borderRadius: '50%', border: `1px solid ${c}66`, animation: 'ring 1.8s ease-out infinite .4s' }}/>
+                      </>
+                    )}
+                    {thinking && (
+                      <div style={{ position: 'absolute', bottom: -4, right: -4, background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 999, padding: '2px 8px', fontFamily: T.fMono, fontSize: 9, color: T.mute, display: 'flex', gap: 3, alignItems: 'center' }}>
+                        <span className="dot-pulse" style={{ display: 'inline-block', width: 3, height: 3, borderRadius: '50%', background: T.accent, animation: 'blink 1s infinite' }}/>
+                        <span className="dot-pulse" style={{ display: 'inline-block', width: 3, height: 3, borderRadius: '50%', background: T.accent, animation: 'blink 1s infinite .2s' }}/>
+                        <span className="dot-pulse" style={{ display: 'inline-block', width: 3, height: 3, borderRadius: '50%', background: T.accent, animation: 'blink 1s infinite .4s' }}/>
+                      </div>
+                    )}
+                  </div>
+                  <div style={{ fontSize: 13, fontWeight: 500, marginTop: 10 }}>{p.name}</div>
+                  <Mono size={9} color={active ? hueDeep(p.hue) : thinking ? T.accent : T.mute}>
+                    {active ? '● SPEAKING' : thinking ? '● THINKING' : 'IDLE'}
+                  </Mono>
+
+                  {/* Speech bubble — shows only on active seat, with typed text */}
+                  {active && (
+                    <div style={{
+                      marginTop: 12, padding: 14, background: '#fff', borderRadius: 12,
+                      border: `1.5px solid ${c}`,
+                      fontFamily: T.fDisplay, fontWeight: 300, fontSize: 13, lineHeight: 1.5,
+                      letterSpacing: -0.2, textAlign: 'left',
+                      boxShadow: `0 8px 24px ${c}22`,
+                      animation: 'fadeUp 300ms cubic-bezier(.2,.7,.3,1)',
+                      position: 'relative',
+                      // Attach a small tail toward the avatar
+                    }}>
+                      {/* Tail */}
+                      <div style={{
+                        position: 'absolute',
+                        top: -8, left: '50%', transform: 'translateX(-50%) rotate(45deg)',
+                        width: 14, height: 14, background: '#fff',
+                        borderLeft: `1.5px solid ${c}`, borderTop: `1.5px solid ${c}`,
+                      }}/>
+                      {typed}
+                      <span style={{ display: 'inline-block', width: 2, height: 13, background: c, verticalAlign: 'middle', marginLeft: 2, animation: 'blink .9s infinite' }}/>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+
+            {/* Facilitator chip */}
+            <div style={{ position: 'absolute', top: 24, left: 24, display: 'flex', alignItems: 'center', gap: 10, padding: '8px 14px 8px 8px', background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 999, boxShadow: '0 2px 8px rgba(0,0,0,0.04)' }}>
+              <div style={{ width: 24, height: 24, borderRadius: '50%', background: `conic-gradient(from 180deg, ${T.accent}, ${T.cool}, ${T.accent})`, animation: 'spin 8s linear infinite' }}/>
+              <Mono size={10}>FACILITATOR · CLAUDE</Mono>
+            </div>
+
+            {/* Ralph draft score — bottom left, trickles up */}
+            <div style={{ position: 'absolute', bottom: 24, left: 24, background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 12, padding: '10px 14px', display: 'flex', alignItems: 'center', gap: 12 }}>
+              <div style={{ width: 32, height: 32, borderRadius: '50%', background: T.coolSoft, color: T.cool, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: T.fDisplay, fontSize: 15, fontWeight: 500 }}>
+                {ralphDraft}
+              </div>
+              <div>
+                <Mono size={9} color={T.mute}>RALPH · DRAFT</Mono>
+                <div style={{ fontSize: 11, color: T.mute, marginTop: 2 }}>target ≥ 7.0</div>
+              </div>
+            </div>
+          </div>
+
+          {/* Transcript rail — live-updating */}
+          <div style={{ borderLeft: `1px solid ${T.hair}`, padding: 24, background: T.paper, overflow: 'auto', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+            <Eyebrow>TRANSCRIPT · LIVE</Eyebrow>
+            <div style={{ marginTop: 20, flex: 1, display: 'flex', flexDirection: 'column', gap: 18, overflow: 'auto' }}>
+              {/* Currently-speaking (in-progress) shown at the top */}
+              {phase === 'speaking' && (
+                <div style={{ display: 'flex', gap: 12, opacity: 1, animation: 'fadeUp 300ms' }}>
+                  <Av p={speakingPerson} size={28}/>
+                  <div style={{ flex: 1 }}>
+                    <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+                      <div style={{ fontSize: 12, fontWeight: 500 }}>{speakingPerson.name.split(' ')[0]}</div>
+                      <Mono size={9} color={hueDeep(speakingPerson.hue)}>● LIVE</Mono>
+                    </div>
+                    <div style={{ fontFamily: T.fDisplay, fontWeight: 300, fontSize: 13, lineHeight: 1.5, letterSpacing: -0.1, marginTop: 4, color: T.ink }}>
+                      {typed}
+                      <span style={{ display: 'inline-block', width: 1.5, height: 12, background: hueBg(speakingPerson.hue), verticalAlign: 'middle', marginLeft: 2, animation: 'blink .9s infinite' }}/>
+                    </div>
+                  </div>
+                </div>
+              )}
+              {transcript.map((m, i) => {
+                const p = P[m.speaker];
+                const min = Math.floor(m.time / 60);
+                const sec = String(Math.floor(m.time) % 60).padStart(2, '0');
+                return (
+                  <div key={nonce + '-' + i} style={{ display: 'flex', gap: 12, opacity: 1 - Math.min(0.5, i * 0.08), animation: 'fadeUp 300ms' }}>
+                    <Av p={p} size={28}/>
+                    <div style={{ flex: 1 }}>
+                      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+                        <div style={{ fontSize: 12, fontWeight: 500 }}>{p.name.split(' ')[0]}</div>
+                        <Mono size={9}>{min}:{sec}</Mono>
+                      </div>
+                      <div style={{ fontFamily: T.fDisplay, fontWeight: 300, fontSize: 13, lineHeight: 1.5, letterSpacing: -0.1, marginTop: 4, color: T.inkSoft }}>
+                        {m.text}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+              {transcript.length === 0 && phase !== 'speaking' && (
+                <div style={{ fontSize: 12, color: T.mute, fontStyle: 'italic', padding: '20px 0' }}>
+                  Waiting for first turn…
+                </div>
+              )}
+            </div>
+            <div style={{ marginTop: 20, paddingTop: 18, borderTop: `1px solid ${T.hair}`, display: 'flex', justifyContent: 'space-between' }}>
+              <Mono size={10}>{transcript.length + (phase === 'speaking' ? 1 : 0)} TURNS · {Math.floor(elapsed * 120)} TOK</Mono>
+              <Mono size={10} color={T.cool}>RALPH {ralphDraft}</Mono>
+            </div>
+          </div>
+        </div>
+
+        <style>{`
+          @keyframes spin { from { transform: rotate(0); } to { transform: rotate(360deg); } }
+          @keyframes blink { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0; } }
+          @keyframes ring { 0% { transform: scale(1); opacity: .7; } 100% { transform: scale(1.4); opacity: 0; } }
+          @keyframes fadeUp { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+        `}</style>
+      </Browser>
+    );
+  }
+
+  window.HF_LiveAnimated = { LiveBAnimated };
+})();

--- a/web/hifi-live.jsx
+++ b/web/hifi-live.jsx
@@ -1,0 +1,298 @@
+// hifi-live.jsx — The core experience: 3 takes on parallel-speaking avatars
+
+(function(){
+  const { tokens: T, PEOPLE: P, InitialsAv: PhotoAv, AppNav, Browser, Note, Kalam, Mono, Wave, Btn, Eyebrow, hueBg, hueSoft, hueDeep } = window.HF;
+
+  // Shared: top bar for live view
+  const LiveTopBar = ({ dark, elapsed = '00:04:12' }) => (
+    <div style={{
+      padding: '18px 32px', display: 'flex', alignItems: 'center', gap: 20,
+      borderBottom: `1px solid ${dark ? 'rgba(255,255,255,0.08)' : T.hair}`,
+      background: dark ? T.ink : T.paper, color: dark ? '#fff' : T.ink,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <div style={{ width: 8, height: 8, borderRadius: '50%', background: T.accent, boxShadow: `0 0 0 4px ${T.accent}33` }}/>
+        <Mono size={11} color={T.accent} style={{ letterSpacing: 2 }}>LIVE</Mono>
+      </div>
+      <div>
+        <div style={{ fontSize: 15, fontWeight: 500, letterSpacing: -0.2 }}>Mobile vs web first in 2026</div>
+        <div style={{ display: 'flex', gap: 14, marginTop: 2 }}>
+          <Mono size={10} color={dark ? 'rgba(255,255,255,0.5)' : T.mute}>MEETING</Mono>
+          <Mono size={10} color={dark ? 'rgba(255,255,255,0.5)' : T.mute}>ITER 1/3</Mono>
+          <Mono size={10} color={dark ? 'rgba(255,255,255,0.5)' : T.mute}>TURN 3/8</Mono>
+          <Mono size={10} color={dark ? 'rgba(255,255,255,0.5)' : T.mute}>{elapsed}</Mono>
+        </div>
+      </div>
+      <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+        <div style={{ padding: '8px 14px', borderRadius: 999, fontSize: 12, color: dark ? 'rgba(255,255,255,0.7)' : T.mute, border: `1px solid ${dark ? 'rgba(255,255,255,0.12)' : T.hair}` }}>Pause</div>
+        <div style={{ padding: '8px 14px', borderRadius: 999, fontSize: 12, color: dark ? '#fff' : T.ink, border: `1px solid ${dark ? 'rgba(255,255,255,0.2)' : T.ink}` }}>Interrupt</div>
+        <div style={{ padding: '8px 14px', borderRadius: 999, fontSize: 12, color: '#fff', background: T.accent }}>End</div>
+      </div>
+    </div>
+  );
+
+  // Pane: one avatar's live box
+  const LivePane = ({ p, state, text, round = 3, dark }) => {
+    const active = state === 'speaking';
+    const pending = state === 'thinking';
+    const c = hueBg(p.hue);
+    const deep = hueDeep(p.hue);
+
+    return (
+      <div style={{
+        position: 'relative', padding: 24, borderRadius: 16,
+        background: dark ? (active ? `linear-gradient(180deg, ${c}22 0%, rgba(255,255,255,0.02) 100%)` : 'rgba(255,255,255,0.03)') : (active ? '#fff' : T.paperSoft),
+        border: `1.5px solid ${active ? c : (dark ? 'rgba(255,255,255,0.08)' : T.hair)}`,
+        boxShadow: active ? `0 8px 40px ${c}22, 0 0 0 4px ${dark ? c + '18' : c + '18'}` : 'none',
+        display: 'flex', flexDirection: 'column', minHeight: 0, overflow: 'hidden',
+        transition: 'all .2s',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 16 }}>
+          <PhotoAv p={p} size={44} ring={active}/>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 14, fontWeight: 500, color: dark ? '#fff' : T.ink, letterSpacing: -0.2 }}>{p.name}</div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 3 }}>
+              <div style={{ width: 6, height: 6, borderRadius: '50%', background: active ? c : (pending ? T.accent : (dark ? 'rgba(255,255,255,0.3)' : T.mute)) }}/>
+              <Mono size={10} color={active ? deep : (dark ? 'rgba(255,255,255,0.5)' : T.mute)}>
+                {active ? 'SPEAKING' : pending ? 'THINKING' : 'IDLE'}
+              </Mono>
+            </div>
+          </div>
+          {active && <Wave color={c} height={22}/>}
+        </div>
+
+        <div style={{ flex: 1, fontSize: 15, lineHeight: 1.55, color: dark ? (active ? '#fff' : 'rgba(255,255,255,0.55)') : (active ? T.ink : T.mute), fontFamily: T.fDisplay, fontWeight: 300, letterSpacing: -0.2, minHeight: 0, overflow: 'hidden' }}>
+          {text}
+          {active && <span style={{ display: 'inline-block', width: 2, height: 16, background: c, verticalAlign: 'middle', marginLeft: 3 }}/>}
+        </div>
+
+        <div style={{ marginTop: 18, paddingTop: 14, borderTop: `1px solid ${dark ? 'rgba(255,255,255,0.06)' : T.hair}`, display: 'flex', gap: 14, alignItems: 'center' }}>
+          <Mono size={10} color={dark ? 'rgba(255,255,255,0.4)' : T.mute}>R{round}</Mono>
+          <div style={{ flex: 1, height: 2, background: dark ? 'rgba(255,255,255,0.06)' : T.hair, borderRadius: 1, overflow: 'hidden' }}>
+            {active && <div style={{ width: '34%', height: '100%', background: c }}/>}
+          </div>
+          <Mono size={10} color={dark ? 'rgba(255,255,255,0.4)' : T.mute}>{active ? '12s' : pending ? '—' : '1m 40s'}</Mono>
+        </div>
+      </div>
+    );
+  };
+
+  // A · PANEL GRID (tmux-like, dark, for developers)
+  function LiveA(){
+    return (
+      <Browser dark url="localhost:7777 · simulation/20260421T140412">
+        <AppNav active="sim" dark/>
+        <LiveTopBar dark/>
+        <div style={{ flex: 1, padding: 24, display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16, background: T.ink, minHeight: 0 }}>
+          <LivePane p={P[0]} state="speaking" dark
+            text={'"Most of what sounds sophisticated about mobile-first is just imitation. If two of you can\'t ship a web app in a weekend, two of you can\'t ship an iOS app in a month. Start where friction is lowest."'} />
+          <LivePane p={P[1]} state="thinking" dark
+            text={'(drafting — leverage angle, compounding returns of web distribution…)'} />
+          <LivePane p={P[2]} state="idle" dark
+            text={'"Monoliths ship. Whatever the form. Next."'} />
+        </div>
+
+        {/* Facilitator bar */}
+        <div style={{ padding: '14px 32px', background: '#0f0d0b', borderTop: `1px solid rgba(255,255,255,0.06)`, display: 'flex', alignItems: 'center', gap: 20, color: 'rgba(255,255,255,0.7)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <div style={{ width: 20, height: 20, borderRadius: 6, background: `conic-gradient(from 180deg, ${T.accent}, ${T.cool}, ${T.accent})` }}/>
+            <Mono size={11} color="#fff">FACILITATOR</Mono>
+          </div>
+          <div style={{ fontSize: 12 }}>calling on Naval next · OK to go long on the leverage angle</div>
+          <div style={{ marginLeft: 'auto', display: 'flex', gap: 18 }}>
+            <div><Mono size={10}>AVG LATENCY</Mono> <Mono size={11} color="#fff">7.2s</Mono></div>
+            <div><Mono size={10}>TOKENS</Mono> <Mono size={11} color="#fff">4.1k</Mono></div>
+            <div><Mono size={10}>MODEL</Mono> <Mono size={11} color="#fff">sonnet-4.5</Mono></div>
+          </div>
+        </div>
+        <Note top={18} right={40} rot={2} w={150} arrow>
+          closest to tmux.<br/>still legible on<br/>a laptop screen.
+        </Note>
+      </Browser>
+    );
+  }
+
+  // B · ROUND TABLE — spatial metaphor, spotlight moves to speaker
+  function LiveB(){
+    const order = [0, 1, 2, 3]; // 4 seats
+    const speakingIdx = 0;
+    return (
+      <Browser>
+        <AppNav active="sim"/>
+        <LiveTopBar/>
+        <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 380px', minHeight: 0 }}>
+          {/* Stage */}
+          <div style={{ position: 'relative', padding: 40, background: `radial-gradient(ellipse 800px 500px at 50% 50%, ${T.paperSoft} 0%, ${T.paper} 70%)`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            {/* the table ellipse */}
+            <div style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', width: 440, height: 240, borderRadius: 220, border: `1.5px solid ${T.hair}`, background: '#fff', boxShadow: `0 24px 80px ${T.paperDeep}80` }}>
+              <div style={{ position: 'absolute', inset: 20, borderRadius: 200, border: `1px dashed ${T.hair}`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <div style={{ textAlign: 'center' }}>
+                  <Kalam size={15} color={T.mute}>the table</Kalam>
+                  <div style={{ fontFamily: T.fDisplay, fontStyle: 'italic', fontWeight: 300, fontSize: 22, letterSpacing: -0.5, marginTop: 4 }}>
+                    "Mobile vs web <br/>first, 2026?"
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Seats */}
+            {[
+              { p: P[0], top: '10%', left: '35%', state: 'speaking' },
+              { p: P[1], top: '10%', right: '35%', state: 'thinking' },
+              { p: P[2], bottom: '10%', left: '35%', state: 'idle' },
+              { p: P[3], bottom: '10%', right: '35%', state: 'idle' },
+            ].map(({ p, state, ...pos }, i) => {
+              const active = state === 'speaking';
+              return (
+                <div key={i} style={{ position: 'absolute', ...pos, transform: 'translate(-50%, 0)', textAlign: 'center', width: 140 }}>
+                  <div style={{ position: 'relative', display: 'inline-block' }}>
+                    <PhotoAv p={p} size={active ? 88 : 68} ring={active}/>
+                    {active && (
+                      <>
+                        <div style={{ position: 'absolute', inset: -14, borderRadius: '50%', border: `1.5px solid ${hueBg(p.hue)}`, animation: 'ring 2s ease-out infinite' }}/>
+                        <div style={{ position: 'absolute', inset: -22, borderRadius: '50%', border: `1px solid ${hueBg(p.hue)}66` }}/>
+                      </>
+                    )}
+                  </div>
+                  <div style={{ fontSize: 13, fontWeight: 500, marginTop: 10 }}>{p.name}</div>
+                  <Mono size={9} color={active ? hueDeep(p.hue) : T.mute}>
+                    {active ? '● SPEAKING' : state.toUpperCase()}
+                  </Mono>
+                  {active && (
+                    <div style={{ marginTop: 10, padding: 12, background: '#fff', borderRadius: 12, border: `1.5px solid ${hueBg(p.hue)}`, fontFamily: T.fDisplay, fontWeight: 300, fontSize: 13, lineHeight: 1.5, letterSpacing: -0.2, textAlign: 'left' }}>
+                      "Ship where friction is lowest. If you can't put a web app on a laptop by Friday, you won't ship an iOS app in a month."
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+
+            {/* Facilitator chip */}
+            <div style={{ position: 'absolute', top: 24, left: 24, display: 'flex', alignItems: 'center', gap: 10, padding: '8px 14px 8px 8px', background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 999 }}>
+              <div style={{ width: 24, height: 24, borderRadius: '50%', background: `conic-gradient(from 180deg, ${T.accent}, ${T.cool}, ${T.accent})` }}/>
+              <Mono size={10}>FACILITATOR · claude</Mono>
+            </div>
+          </div>
+
+          {/* Transcript rail */}
+          <div style={{ borderLeft: `1px solid ${T.hair}`, padding: 24, background: T.paper, overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
+            <Eyebrow>TRANSCRIPT · LIVE</Eyebrow>
+            <div style={{ marginTop: 20, flex: 1, display: 'flex', flexDirection: 'column', gap: 18 }}>
+              {[
+                { p: P[2], t: '"Monoliths ship. Whatever the form. Start."', time: '04:08' },
+                { p: P[1], t: '"But distribution matters. The web compounds — an app store doesn\'t."', time: '04:02' },
+                { p: P[0], t: '"Build where friction is lowest. Mobile-first is often just imitation."', time: '03:48', active: true },
+              ].map((m, i) => (
+                <div key={i} style={{ display: 'flex', gap: 12, opacity: m.active ? 1 : 0.55 }}>
+                  <PhotoAv p={m.p} size={28}/>
+                  <div style={{ flex: 1 }}>
+                    <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+                      <div style={{ fontSize: 12, fontWeight: 500 }}>{m.p.name.split(' ')[0]}</div>
+                      <Mono size={9}>{m.time}</Mono>
+                    </div>
+                    <div style={{ fontFamily: T.fDisplay, fontWeight: 300, fontSize: 14, lineHeight: 1.5, letterSpacing: -0.1, marginTop: 4 }}>{m.t}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div style={{ marginTop: 20, paddingTop: 18, borderTop: `1px solid ${T.hair}`, display: 'flex', justifyContent: 'space-between' }}>
+              <Mono size={10}>3 TURNS · 4.1K TOK</Mono>
+              <Mono size={10} color={T.cool}>RALPH DRAFT 6.8</Mono>
+            </div>
+          </div>
+        </div>
+        <Note top={90} right={410} rot={-3} w={140} arrow>
+          spatial metaphor.<br/>you feel who's<br/>talking to whom.
+        </Note>
+      </Browser>
+    );
+  }
+
+  // C · CARDS + TRANSCRIPT RIVER — everyone visible, transcript scrolls below
+  function LiveC(){
+    const pane = P.slice(0,3);
+    return (
+      <Browser>
+        <AppNav active="sim"/>
+        <LiveTopBar/>
+        <div style={{ flex: 1, padding: '24px 32px', display: 'flex', flexDirection: 'column', gap: 20, minHeight: 0, overflow: 'hidden', background: T.paper }}>
+          {/* Top: horizontal cast strip with live states */}
+          <div style={{ display: 'grid', gridTemplateColumns: `repeat(${pane.length}, 1fr)`, gap: 16 }}>
+            {[
+              { p: P[0], state: 'speaking' },
+              { p: P[1], state: 'thinking' },
+              { p: P[2], state: 'idle' },
+            ].map(({ p, state }, i) => {
+              const active = state === 'speaking';
+              const pending = state === 'thinking';
+              const c = hueBg(p.hue);
+              return (
+                <div key={i} style={{
+                  padding: 20, background: '#fff', borderRadius: 16,
+                  border: `1.5px solid ${active ? c : T.hair}`,
+                  boxShadow: active ? `0 0 0 4px ${c}20` : 'none',
+                  display: 'flex', alignItems: 'center', gap: 16,
+                }}>
+                  <PhotoAv p={p} size={56} ring={active}/>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 14, fontWeight: 500 }}>{p.name}</div>
+                    <div style={{ fontSize: 12, color: T.mute, marginTop: 1 }}>{p.role}</div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 6 }}>
+                      <div style={{ width: 6, height: 6, borderRadius: '50%', background: active ? c : (pending ? T.accent : T.mute) }}/>
+                      <Mono size={9} color={active ? hueDeep(p.hue) : T.mute}>
+                        {active ? 'SPEAKING · 0:12' : pending ? 'DRAFTING REPLY' : 'HAS SPOKEN'}
+                      </Mono>
+                    </div>
+                  </div>
+                  {active && <Wave color={c} height={26} bars={11}/>}
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Transcript river */}
+          <div style={{ flex: 1, background: '#fff', borderRadius: 16, border: `1px solid ${T.hair}`, padding: '28px 36px', overflow: 'auto', minHeight: 0 }}>
+            <Eyebrow>TRANSCRIPT</Eyebrow>
+            <div style={{ marginTop: 20, display: 'flex', flexDirection: 'column', gap: 22 }}>
+              {[
+                { p: P[2], time: '00:03:48', t: 'Monoliths ship. Mobile vs web, whatever — pick the one you can ship by Friday. The conversation is always which one is "the future" but the actual question is which one you can put in a user\'s hands in a week.' },
+                { p: P[1], time: '00:04:02', t: 'Distribution compounds. An App Store listing is a cold start; a web URL you can put in a tweet tomorrow. Early on, you want the shortest path between an idea and a first hundred users.' },
+                { p: P[0], time: '00:04:12', active: true, t: 'Most of what sounds sophisticated about mobile-first is just imitation. If two of you can\'t ship a web app in a weekend, two of you can\'t ship an iOS app in a month. Start where friction is lowest, not where fashion is highest.' },
+              ].map((m, i) => {
+                const c = hueBg(m.p.hue);
+                return (
+                  <div key={i} style={{ display: 'flex', gap: 18, opacity: m.active ? 1 : 0.72 }}>
+                    <div style={{ width: 80, flexShrink: 0 }}>
+                      <PhotoAv p={m.p} size={40} ring={m.active}/>
+                      <div style={{ fontSize: 12, fontWeight: 500, marginTop: 8 }}>{m.p.name.split(' ')[0]}</div>
+                      <Mono size={9}>{m.time}</Mono>
+                    </div>
+                    <div style={{ flex: 1, borderLeft: `2px solid ${m.active ? c : T.hair}`, paddingLeft: 20, fontFamily: T.fDisplay, fontWeight: 300, fontSize: 18, lineHeight: 1.55, letterSpacing: -0.3, color: m.active ? T.ink : T.inkSoft }}>
+                      "{m.t}"
+                      {m.active && <span style={{ display: 'inline-block', width: 2, height: 18, background: c, verticalAlign: 'middle', marginLeft: 4 }}/>}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Facilitator */}
+          <div style={{ padding: '14px 20px', background: T.paperSoft, borderRadius: 12, display: 'flex', alignItems: 'center', gap: 16 }}>
+            <div style={{ width: 22, height: 22, borderRadius: 6, background: `conic-gradient(from 180deg, ${T.accent}, ${T.cool}, ${T.accent})` }}/>
+            <div style={{ fontSize: 13 }}>Facilitator <span style={{ color: T.mute }}>· next: Naval · probe leverage</span></div>
+            <div style={{ marginLeft: 'auto', display: 'flex', gap: 12 }}>
+              <Mono size={10}>TURN 3 / 8</Mono>
+              <Mono size={10} color={T.cool}>RALPH DRAFT 6.8</Mono>
+            </div>
+          </div>
+        </div>
+        <Note top={120} right={28} rot={3} w={150}>
+          readable,<br/>quotable.<br/>feels editorial.
+        </Note>
+      </Browser>
+    );
+  }
+
+  window.HF_Live = { LiveA, LiveB, LiveC };
+})();

--- a/web/hifi-results.jsx
+++ b/web/hifi-results.jsx
@@ -1,0 +1,301 @@
+// hifi-results.jsx — 3 takes on simulation results, with playful Ralph score viz
+
+(function(){
+  const { tokens: T, PEOPLE: P, InitialsAv: PhotoAv, AppNav, Browser, Note, Kalam, Mono, RalphRing, Btn, Eyebrow, hueBg, hueSoft, hueDeep } = window.HF;
+
+  // Ralph trajectory — shows iteration-over-iteration improvement
+  const RalphTrajectory = ({ scores = [5.2, 6.4, 8.1], target = 7, width = 420, height = 140 }) => {
+    const pad = 20;
+    const w = width - pad * 2;
+    const h = height - pad * 2;
+    const points = scores.map((s, i) => ({
+      x: pad + (i / Math.max(scores.length - 1, 1)) * w,
+      y: pad + (1 - s / 10) * h,
+      s,
+    }));
+    const targetY = pad + (1 - target / 10) * h;
+    return (
+      <svg width={width} height={height} style={{ display: 'block' }}>
+        {/* grid */}
+        {[0, 2.5, 5, 7.5, 10].map(v => {
+          const y = pad + (1 - v / 10) * h;
+          return <line key={v} x1={pad} y1={y} x2={pad + w} y2={y} stroke={T.hair} strokeWidth="1"/>;
+        })}
+        {/* target line */}
+        <line x1={pad} y1={targetY} x2={pad + w} y2={targetY} stroke={T.accent} strokeWidth="1.5" strokeDasharray="4 3"/>
+        <text x={pad + w - 4} y={targetY - 4} textAnchor="end" fontSize="10" fontFamily={T.fMono} fill={T.accent}>TARGET {target}</text>
+        {/* path */}
+        <path d={`M ${points.map(p => `${p.x} ${p.y}`).join(' L ')}`} fill="none" stroke={T.ink} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+        {/* dots */}
+        {points.map((p, i) => (
+          <g key={i}>
+            <circle cx={p.x} cy={p.y} r={p.s >= target ? 8 : 6} fill={p.s >= target ? T.cool : T.ink}/>
+            <circle cx={p.x} cy={p.y} r={p.s >= target ? 8 : 6} fill="none" stroke="#fff" strokeWidth="2"/>
+            <text x={p.x} y={p.y + 24} textAnchor="middle" fontSize="11" fontFamily={T.fMono} fill={T.mute}>iter {i+1}</text>
+            <text x={p.x} y={p.y - 10} textAnchor="middle" fontSize="13" fontWeight="500" fontFamily={T.fSans} fill={T.ink}>{p.s.toFixed(1)}</text>
+          </g>
+        ))}
+      </svg>
+    );
+  };
+
+  // Per-criterion bars
+  const CriteriaBars = ({ data }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      {data.map((d, i) => {
+        const passed = d.score >= d.target;
+        const c = passed ? T.cool : T.accent;
+        return (
+          <div key={i} style={{ display: 'grid', gridTemplateColumns: '140px 1fr 44px', gap: 12, alignItems: 'center' }}>
+            <div style={{ fontSize: 12, color: T.inkSoft }}>{d.label}</div>
+            <div style={{ height: 6, background: T.paperSoft, borderRadius: 3, position: 'relative' }}>
+              <div style={{ position: 'absolute', left: 0, top: 0, height: '100%', width: `${d.score * 10}%`, background: c, borderRadius: 3 }}/>
+              <div style={{ position: 'absolute', left: `${d.target * 10}%`, top: -3, height: 12, width: 1.5, background: T.ink }}/>
+            </div>
+            <Mono size={11} color={c} style={{ textAlign: 'right', fontWeight: 500 }}>{d.score.toFixed(1)}</Mono>
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  // A · SCORECARD HERO — celebrate the result
+  function ResultsA(){
+    const criteria = [
+      { label: 'Clarity',          score: 8.4, target: 7 },
+      { label: 'Disagreement',     score: 8.9, target: 7 },
+      { label: 'Evidence cited',   score: 7.6, target: 7 },
+      { label: 'Resolution',       score: 7.2, target: 7 },
+      { label: 'Voice fidelity',   score: 8.8, target: 7 },
+    ];
+    return (
+      <Browser url="localhost:7777/sim/20260421T1404.../results">
+        <AppNav active="results"/>
+        <div style={{ flex: 1, overflow: 'auto', padding: '48px 80px' }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 16, marginBottom: 6 }}>
+            <Mono color={T.mute}>← simulation · 20260421T1404</Mono>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 220px', gap: 48, alignItems: 'flex-end', marginBottom: 40 }}>
+            <div>
+              <Eyebrow color={T.cool}>● RALPH PASSED · ITER 3 OF 3</Eyebrow>
+              <div style={{ fontFamily: T.fDisplay, fontWeight: 400, fontSize: 56, letterSpacing: -1.8, lineHeight: 1.05, marginTop: 14 }}>
+                Mobile vs web first<br/>
+                <span style={{ fontStyle: 'italic', fontWeight: 300 }}>in 2026?</span>
+              </div>
+              <div style={{ fontSize: 15, color: T.mute, marginTop: 14, maxWidth: 560, lineHeight: 1.5 }}>
+                Three rounds. One conclusion: start with the web because distribution compounds and friction is lowest — unless your specific user's touchpoint is mobile-only.
+              </div>
+            </div>
+            <RalphRing score={8.1} target={7} size={180}/>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1.4fr 1fr', gap: 24, marginBottom: 40 }}>
+            {/* Trajectory */}
+            <div style={{ padding: 28, background: '#fff', borderRadius: 18, border: `1px solid ${T.hair}` }}>
+              <Eyebrow>SCORE OVER ITERATIONS</Eyebrow>
+              <div style={{ marginTop: 14 }}>
+                <RalphTrajectory scores={[5.2, 6.4, 8.1]} target={7} width={460} height={170}/>
+              </div>
+              <div style={{ marginTop: 12, fontSize: 13, color: T.mute, lineHeight: 1.5 }}>
+                <Kalam size={14} color={T.accent}>jumped after dhh stopped hedging →</Kalam>
+              </div>
+            </div>
+
+            {/* Criteria bars */}
+            <div style={{ padding: 28, background: '#fff', borderRadius: 18, border: `1px solid ${T.hair}` }}>
+              <Eyebrow>CRITERIA</Eyebrow>
+              <div style={{ marginTop: 18 }}>
+                <CriteriaBars data={criteria}/>
+              </div>
+            </div>
+          </div>
+
+          {/* Participants + downloads */}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 300px', gap: 24 }}>
+            <div style={{ padding: 28, background: T.paperSoft, borderRadius: 18 }}>
+              <Eyebrow>WHO SPOKE</Eyebrow>
+              <div style={{ marginTop: 18, display: 'flex', gap: 24 }}>
+                {P.slice(0,3).map((p, i) => {
+                  const pct = [38, 34, 28][i];
+                  return (
+                    <div key={p.id} style={{ flex: 1 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
+                        <PhotoAv p={p} size={36}/>
+                        <div>
+                          <div style={{ fontSize: 13, fontWeight: 500 }}>{p.name.split(' ')[0]}</div>
+                          <Mono size={10}>{pct}% · {[12,10,9][i]} turns</Mono>
+                        </div>
+                      </div>
+                      <div style={{ height: 4, background: T.hair, borderRadius: 2 }}>
+                        <div style={{ width: `${pct * 1.5}%`, height: '100%', background: hueBg(p.hue), borderRadius: 2 }}/>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div style={{ padding: 28, background: T.ink, color: '#fff', borderRadius: 18 }}>
+              <Eyebrow color="rgba(255,255,255,0.5)">DOWNLOAD</Eyebrow>
+              <div style={{ marginTop: 14, display: 'flex', flexDirection: 'column', gap: 10 }}>
+                {[['transcript.md','22 KB'],['results.docx','184 KB'],['summary.pptx','1.2 MB']].map(([f,s],i) => (
+                  <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 14px', background: 'rgba(255,255,255,0.06)', borderRadius: 10 }}>
+                    <div style={{ fontSize: 14 }}>↓</div>
+                    <div style={{ fontFamily: T.fMono, fontSize: 12, flex: 1 }}>{f}</div>
+                    <Mono size={10} color="rgba(255,255,255,0.5)">{s}</Mono>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+        <Note top={80} right={40} rot={3} w={140}>
+          score ring →<br/>celebratory, like<br/>closing rings.
+        </Note>
+      </Browser>
+    );
+  }
+
+  // B · TRANSCRIPT-FIRST — the words matter most
+  function ResultsB(){
+    return (
+      <Browser>
+        <AppNav active="results"/>
+        <div style={{ flex: 1, overflow: 'auto', padding: '60px 120px', maxWidth: 960, margin: '0 auto', width: '100%' }}>
+          <Mono color={T.mute}>← results · 20260421T1404</Mono>
+
+          <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginTop: 20, marginBottom: 32, gap: 40 }}>
+            <div style={{ flex: 1 }}>
+              <Eyebrow color={T.cool}>RALPH 8.1 · PASSED IN 3</Eyebrow>
+              <div style={{ fontFamily: T.fDisplay, fontWeight: 400, fontSize: 44, letterSpacing: -1.4, lineHeight: 1.1, marginTop: 10 }}>
+                Mobile vs web first <span style={{ fontStyle: 'italic', fontWeight: 300 }}>in 2026?</span>
+              </div>
+            </div>
+            <RalphRing score={8.1} target={7} size={110}/>
+          </div>
+
+          {/* KEY TAKEAWAY */}
+          <div style={{ padding: '28px 32px', background: T.accentSoft, borderRadius: 16, marginBottom: 40 }}>
+            <Eyebrow>THE ROOM AGREED</Eyebrow>
+            <div style={{ fontFamily: T.fDisplay, fontStyle: 'italic', fontWeight: 300, fontSize: 24, lineHeight: 1.4, letterSpacing: -0.4, marginTop: 10 }}>
+              "Web first, unless the user's only touchpoint is mobile. Distribution compounds faster than app-store installs; ship by Friday, not by quarter-end."
+            </div>
+          </div>
+
+          {/* Transcript */}
+          <Eyebrow>TRANSCRIPT · ITER 3</Eyebrow>
+          <div style={{ marginTop: 20, display: 'flex', flexDirection: 'column', gap: 32 }}>
+            {[
+              { p: P[0], time: '00:04:12', t: 'Most of what sounds sophisticated about mobile-first is just imitation. If two of you can\'t ship a web app in a weekend, two of you can\'t ship an iOS app in a month.', hl: true },
+              { p: P[1], time: '00:04:39', t: 'Distribution compounds. A web URL is a tweet you send tomorrow; an App Store listing is a cold start you earn over months. Leverage sits where friction is lowest.' },
+              { p: P[2], time: '00:05:08', t: 'Monoliths ship. So do web apps. Put it in someone\'s hands this week. Whatever argument you\'re having about "the future of the form factor" is an argument you\'re not having with a user.' },
+              { p: P[0], time: '00:05:42', t: 'The only case for mobile-first is if your user only exists on mobile — drivers, field workers, kids on parents\' hand-me-downs. Otherwise: web, Friday, go.', hl: true },
+            ].map((m, i) => {
+              const c = hueBg(m.p.hue);
+              return (
+                <div key={i} style={{ display: 'flex', gap: 24 }}>
+                  <div style={{ width: 110, flexShrink: 0, textAlign: 'right' }}>
+                    <div style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'center' }}>
+                      <PhotoAv p={m.p} size={42}/>
+                      <div style={{ fontSize: 12, fontWeight: 500, marginTop: 8 }}>{m.p.name.split(' ')[0]}</div>
+                      <Mono size={9}>{m.time}</Mono>
+                    </div>
+                  </div>
+                  <div style={{ flex: 1, paddingLeft: 20, borderLeft: `2px solid ${m.hl ? c : T.hair}`, fontFamily: T.fDisplay, fontWeight: 300, fontSize: 19, lineHeight: 1.55, letterSpacing: -0.3 }}>
+                    {m.hl && <span style={{ background: hueSoft(m.p.hue), padding: '0 4px', borderRadius: 3 }}>"{m.t}"</span>}
+                    {!m.hl && <>"{m.t}"</>}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <div style={{ marginTop: 56, padding: '20px 24px', background: T.paperSoft, borderRadius: 14, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Mono color={T.mute}>22 KB · 847 words · 3 iters</Mono>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <Btn size="sm">↓ .md</Btn>
+              <Btn size="sm">↓ .docx</Btn>
+              <Btn size="sm" primary>↓ .pptx</Btn>
+            </div>
+          </div>
+        </div>
+        <Note top={80} right={40} rot={-3} w={130}>
+          reads like a<br/>New Yorker profile<br/>of the argument.
+        </Note>
+      </Browser>
+    );
+  }
+
+  // C · ITERATIONS TIMELINE — all 3 iterations side-by-side, showing the climb
+  function ResultsC(){
+    const iters = [
+      { n: 1, score: 5.2, note: 'Everyone hedged. PG quoted himself. Naval spoke in koans. DHH was polite.', key: 'too agreeable' },
+      { n: 2, score: 6.4, note: 'Facilitator pushed. Real disagreement surfaced around distribution.', key: 'distribution fight' },
+      { n: 3, score: 8.1, note: 'DHH stopped hedging. PG narrowed the claim. Conclusion emerged.', key: 'passed', passed: true },
+    ];
+    return (
+      <Browser>
+        <AppNav active="results"/>
+        <div style={{ flex: 1, overflow: 'auto', padding: '48px 72px' }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 16, marginBottom: 8 }}>
+            <Mono color={T.mute}>← 20260421T1404</Mono>
+          </div>
+          <div style={{ fontFamily: T.fDisplay, fontWeight: 400, fontSize: 44, letterSpacing: -1.3, lineHeight: 1.05, marginBottom: 10 }}>
+            The climb to <span style={{ fontStyle: 'italic', fontWeight: 300 }}>clarity.</span>
+          </div>
+          <div style={{ fontSize: 15, color: T.mute, marginBottom: 40, maxWidth: 560 }}>
+            Three iterations of the same meeting. Watch the score rise as the room stops hedging.
+          </div>
+
+          {/* Big trajectory */}
+          <div style={{ padding: 32, background: '#fff', borderRadius: 20, border: `1px solid ${T.hair}`, marginBottom: 24 }}>
+            <RalphTrajectory scores={[5.2, 6.4, 8.1]} target={7} width={880} height={200}/>
+          </div>
+
+          {/* Three iteration cards */}
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16 }}>
+            {iters.map(it => {
+              const c = it.passed ? T.cool : (it.score >= 6 ? T.accent : T.mute);
+              return (
+                <div key={it.n} style={{
+                  padding: 24, borderRadius: 16,
+                  background: it.passed ? '#fff' : T.paperSoft,
+                  border: `1.5px solid ${it.passed ? T.cool : T.hair}`,
+                  position: 'relative',
+                }}>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
+                    <Eyebrow color={c}>ITERATION {it.n}</Eyebrow>
+                    {it.passed && <Mono size={10} color={T.cool} style={{ padding: '3px 8px', background: T.coolSoft, borderRadius: 4 }}>● PASSED</Mono>}
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'baseline', gap: 6, marginBottom: 14 }}>
+                    <div style={{ fontFamily: T.fDisplay, fontSize: 48, fontWeight: 400, letterSpacing: -1.5, color: c, lineHeight: 1 }}>{it.score.toFixed(1)}</div>
+                    <Mono color={T.mute}>/ 10</Mono>
+                  </div>
+                  <div style={{ fontSize: 13, lineHeight: 1.5, color: T.inkSoft, marginBottom: 16 }}>
+                    {it.note}
+                  </div>
+                  <Kalam size={14} color={T.accent}>→ {it.key}</Kalam>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Footer actions */}
+          <div style={{ marginTop: 32, display: 'flex', gap: 12, alignItems: 'center' }}>
+            <Btn primary size="md">Open transcript →</Btn>
+            <Btn size="md">Run again</Btn>
+            <Btn size="md">Tune criteria</Btn>
+            <div style={{ marginLeft: 'auto' }}>
+              <Mono>3 DOWNLOADS · md · docx · pptx</Mono>
+            </div>
+          </div>
+        </div>
+        <Note top={40} right={30} rot={2} w={150} arrow>
+          the "climb" is<br/>the story. frame<br/>it that way.
+        </Note>
+      </Browser>
+    );
+  }
+
+  window.HF_Results = { ResultsA, ResultsB, ResultsC };
+})();

--- a/web/hifi-v2-screens.jsx
+++ b/web/hifi-v2-screens.jsx
@@ -1,0 +1,262 @@
+// hifi-v2-screens.jsx — missing screens (Detail · Create · Setup · Settings)
+// Also re-wraps approved screens so every PhotoAv becomes InitialsAv via HF.Av.
+
+(function(){
+  const { tokens: T, PEOPLE: P, InitialsAv: Av, AppNav, Browser, Note, Kalam, Mono, Display, Btn, Eyebrow, hueBg, hueSoft, hueDeep, RalphRing, Wave } = window.HF;
+
+  // ── Avatar Detail ────────────────────────────────────────────
+  function DetailScreen({ onNav }){
+    const p = P[0];
+    return (
+      <Browser>
+        <AppNav active="library"/>
+        <div style={{ flex: 1, overflow: 'auto', padding: '40px 72px' }}>
+          <div onClick={() => onNav && onNav('library')} style={{ cursor: 'pointer', display: 'inline-block' }}>
+            <Mono color={T.mute}>← Library</Mono>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: '340px 1fr', gap: 60, marginTop: 28 }}>
+            <div>
+              <Av p={p} size={140}/>
+              <Eyebrow style={{ marginTop: 24 }}>AVATAR · PUBLIC</Eyebrow>
+              <div style={{ fontFamily: T.fDisplay, fontSize: 40, letterSpacing: -1.3, fontWeight: 400, lineHeight: 1.05, marginTop: 10 }}>
+                {p.name}
+              </div>
+              <div style={{ fontSize: 14, color: T.mute, marginTop: 6 }}>{p.role} · b. {p.born}</div>
+              <div style={{ marginTop: 24, fontFamily: T.fMono, fontSize: 11, color: T.mute, lineHeight: 1.8 }}>
+                mode · public<br/>
+                corpus · {p.corpus} tokens<br/>
+                created · 2026-04-19<br/>
+                last edit · v7 (2h ago)
+              </div>
+              <div style={{ marginTop: 24, display: 'flex', flexDirection: 'column', gap: 10 }}>
+                <Btn accent size="md" style={{ justifyContent: 'center' }} >Start simulation →</Btn>
+                <Btn size="md" style={{ justifyContent: 'center' }}>Edit persona</Btn>
+              </div>
+            </div>
+
+            <div>
+              <div style={{ display: 'flex', gap: 28, borderBottom: `1px solid ${T.hair}`, marginBottom: 28 }}>
+                {['Voice','Experiences','Positions','Corpus','Raw files'].map((t,i) => (
+                  <div key={t} style={{ padding: '14px 0', fontSize: 13, fontWeight: i === 0 ? 500 : 400, color: i === 0 ? T.ink : T.mute, borderBottom: i === 0 ? `2px solid ${T.accent}` : 'none', marginBottom: -1 }}>{t}</div>
+                ))}
+              </div>
+
+              <Eyebrow>SIGNATURE PHRASINGS</Eyebrow>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 14, marginBottom: 36 }}>
+                {['make something people want','default alive or default dead','ramen profitable','schlep blindness','the wave of the future','this is going to sound counterintuitive'].map(t => (
+                  <div key={t} style={{ fontSize: 13, padding: '8px 14px', borderRadius: 999, background: '#fff', border: `1px solid ${T.hair}`, fontFamily: T.fDisplay, fontWeight: 300 }}>"{t}"</div>
+                ))}
+              </div>
+
+              <Eyebrow>RHETORICAL FRAME</Eyebrow>
+              <div style={{ fontFamily: T.fDisplay, fontWeight: 300, fontSize: 20, lineHeight: 1.55, letterSpacing: -0.2, marginTop: 14, marginBottom: 36, color: T.inkSoft }}>
+                Plain-spoken. Starts small, lands a surprising claim, backs it with a concrete founder he watched. Avoids jargon; treats "monetize" as tell.
+              </div>
+
+              <Eyebrow>WHAT HE AVOIDS</Eyebrow>
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 14 }}>
+                {['jargon','decks','"monetize"','frameworks in caps','acronyms'].map(t => (
+                  <div key={t} style={{ fontSize: 12, padding: '5px 12px', border: `1px dashed ${T.hair}`, borderRadius: 4, color: T.mute, fontFamily: T.fMono }}>{t}</div>
+                ))}
+              </div>
+
+              <div style={{ marginTop: 48, padding: '20px 24px', background: T.paperSoft, borderRadius: 14, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                <div style={{ fontSize: 13 }}>In <b>4 simulations</b> · avg Ralph 7.6</div>
+                <Btn size="sm">History →</Btn>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Browser>
+    );
+  }
+
+  // ── Create Avatar ────────────────────────────────────────────
+  function CreateScreen({ onNav }){
+    return (
+      <Browser>
+        <AppNav active="create"/>
+        <div style={{ flex: 1, overflow: 'auto', padding: '60px 120px', display: 'flex', justifyContent: 'center' }}>
+          <div style={{ width: '100%', maxWidth: 880 }}>
+            <Eyebrow>NEW AVATAR</Eyebrow>
+            <div style={{ fontFamily: T.fDisplay, fontSize: 52, letterSpacing: -1.8, fontWeight: 400, lineHeight: 1.05, marginTop: 14, marginBottom: 12 }}>
+              Who do you want <span style={{ fontStyle: 'italic', fontWeight: 300 }}>to simulate?</span>
+            </div>
+            <div style={{ fontSize: 16, color: T.mute, marginBottom: 40, maxWidth: 560, lineHeight: 1.5 }}>
+              Choose a starting point. You can always mix both later.
+            </div>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>
+              <div style={{ padding: 32, background: '#fff', border: `1.5px solid ${T.ink}`, borderRadius: 18, position: 'relative' }}>
+                <div style={{ position: 'absolute', top: 20, right: 20, width: 10, height: 10, borderRadius: '50%', background: T.accent }}/>
+                <Mono size={10} color={T.accent} style={{ letterSpacing: 2 }}>MODE · PRIVATE</Mono>
+                <div style={{ fontFamily: T.fDisplay, fontSize: 28, letterSpacing: -0.8, fontWeight: 400, marginTop: 14, marginBottom: 12 }}>
+                  Your files.
+                </div>
+                <div style={{ fontSize: 14, color: T.inkSoft, lineHeight: 1.55, marginBottom: 22 }}>
+                  Upload PDFs, audio, transcripts, URLs. Stays local. Best for colleagues, interviewers, yourself.
+                </div>
+                <div style={{ padding: 16, borderRadius: 10, background: T.paperSoft, fontFamily: T.fMono, fontSize: 11, color: T.mute, lineHeight: 1.8, marginBottom: 20 }}>
+                  PDF · DOCX · TXT · MP3 · WAV<br/>urls.txt · youtube_urls.txt
+                </div>
+                <Btn accent size="md" style={{ justifyContent: 'center', width: '100%' }}>Upload files →</Btn>
+              </div>
+              <div style={{ padding: 32, background: T.paperSoft, border: `1px solid ${T.hair}`, borderRadius: 18 }}>
+                <Mono size={10} style={{ letterSpacing: 2 }}>MODE · CELEBRITY</Mono>
+                <div style={{ fontFamily: T.fDisplay, fontSize: 28, letterSpacing: -0.8, fontWeight: 400, marginTop: 14, marginBottom: 12 }}>
+                  Just a name.
+                </div>
+                <div style={{ fontSize: 14, color: T.inkSoft, lineHeight: 1.55, marginBottom: 22 }}>
+                  We harvest public material. Best for public figures — founders, authors, directors.
+                </div>
+                <div style={{ padding: '12px 14px', borderRadius: 10, background: '#fff', border: `1px solid ${T.hair}`, fontFamily: T.fMono, fontSize: 12, color: T.mute, marginBottom: 20 }}>
+                  e.g. "Bong Joon-ho · Korean film director"
+                </div>
+                <Btn size="md" style={{ justifyContent: 'center', width: '100%' }}>Search & build →</Btn>
+              </div>
+            </div>
+
+            <div style={{ marginTop: 32, padding: '14px 18px', border: `1px solid ${T.hair}`, borderRadius: 12, display: 'flex', gap: 12, alignItems: 'flex-start', fontSize: 13, color: T.mute, lineHeight: 1.5 }}>
+              <span style={{ color: T.accent, fontSize: 16 }}>⚠</span>
+              <div>Celebrity avatars never impersonate. You'll review and approve the generated profile before it can be used.</div>
+            </div>
+
+            <Note top={40} right={-60} rot={-2} w={150}>upload experience<br/>is the new<br/>iTunes CD-rip.</Note>
+          </div>
+        </div>
+      </Browser>
+    );
+  }
+
+  // ── Simulation Setup ────────────────────────────────────────
+  function SetupScreen({ onNav }){
+    return (
+      <Browser>
+        <AppNav active="sim"/>
+        <div style={{ flex: 1, overflow: 'auto', padding: '48px 80px' }}>
+          <Eyebrow>NEW SIMULATION</Eyebrow>
+          <div style={{ fontFamily: T.fDisplay, fontSize: 48, letterSpacing: -1.6, fontWeight: 400, lineHeight: 1.05, marginTop: 12, marginBottom: 40 }}>
+            Seat the <span style={{ fontStyle: 'italic', fontWeight: 300 }}>room.</span>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 340px', gap: 48 }}>
+            <div>
+              <Eyebrow style={{ color: T.mute }}>TOPIC</Eyebrow>
+              <div style={{ padding: 22, border: `1.5px solid ${T.ink}`, borderRadius: 14, fontFamily: T.fDisplay, fontSize: 22, fontWeight: 300, letterSpacing: -0.4, lineHeight: 1.3, marginTop: 10 }}>
+                Should a two-person team build mobile or web first in 2026?
+              </div>
+              <div style={{ fontSize: 12, color: T.mute, marginTop: 8, marginBottom: 32 }}>A clear question produces a better simulation.</div>
+
+              <Eyebrow style={{ color: T.mute }}>PARTICIPANTS · 3</Eyebrow>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, marginTop: 14, marginBottom: 32 }}>
+                {P.slice(0,3).map(p => (
+                  <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 14px 6px 6px', background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 999 }}>
+                    <Av p={p} size={28}/>
+                    <div style={{ fontSize: 13, fontWeight: 500 }}>{p.name}</div>
+                    <span style={{ color: T.mute, fontSize: 16, cursor: 'pointer' }}>×</span>
+                  </div>
+                ))}
+                <div style={{ padding: '10px 16px', border: `1.5px dashed ${T.hair}`, borderRadius: 999, fontSize: 13, color: T.mute }}>+ Add</div>
+              </div>
+
+              <Eyebrow style={{ color: T.mute }}>FORMAT</Eyebrow>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10, marginTop: 14, marginBottom: 32 }}>
+                <div style={{ padding: 18, border: `1.5px solid ${T.ink}`, borderRadius: 12, background: '#fff', position: 'relative' }}>
+                  <div style={{ position: 'absolute', top: 14, right: 14, width: 16, height: 16, borderRadius: '50%', border: `2px solid ${T.ink}`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}><div style={{ width: 8, height: 8, borderRadius: '50%', background: T.ink }}/></div>
+                  <div style={{ fontSize: 15, fontWeight: 500 }}>Meeting</div>
+                  <div style={{ fontSize: 12, color: T.mute, marginTop: 4 }}>Facilitator leads. Agenda-driven.</div>
+                </div>
+                <div style={{ padding: 18, border: `1px solid ${T.hair}`, borderRadius: 12, position: 'relative' }}>
+                  <div style={{ position: 'absolute', top: 14, right: 14, width: 16, height: 16, borderRadius: '50%', border: `2px solid ${T.hair}` }}/>
+                  <div style={{ fontSize: 15, fontWeight: 500 }}>Debate</div>
+                  <div style={{ fontSize: 12, color: T.mute, marginTop: 4 }}>Round-robin. Everyone weighs in.</div>
+                </div>
+              </div>
+
+              <Eyebrow style={{ color: T.mute }}>RALPH LOOP</Eyebrow>
+              <div style={{ marginTop: 14, padding: 18, background: T.paperSoft, borderRadius: 12, display: 'flex', alignItems: 'center', gap: 16 }}>
+                <div style={{ width: 40, height: 22, borderRadius: 999, background: T.ink, position: 'relative' }}>
+                  <div style={{ position: 'absolute', right: 2, top: 2, width: 18, height: 18, borderRadius: '50%', background: '#fff' }}/>
+                </div>
+                <div style={{ fontSize: 14 }}>Retry until <b>Ralph ≥ 7</b>, max <b>3</b> iterations</div>
+                <Mono style={{ marginLeft: 'auto' }}>edit criteria</Mono>
+              </div>
+            </div>
+
+            <div>
+              <div style={{ position: 'sticky', top: 0, padding: 24, background: T.ink, color: '#fff', borderRadius: 18 }}>
+                <Eyebrow color="rgba(255,255,255,0.5)">SUMMARY</Eyebrow>
+                <div style={{ fontFamily: T.fDisplay, fontWeight: 300, fontSize: 20, letterSpacing: -0.3, lineHeight: 1.4, marginTop: 14, marginBottom: 22 }}>
+                  A meeting with 3 people about mobile vs web in 2026. Up to 3 rounds.
+                </div>
+                <div style={{ display: 'flex', marginBottom: 20 }}>
+                  {P.slice(0,3).map((p,i) => (
+                    <div key={p.id} style={{ marginLeft: i === 0 ? 0 : -10 }}>
+                      <Av p={p} size={36} ring/>
+                    </div>
+                  ))}
+                </div>
+                <div onClick={() => onNav && onNav('live')} style={{ cursor: 'pointer', padding: '14px 20px', borderRadius: 999, background: '#fff', color: T.ink, fontSize: 14, fontWeight: 500, textAlign: 'center' }}>
+                  Start simulation →
+                </div>
+                <div style={{ fontFamily: T.fMono, fontSize: 10, color: 'rgba(255,255,255,0.4)', textAlign: 'center', marginTop: 10 }}>⌘↵</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Browser>
+    );
+  }
+
+  // ── Settings ────────────────────────────────────────────────
+  function SettingsScreen(){
+    return (
+      <Browser>
+        <AppNav/>
+        <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '240px 1fr', overflow: 'hidden' }}>
+          <div style={{ borderRight: `1px solid ${T.hair}`, padding: '32px 20px' }}>
+            <Eyebrow>SETTINGS</Eyebrow>
+            <div style={{ marginTop: 20 }}>
+              {['Model','Library location','Transcripts','Appearance','Keyboard','About'].map((s, i) => (
+                <div key={s} style={{ padding: '10px 12px', fontSize: 13, borderRadius: 8, background: i === 0 ? T.paperSoft : 'transparent', fontWeight: i === 0 ? 500 : 400, marginBottom: 2, color: i === 0 ? T.ink : T.inkSoft }}>{s}</div>
+              ))}
+            </div>
+          </div>
+
+          <div style={{ overflow: 'auto', padding: '48px 64px', maxWidth: 720 }}>
+            <div style={{ fontFamily: T.fDisplay, fontSize: 36, letterSpacing: -1, fontWeight: 400, marginBottom: 8 }}>Model</div>
+            <div style={{ fontSize: 14, color: T.mute, marginBottom: 32 }}>Which Claude powers your avatars.</div>
+
+            {[
+              ['claude-sonnet-4.5','Default · balanced · fast','selected'],
+              ['claude-opus-4.1','Slower · deepest reasoning',''],
+              ['claude-haiku-4.5','Fastest · draft mode',''],
+            ].map(([n, s, sel], i) => (
+              <div key={i} style={{ padding: 20, border: sel ? `1.5px solid ${T.ink}` : `1px solid ${T.hair}`, borderRadius: 14, marginBottom: 10, display: 'flex', alignItems: 'center', gap: 16, background: sel ? '#fff' : 'transparent' }}>
+                <div style={{ width: 18, height: 18, borderRadius: '50%', border: `2px solid ${sel ? T.ink : T.hair}`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  {sel && <div style={{ width: 8, height: 8, borderRadius: '50%', background: T.ink }}/>}
+                </div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontFamily: T.fMono, fontSize: 13 }}>{n}</div>
+                  <div style={{ fontSize: 12, color: T.mute, marginTop: 2 }}>{s}</div>
+                </div>
+              </div>
+            ))}
+
+            <div style={{ marginTop: 48, fontFamily: T.fDisplay, fontSize: 22, letterSpacing: -0.5, fontWeight: 400, marginBottom: 16 }}>Library location</div>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+              {[['Local','~/persona-studio/data','selected'],['Global','~/.claude/personas','']].map(([t,p,sel]) => (
+                <div key={t} style={{ padding: 18, border: sel ? `1.5px solid ${T.ink}` : `1px solid ${T.hair}`, borderRadius: 12, background: sel ? '#fff' : 'transparent' }}>
+                  <div style={{ fontSize: 14, fontWeight: 500 }}>{t}</div>
+                  <Mono size={11} style={{ marginTop: 4, display: 'block' }}>{p}</Mono>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </Browser>
+    );
+  }
+
+  window.HF_V2 = { DetailScreen, CreateScreen, SetupScreen, SettingsScreen };
+})();

--- a/web/hifi-v2.html
+++ b/web/hifi-v2.html
@@ -1,0 +1,189 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8"/>
+<title>Persona Studio — Hi-Fi v2 · Prototype</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,500;1,9..144,300;1,9..144,400&family=Kalam:wght@300;400;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+<style>
+  html, body { margin: 0; padding: 0; background: #fbfaf7; font-family: 'Inter', -apple-system, system-ui, sans-serif; -webkit-font-smoothing: antialiased; min-height: 100vh; }
+  * { box-sizing: border-box; }
+  @keyframes blink { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0; } }
+  @keyframes ring { 0% { transform: scale(1); opacity: .8; } 100% { transform: scale(1.3); opacity: 0; } }
+  @keyframes fadeUp { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+  .screen { animation: fadeUp .35s cubic-bezier(.2,.7,.3,1); }
+  .navpill { transition: all .15s; }
+  .navpill:hover { transform: translateY(-1px); }
+</style>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+</head>
+<body>
+<div id="root"></div>
+
+<script type="text/babel" src="hifi-atoms.jsx"></script>
+<script type="text/babel" src="hifi-home.jsx"></script>
+<script type="text/babel" src="hifi-library.jsx"></script>
+<script type="text/babel" src="hifi-live.jsx"></script>
+<script type="text/babel" src="hifi-results.jsx"></script>
+<script type="text/babel" src="hifi-v2-screens.jsx"></script>
+<script type="text/babel" src="hifi-live-animated.jsx"></script>
+<script type="text/babel" src="hifi-auth-screens.jsx"></script>
+
+<script type="text/babel">
+  const { useState, useEffect } = React;
+  const T = window.HF.tokens;
+
+  // Wrap the imported screens so clicks on their AppNav/CTAs can navigate.
+  // Since the variation files don't accept callbacks, we overlay click
+  // targets on known zones via a transparent overlay router.
+  // OSS-first prototype: auth is deferred. Sign-in/up/onboard screens are
+  // kept in the source (hifi-auth-screens.jsx) for later but removed from the
+  // main flow. Pricing/Upgrade are relabelled as "Cloud · Coming soon" so
+  // there's a seat for a future managed offering.
+  const SCREENS = [
+    { id: 'home',     label: 'Home',              render: (nav) => <window.HF_Home.HomeA/> },
+    { id: 'library',  label: 'Library',           render: (nav) => <window.HF_Library.LibraryA/> },
+    { id: 'detail',   label: 'Avatar',            render: (nav) => <window.HF_V2.DetailScreen onNav={nav}/> },
+    { id: 'create',   label: 'New avatar',        render: (nav) => <window.HF_V2.CreateScreen onNav={nav}/> },
+    { id: 'setup',    label: 'Setup',             render: (nav) => <window.HF_V2.SetupScreen onNav={nav}/> },
+    { id: 'live',     label: 'Live',              render: (nav) => <window.HF_LiveAnimated.LiveBAnimated/> },
+    { id: 'results',  label: 'Results',           render: (nav) => <window.HF_Results.ResultsA/> },
+    { id: 'settings', label: 'Settings',          render: (nav) => <window.HF_Auth.SettingsScreen onNav={nav}/> },
+    { id: 'pricing',  label: 'Cloud · soon',      render: (nav) => <window.HF_Auth.PricingScreen onNav={nav}/> },
+  ];
+
+  function App(){
+    const [cur, setCur] = useState(() => {
+      try {
+        const saved = localStorage.getItem('ps_screen');
+        // Auth screens are no longer in the flow — fall back to home.
+        if (!saved || ['signin','signup','onboard','upgrade'].includes(saved)) return 'home';
+        return saved;
+      } catch { return 'home'; }
+    });
+    const nav = (id) => { setCur(id); try { localStorage.setItem('ps_screen', id); } catch {} };
+
+    useEffect(() => {
+      const onKey = (e) => {
+        if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+        const i = SCREENS.findIndex(s => s.id === cur);
+        if (e.key === 'ArrowRight') nav(SCREENS[Math.min(i+1, SCREENS.length-1)].id);
+        if (e.key === 'ArrowLeft')  nav(SCREENS[Math.max(i-1, 0)].id);
+      };
+      window.addEventListener('keydown', onKey);
+      return () => window.removeEventListener('keydown', onKey);
+    }, [cur]);
+
+    const screen = SCREENS.find(s => s.id === cur) || SCREENS[0];
+
+    // Primary-CTA hotspot table: in each screen, where's the "next" click?
+    const HOTSPOTS = {
+      home:   [
+        { top: 380, left: 120, w: 240, h: 60, to: 'setup',  title: 'Start a simulation →' },
+        { top: 380, left: 380, w: 200, h: 60, to: 'create', title: 'Build an avatar' },
+      ],
+      library: [
+        { top: 0, left: 0, w: '100%', h: 56, to: '__nav', title: 'Top nav' }, // handled by nav bar below
+        { top: 160, right: 80, w: 140, h: 40, to: 'create', title: '+ New avatar' },
+        { top: 240, left: 72, w: 240, h: 340, to: 'detail', title: 'Open Paul Graham' },
+      ],
+      detail:  [
+        { top: 500, left: 72, w: 300, h: 50, to: 'setup', title: 'Start simulation →' },
+      ],
+      create:  [
+        { top: 540, left: 120, w: 380, h: 60, to: 'library', title: 'Upload files →' },
+      ],
+      setup:   [],  // handled by onNav prop already
+      live:    [
+        { bottom: 24, right: 32, w: 90, h: 40, to: 'results', title: 'End → results' },
+      ],
+      results: [
+        { top: 0, left: 0, w: 120, h: 56, to: 'home', title: '← Home' },
+      ],
+      settings: [],
+    };
+
+    return (
+      <div style={{ minHeight: '100vh', background: '#f0eee9', padding: '20px 20px 100px' }}>
+        {/* Prototype chrome */}
+        <div style={{ maxWidth: 1400, margin: '0 auto 20px', display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap' }}>
+          <div style={{ fontFamily: T.fDisplay, fontSize: 22, letterSpacing: -0.5, fontWeight: 500 }}>Persona Studio</div>
+          <div style={{ fontFamily: T.fMono, fontSize: 10, color: T.accent, letterSpacing: 2, padding: '3px 8px', background: T.accentSoft, borderRadius: 4 }}>HI-FI v2 · CLICKABLE</div>
+          <div style={{ fontFamily: T.fMono, fontSize: 10, color: T.cool, letterSpacing: 2, padding: '3px 8px', background: T.coolSoft, borderRadius: 4 }}>OSS · ELv2</div>
+          <div style={{ fontFamily: T.fMono, fontSize: 10, color: T.mute, letterSpacing: 1.5, padding: '3px 10px', background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 999, display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            <span style={{ width: 6, height: 6, borderRadius: '50%', background: T.green, display: 'inline-block' }}/>
+            GUEST MODE · LOCAL ONLY
+          </div>
+          <div style={{ flex: 1 }}/>
+          <div style={{ fontFamily: T.fMono, fontSize: 10, color: T.ink, letterSpacing: 1, padding: '5px 12px', background: '#fff', border: `1px solid ${T.hair}`, borderRadius: 999, display: 'inline-flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+            <span>★</span> Star on GitHub <span style={{ color: T.mute }}>· 2.4k</span>
+          </div>
+          <div style={{ fontFamily: T.fMono, fontSize: 10, color: T.mute, letterSpacing: 1 }}>← →</div>
+        </div>
+
+        {/* Nav pills */}
+        <div style={{ maxWidth: 1400, margin: '0 auto 20px', display: 'flex', gap: 6, flexWrap: 'wrap', padding: 8, background: '#fff', borderRadius: 999, border: `1px solid ${T.hair}`, boxShadow: '0 1px 3px rgba(0,0,0,0.04)' }}>
+          {SCREENS.map((s, i) => (
+            <div key={s.id} className="navpill" onClick={() => nav(s.id)} style={{
+              padding: '8px 16px', borderRadius: 999, fontSize: 13, cursor: 'pointer',
+              background: cur === s.id ? T.ink : 'transparent',
+              color: cur === s.id ? '#fff' : T.inkSoft,
+              fontWeight: cur === s.id ? 500 : 400,
+              fontFamily: T.fSans, letterSpacing: -0.1,
+              display: 'flex', alignItems: 'center', gap: 8,
+            }}>
+              <span style={{ fontFamily: T.fMono, fontSize: 10, opacity: 0.5 }}>{String(i).padStart(2,'0')}</span>
+              {s.label}
+            </div>
+          ))}
+          <div style={{ flex: 1 }}/>
+          <div style={{ padding: '8px 14px', fontFamily: T.fMono, fontSize: 11, color: T.mute }}>{cur}</div>
+        </div>
+
+        {/* Frame */}
+        <div style={{ maxWidth: 1400, margin: '0 auto', background: '#fff', borderRadius: 18, overflow: 'hidden', boxShadow: '0 20px 60px rgba(0,0,0,0.08), 0 2px 6px rgba(0,0,0,0.04)', height: 860, position: 'relative' }}>
+          <div className="screen" key={cur} style={{ height: '100%', position: 'relative' }}>
+            {screen.render(nav)}
+            {/* Hotspot overlays */}
+            {(HOTSPOTS[cur] || []).filter(h => h.to !== '__nav').map((h, i) => (
+              <div key={i} onClick={() => nav(h.to)} title={h.title} style={{
+                position: 'absolute', top: h.top, left: h.left, right: h.right, bottom: h.bottom,
+                width: h.w, height: h.h, cursor: 'pointer', zIndex: 20,
+                borderRadius: 12,
+              }}/>
+            ))}
+          </div>
+        </div>
+
+        {/* Flow map footer */}
+        <div style={{ maxWidth: 1400, margin: '24px auto 0', padding: 20, background: '#fff', borderRadius: 14, border: `1px solid ${T.hair}` }}>
+          <div style={{ fontFamily: T.fMono, fontSize: 10, color: T.accent, letterSpacing: 2, marginBottom: 10 }}>HAPPY PATH</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', fontFamily: T.fSans, fontSize: 13 }}>
+            {['home','setup','live','results'].map((s, i, a) => (
+              <React.Fragment key={s}>
+                <div onClick={() => nav(s)} style={{
+                  padding: '8px 14px', borderRadius: 999, cursor: 'pointer',
+                  background: cur === s ? T.accent : T.paperSoft,
+                  color: cur === s ? '#fff' : T.ink,
+                  fontWeight: cur === s ? 500 : 400,
+                }}>{SCREENS.find(x => x.id === s).label}</div>
+                {i < a.length - 1 && <div style={{ color: T.mute }}>→</div>}
+              </React.Fragment>
+            ))}
+            <div style={{ color: T.mute, marginLeft: 16, fontSize: 12 }}>· use ← → to navigate any screen</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  ReactDOM.createRoot(document.getElementById('root')).render(<App/>);
+</script>
+</body>
+</html>

--- a/web/hifi.html
+++ b/web/hifi.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8"/>
+<title>Persona Studio — Hi-Fi</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,500;1,9..144,300;1,9..144,400&family=Kalam:wght@300;400;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+<style>
+  html, body { margin: 0; padding: 0; background: #f0eee9; font-family: 'Inter', -apple-system, system-ui, sans-serif; -webkit-font-smoothing: antialiased; }
+  * { box-sizing: border-box; }
+  @keyframes blink { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0; } }
+  @keyframes ring { 0% { transform: scale(1); opacity: .8; } 100% { transform: scale(1.3); opacity: 0; } }
+</style>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+</head>
+<body>
+<div id="root"></div>
+
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="hifi-atoms.jsx"></script>
+<script type="text/babel" src="hifi-avatars.jsx"></script>
+<script type="text/babel" src="hifi-home.jsx"></script>
+<script type="text/babel" src="hifi-library.jsx"></script>
+<script type="text/babel" src="hifi-live.jsx"></script>
+<script type="text/babel" src="hifi-results.jsx"></script>
+
+<script type="text/babel">
+  const { DesignCanvas, DCSection, DCArtboard } = window;
+  const { HomeA, HomeB, HomeC } = window.HF_Home;
+  const { LibraryA, LibraryB } = window.HF_Library;
+  const { LiveA, LiveB, LiveC } = window.HF_Live;
+  const { ResultsA, ResultsB, ResultsC } = window.HF_Results;
+  const { AvatarExplorations } = window.HF_Avatars;
+
+  function Intro() {
+    const T = window.HF.tokens;
+    return (
+      <div style={{ padding: 40, background: T.paper, height: '100%', fontFamily: T.fSans, color: T.ink, overflow: 'hidden' }}>
+        <div style={{ fontFamily: T.fMono, fontSize: 11, color: T.accent, letterSpacing: 2, textTransform: 'uppercase' }}>HI-FI · V1</div>
+        <div style={{ fontFamily: T.fDisplay, fontWeight: 400, fontSize: 44, letterSpacing: -1.4, lineHeight: 1.05, marginTop: 14, marginBottom: 18 }}>
+          From wireframes to <span style={{ fontStyle: 'italic', fontWeight: 300 }}>skin.</span>
+        </div>
+        <div style={{ fontSize: 14, color: T.mute, lineHeight: 1.55, maxWidth: 520, marginBottom: 28 }}>
+          Apple-ish restraint. Warm paper, one terracotta accent, a cool teal for Ralph "passed" moments. Display type in Fraunces italic for soft punctuation; Inter for the rest; Kalam kept for margin notes.
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 14 }}>
+          {[
+            { c: T.paper, l: 'paper' },
+            { c: T.ink, l: 'ink' },
+            { c: T.accent, l: 'accent' },
+            { c: T.cool, l: 'ralph ✓' },
+          ].map(s => (
+            <div key={s.l}>
+              <div style={{ height: 56, borderRadius: 10, background: s.c, border: `1px solid ${T.hair}` }}/>
+              <div style={{ fontFamily: T.fMono, fontSize: 10, color: T.mute, marginTop: 6 }}>{s.l}</div>
+            </div>
+          ))}
+        </div>
+        <div style={{ marginTop: 24, fontFamily: T.fHand, fontSize: 14, color: T.accent, transform: 'rotate(-1deg)', display: 'inline-block' }}>
+          drag cards · click labels · focus any artboard
+        </div>
+      </div>
+    );
+  }
+
+  function App() {
+    return (
+      <DesignCanvas>
+        <DCSection id="system" title="0 · System" subtitle="Palette, type, avatar treatments — the language the rest is built from.">
+          <DCArtboard id="intro" label="Language" width={640} height={420}><Intro/></DCArtboard>
+          <DCArtboard id="avatars" label="Avatar treatment · 3 directions" width={1200} height={660}><AvatarExplorations/></DCArtboard>
+        </DCSection>
+
+        <DCSection id="home" title="1 · Home" subtitle="First screen. Apple-ish 3 ways.">
+          <DCArtboard id="a" label="A · Quiet hero (apple.com)" width={1200} height={780}><HomeA/></DCArtboard>
+          <DCArtboard id="b" label="B · Room of faces (warm)" width={1200} height={780}><HomeB/></DCArtboard>
+          <DCArtboard id="c" label="C · Dark command (⌘K)" width={1200} height={780}><HomeC/></DCArtboard>
+        </DCSection>
+
+        <DCSection id="library" title="2 · Library" subtitle="The cast as product surface.">
+          <DCArtboard id="a" label="A · Editorial portrait grid" width={1200} height={780}><LibraryA/></DCArtboard>
+          <DCArtboard id="b" label="B · Museum row" width={1200} height={780}><LibraryB/></DCArtboard>
+        </DCSection>
+
+        <DCSection id="live" title="3 · Live Simulation" subtitle="The core new experience — avatars speaking in parallel.">
+          <DCArtboard id="a" label="A · Panel grid (dark · tmux-native)" width={1400} height={880}><LiveA/></DCArtboard>
+          <DCArtboard id="b" label="B · Round table (spatial)" width={1400} height={880}><LiveB/></DCArtboard>
+          <DCArtboard id="c" label="C · Transcript river (editorial)" width={1400} height={880}><LiveC/></DCArtboard>
+        </DCSection>
+
+        <DCSection id="results" title="4 · Results" subtitle="Ralph score tells the story of the climb.">
+          <DCArtboard id="a" label="A · Scorecard hero" width={1200} height={900}><ResultsA/></DCArtboard>
+          <DCArtboard id="b" label="B · Transcript-first" width={1200} height={900}><ResultsB/></DCArtboard>
+          <DCArtboard id="c" label="C · Iterations timeline" width={1200} height={820}><ResultsC/></DCArtboard>
+        </DCSection>
+      </DesignCanvas>
+    );
+  }
+
+  ReactDOM.createRoot(document.getElementById('root')).render(<App/>);
+</script>
+</body>
+</html>

--- a/web/landing.html
+++ b/web/landing.html
@@ -1,0 +1,503 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>Persona Studio — open-source AI roundtables</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,500;1,9..144,300;1,9..144,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+<style>
+  :root {
+    --paper: #fbfaf7;
+    --paper-soft: #f4f2ed;
+    --paper-deep: #eae6dd;
+    --ink: #1a1714;
+    --ink-soft: #3a342d;
+    --mute: #8a857b;
+    --hair: #e8e3d9;
+    --accent: #c96442;
+    --accent-soft: #f6e6dd;
+    --cool: #2f6b6b;
+    --cool-soft: #dbe9e7;
+    --green: #4a7c4e;
+    --f-sans: 'Inter', -apple-system, system-ui, sans-serif;
+    --f-display: 'Fraunces', 'New York', Georgia, serif;
+    --f-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--paper); color: var(--ink); font-family: var(--f-sans); -webkit-font-smoothing: antialiased; }
+  a { color: inherit; text-decoration: none; }
+  .mono { font-family: var(--f-mono); letter-spacing: 0.3px; }
+  .serif { font-family: var(--f-display); }
+  .eyebrow { font-family: var(--f-mono); font-size: 11px; letter-spacing: 2px; text-transform: uppercase; color: var(--accent); }
+  .container { max-width: 1280px; margin: 0 auto; padding: 0 48px; }
+
+  /* Nav */
+  .nav { position: sticky; top: 0; z-index: 50; background: rgba(251,250,247,0.85); backdrop-filter: blur(12px); border-bottom: 1px solid var(--hair); }
+  .nav-inner { display: flex; align-items: center; gap: 36px; padding: 14px 48px; max-width: 1280px; margin: 0 auto; }
+  .logo { display: flex; align-items: center; gap: 10px; font-weight: 600; font-size: 14px; letter-spacing: -0.2px; }
+  .logo-mark { width: 22px; height: 22px; border-radius: 6px; background: conic-gradient(from 180deg, var(--accent), var(--cool), var(--accent)); }
+  .nav-links { display: flex; gap: 26px; font-size: 13px; color: var(--ink-soft); }
+  .nav-links a:hover { color: var(--ink); }
+  .nav-right { margin-left: auto; display: flex; align-items: center; gap: 14px; font-size: 13px; }
+  .nav-star { display: flex; align-items: center; gap: 6px; padding: 6px 12px; border: 1px solid var(--hair); border-radius: 999px; background: #fff; font-size: 12px; }
+  .nav-star .count { color: var(--mute); font-family: var(--f-mono); font-size: 11px; }
+  .btn { display: inline-flex; align-items: center; gap: 8px; padding: 9px 18px; border-radius: 999px; font-size: 13px; font-weight: 500; cursor: pointer; border: 1px solid transparent; transition: all .15s; }
+  .btn-primary { background: var(--ink); color: #fff; }
+  .btn-primary:hover { background: #000; }
+  .btn-ghost { border-color: var(--ink); color: var(--ink); }
+
+  /* Hero */
+  .hero { padding: 80px 0 96px; position: relative; overflow: hidden; }
+  .hero::before { content: ''; position: absolute; inset: 0; background: radial-gradient(ellipse 900px 500px at 80% 0%, var(--accent-soft) 0%, transparent 55%), radial-gradient(ellipse 700px 400px at 10% 100%, var(--cool-soft) 0%, transparent 55%); pointer-events: none; }
+  .hero-inner { position: relative; }
+  .hero-badges { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 24px; }
+  .badge { display: inline-flex; align-items: center; gap: 6px; padding: 5px 12px; border-radius: 999px; border: 1px solid var(--hair); background: #fff; font-family: var(--f-mono); font-size: 11px; color: var(--ink-soft); letter-spacing: 0.5px; }
+  .badge .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--green); }
+  .hero h1 { font-family: var(--f-sans); font-weight: 500; font-size: clamp(48px, 7vw, 96px); letter-spacing: -3.5px; line-height: 1.0; margin: 0 0 24px; max-width: 900px; text-wrap: balance; }
+  .hero h1 em { font-family: var(--f-display); font-style: italic; font-weight: 300; letter-spacing: -2px; }
+  .hero-sub { font-size: 20px; color: var(--mute); line-height: 1.5; max-width: 580px; margin: 0 0 36px; letter-spacing: -0.2px; }
+  .hero-actions { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+  .hero-install { display: flex; align-items: center; gap: 10px; padding: 10px 16px; background: var(--ink); color: #fff; border-radius: 10px; font-family: var(--f-mono); font-size: 13px; cursor: pointer; }
+  .hero-install .prompt { color: var(--accent); }
+  .hero-install .copy { font-size: 11px; color: rgba(255,255,255,0.5); margin-left: 6px; }
+
+  /* Floating cast */
+  .hero-cast { position: absolute; right: -40px; top: 40px; width: 440px; height: 480px; pointer-events: none; }
+  .hero-cast .card { position: absolute; width: 180px; background: #fff; border: 1px solid var(--hair); border-radius: 14px; padding: 14px; box-shadow: 0 20px 50px rgba(26,23,20,0.08); }
+  .hero-cast .card .ava { width: 44px; height: 44px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; color: #fff; font-weight: 500; font-size: 16px; }
+  .hero-cast .card .name { font-weight: 500; margin-top: 10px; font-size: 14px; }
+  .hero-cast .card .role { font-size: 11px; color: var(--mute); margin-top: 2px; }
+  .hero-cast .card .bubble { margin-top: 10px; padding: 8px 10px; background: var(--paper-soft); border-radius: 8px; font-size: 12px; color: var(--ink-soft); line-height: 1.4; font-family: var(--f-display); font-style: italic; }
+  .c1 { top: 20px;  right: 40px;  transform: rotate(2deg); }
+  .c2 { top: 180px; right: 220px; transform: rotate(-3deg); }
+  .c3 { top: 320px; right: 60px;  transform: rotate(1.5deg); }
+
+  /* Running strip */
+  .strip { padding: 18px 0; border-top: 1px solid var(--hair); border-bottom: 1px solid var(--hair); font-family: var(--f-mono); font-size: 11px; color: var(--mute); letter-spacing: 1.5px; text-transform: uppercase; }
+  .strip-inner { display: flex; gap: 36px; overflow: hidden; }
+  .strip-inner > span { white-space: nowrap; }
+
+  /* Sections */
+  section { padding: 96px 0; }
+  .section-head { display: flex; align-items: flex-end; justify-content: space-between; margin-bottom: 48px; gap: 40px; }
+  .section-head h2 { font-family: var(--f-sans); font-weight: 500; font-size: clamp(36px, 4.5vw, 56px); letter-spacing: -2px; line-height: 1.05; margin: 10px 0 0; max-width: 680px; text-wrap: balance; }
+  .section-head h2 em { font-family: var(--f-display); font-style: italic; font-weight: 300; }
+  .section-head .aside { max-width: 320px; color: var(--mute); font-size: 14px; line-height: 1.5; }
+
+  /* How it works — 3 steps */
+  .steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 28px; }
+  .step { background: #fff; border: 1px solid var(--hair); border-radius: 16px; padding: 28px; position: relative; }
+  .step .num { font-family: var(--f-mono); font-size: 11px; color: var(--accent); letter-spacing: 2px; }
+  .step h3 { font-family: var(--f-display); font-weight: 400; font-size: 26px; letter-spacing: -0.6px; margin: 14px 0 10px; }
+  .step p { color: var(--ink-soft); font-size: 14px; line-height: 1.55; margin: 0; }
+  .step .demo { margin-top: 20px; padding: 14px; background: var(--paper-soft); border-radius: 10px; font-family: var(--f-mono); font-size: 11px; color: var(--ink-soft); line-height: 1.6; min-height: 110px; }
+  .step .demo .k { color: var(--accent); }
+  .step .demo .m { color: var(--mute); }
+
+  /* Product shot — big canvas */
+  .shot { background: var(--ink); color: #fff; border-radius: 20px; overflow: hidden; position: relative; }
+  .shot-chrome { height: 32px; display: flex; align-items: center; gap: 6px; padding: 0 14px; background: #0f0d0b; border-bottom: 1px solid rgba(255,255,255,0.08); }
+  .shot-chrome .tl { width: 10px; height: 10px; border-radius: 50%; }
+  .shot-chrome .url { flex: 1; margin-left: 14px; height: 20px; background: rgba(255,255,255,0.06); border-radius: 6px; font-family: var(--f-mono); font-size: 10px; color: var(--mute); display: flex; align-items: center; padding: 0 10px; }
+  .shot-body { padding: 40px; display: grid; grid-template-columns: 1.2fr 1fr; gap: 32px; min-height: 440px; }
+  .shot-stage { background: #231e19; border-radius: 14px; padding: 24px; display: flex; flex-direction: column; gap: 12px; }
+  .shot-msg { display: flex; gap: 12px; align-items: flex-start; }
+  .shot-msg .a { width: 32px; height: 32px; border-radius: 50%; flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-size: 11px; font-weight: 500; color: #fff; }
+  .shot-msg .t { flex: 1; }
+  .shot-msg .t .who { font-size: 11px; color: rgba(255,255,255,0.5); font-family: var(--f-mono); letter-spacing: 0.5px; }
+  .shot-msg .t .body { font-family: var(--f-display); font-style: italic; font-size: 16px; line-height: 1.4; margin-top: 4px; color: rgba(255,255,255,0.92); }
+  .shot-side { display: flex; flex-direction: column; gap: 16px; }
+  .shot-ring { width: 180px; height: 180px; margin: 0 auto; position: relative; }
+  .shot-ring svg { transform: rotate(-90deg); }
+  .shot-ring .score { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; }
+  .shot-ring .score .n { font-family: var(--f-display); font-size: 52px; letter-spacing: -1px; }
+  .shot-ring .score .l { font-family: var(--f-mono); font-size: 10px; color: var(--mute); letter-spacing: 1.5px; margin-top: 4px; }
+
+  /* Features grid */
+  .features { display: grid; grid-template-columns: repeat(3, 1fr); gap: 2px; background: var(--hair); border-radius: 18px; overflow: hidden; border: 1px solid var(--hair); }
+  .feature { background: var(--paper); padding: 32px; min-height: 240px; }
+  .feature .ico { width: 38px; height: 38px; border-radius: 10px; background: var(--paper-soft); display: flex; align-items: center; justify-content: center; font-family: var(--f-display); font-size: 18px; color: var(--accent); }
+  .feature h4 { font-family: var(--f-sans); font-weight: 500; font-size: 18px; letter-spacing: -0.4px; margin: 18px 0 6px; }
+  .feature p { color: var(--ink-soft); font-size: 13.5px; line-height: 1.55; margin: 0; }
+
+  /* Open source section */
+  .oss { background: var(--paper-soft); border-radius: 20px; padding: 60px; display: grid; grid-template-columns: 1.1fr 1fr; gap: 60px; align-items: center; }
+  .oss-left h2 { font-family: var(--f-sans); font-weight: 500; font-size: 48px; letter-spacing: -1.8px; line-height: 1.05; margin: 14px 0 20px; }
+  .oss-left h2 em { font-family: var(--f-display); font-style: italic; font-weight: 300; }
+  .oss-left p { color: var(--ink-soft); font-size: 15px; line-height: 1.55; margin: 0 0 24px; max-width: 480px; }
+  .oss-list { list-style: none; padding: 0; margin: 0; }
+  .oss-list li { padding: 10px 0; border-top: 1px solid var(--hair); display: flex; align-items: baseline; gap: 14px; font-size: 14px; }
+  .oss-list li:first-child { border-top: none; }
+  .oss-list .yes { color: var(--cool); font-family: var(--f-mono); font-size: 12px; letter-spacing: 1px; }
+  .oss-list .no { color: var(--accent); font-family: var(--f-mono); font-size: 12px; letter-spacing: 1px; }
+  .oss-right { background: var(--ink); color: #fff; border-radius: 14px; padding: 24px; font-family: var(--f-mono); font-size: 12.5px; line-height: 1.7; }
+  .oss-right .c { color: var(--mute); }
+  .oss-right .h { color: var(--accent); }
+  .oss-right .s { color: #8fb48f; }
+
+  /* Contributors */
+  .contrib { display: flex; align-items: center; gap: 16px; margin-top: 24px; }
+  .contrib .stack { display: flex; }
+  .contrib .stack > div { width: 30px; height: 30px; border-radius: 50%; border: 2px solid var(--paper-soft); margin-left: -8px; }
+  .contrib .stack > div:first-child { margin-left: 0; }
+  .contrib .count { font-family: var(--f-mono); font-size: 12px; color: var(--mute); }
+
+  /* CTA */
+  .cta { text-align: center; padding: 120px 0; position: relative; }
+  .cta::before { content: ''; position: absolute; inset: 0; background: radial-gradient(ellipse 700px 400px at 50% 50%, var(--accent-soft) 0%, transparent 60%); pointer-events: none; }
+  .cta-inner { position: relative; }
+  .cta h2 { font-family: var(--f-sans); font-weight: 500; font-size: 72px; letter-spacing: -3px; line-height: 1.0; margin: 14px 0 20px; }
+  .cta h2 em { font-family: var(--f-display); font-style: italic; font-weight: 300; }
+  .cta p { color: var(--mute); font-size: 18px; max-width: 560px; margin: 0 auto 32px; }
+  .cta-actions { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+
+  /* Footer */
+  footer { border-top: 1px solid var(--hair); padding: 48px 0 36px; font-size: 13px; color: var(--ink-soft); }
+  .foot-grid { display: grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap: 40px; margin-bottom: 40px; }
+  .foot-col h5 { font-family: var(--f-mono); font-size: 10px; letter-spacing: 1.5px; color: var(--mute); text-transform: uppercase; margin: 0 0 14px; }
+  .foot-col a { display: block; padding: 5px 0; color: var(--ink-soft); }
+  .foot-col a:hover { color: var(--ink); }
+  .foot-bottom { display: flex; justify-content: space-between; align-items: center; border-top: 1px solid var(--hair); padding-top: 20px; font-family: var(--f-mono); font-size: 11px; color: var(--mute); letter-spacing: 0.5px; }
+
+  /* Hand-written note annotation (designer voice) */
+  .note { position: absolute; font-family: 'Kalam', cursive; color: var(--accent); font-size: 14px; line-height: 1.3; pointer-events: none; }
+</style>
+</head>
+<body>
+
+<nav class="nav">
+  <div class="nav-inner">
+    <div class="logo">
+      <div class="logo-mark"></div>
+      Persona Studio
+    </div>
+    <div class="nav-links">
+      <a href="#how">How it works</a>
+      <a href="#features">Features</a>
+      <a href="#oss">Open source</a>
+      <a href="#">Docs</a>
+      <a href="#">Blog</a>
+    </div>
+    <div class="nav-right">
+      <a class="nav-star">
+        <span>★</span>
+        <span>Star</span>
+        <span class="count">2.4k</span>
+      </a>
+      <a class="btn btn-primary">Try it live →</a>
+    </div>
+  </div>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="container hero-inner">
+    <div class="hero-badges">
+      <span class="badge"><span class="dot"></span> v0.5.3 · alpha</span>
+      <span class="badge">Elastic License 2.0</span>
+      <span class="badge">Self-host in 60 seconds</span>
+    </div>
+    <h1>Rehearse tomorrow's<br/>meeting <em>today.</em></h1>
+    <p class="hero-sub">Build AI avatars of the people who'll be in the room — essayists, colleagues, customers, your own past self — then listen in as they argue it out.</p>
+    <div class="hero-actions">
+      <a class="btn btn-primary" style="padding: 12px 22px; font-size: 14px;">Try the hosted demo →</a>
+      <div class="hero-install" onclick="navigator.clipboard && navigator.clipboard.writeText('pnpm i persona-studio')">
+        <span class="prompt">$</span>
+        <span>pnpm i persona-studio</span>
+        <span class="copy">⌘C</span>
+      </div>
+    </div>
+
+    <!-- Floating cast cards -->
+    <div class="hero-cast">
+      <div class="card c1">
+        <div class="ava" style="background: oklch(0.70 0.11 28);">PG</div>
+        <div class="name">Paul Graham</div>
+        <div class="role">Essayist · Y Combinator</div>
+        <div class="bubble">"Do things that don't scale."</div>
+      </div>
+      <div class="card c2">
+        <div class="ava" style="background: oklch(0.70 0.11 195);">NR</div>
+        <div class="name">Naval Ravikant</div>
+        <div class="role">AngelList</div>
+        <div class="bubble">"Seek wealth, not money."</div>
+      </div>
+      <div class="card c3">
+        <div class="ava" style="background: oklch(0.70 0.11 350);">DH</div>
+        <div class="name">DHH</div>
+        <div class="role">Basecamp · Rails</div>
+        <div class="bubble">"Small teams, small problems."</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Running strip -->
+<div class="strip">
+  <div class="container strip-inner">
+    <span>★ Self-hostable</span>
+    <span>★ No vendor lock-in</span>
+    <span>★ Bring your own model</span>
+    <span>★ JSON-first data</span>
+    <span>★ Built in the open</span>
+    <span>★ 43 contributors</span>
+    <span>★ MIT-compatible core</span>
+  </div>
+</div>
+
+<!-- HOW IT WORKS -->
+<section id="how">
+  <div class="container">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">How it works</div>
+        <h2>Three steps, <em>one afternoon.</em></h2>
+      </div>
+      <div class="aside">From raw source material to a working roundtable in about twenty minutes — no fine-tuning, no training runs.</div>
+    </div>
+    <div class="steps">
+      <div class="step">
+        <div class="num">01 · INGEST</div>
+        <h3>Feed it a voice.</h3>
+        <p>Drop in essays, transcripts, a podcast feed, your Notion export, or a single URL. It builds a persona grounded in the actual writing — not a caricature.</p>
+        <div class="demo">
+          <span class="m">$</span> <span class="k">persona ingest</span> paulgraham.com/*.html<br/>
+          <span class="m">→ parsed 184 essays · 84k tokens</span><br/>
+          <span class="m">→ avatar "paul_graham" ready.</span>
+        </div>
+      </div>
+      <div class="step">
+        <div class="num">02 · ROUND</div>
+        <h3>Pick a table.</h3>
+        <p>Invite two to eight personas. Hand them a question, a pitch, a pull request. They'll disagree in character. You watch.</p>
+        <div class="demo">
+          <span class="k">› simulate</span> <span class="m">meeting with</span><br/>
+          <span class="k">@paul_graham</span> <span class="k">@naval</span> <span class="k">@dhh</span><br/>
+          <span class="m">about</span> "should we raise a seed?"
+        </div>
+      </div>
+      <div class="step">
+        <div class="num">03 · GRADE</div>
+        <h3>Score the result.</h3>
+        <p>Define what "good" looks like — clarity, rigor, kindness, whatever — and get a Ralph score against that rubric. Iterate until it lands.</p>
+        <div class="demo">
+          <span class="m">Ralph rubric · 4 axes</span><br/>
+          <span class="k">clarity</span>  ████████░ 8.2<br/>
+          <span class="k">rigor</span>    ██████░░░ 6.4<br/>
+          <span class="k">kindness</span> ████████░ 8.0
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- PRODUCT SHOT -->
+<section style="padding-top: 0;">
+  <div class="container">
+    <div class="shot">
+      <div class="shot-chrome">
+        <div class="tl" style="background: #ed6a5e;"></div>
+        <div class="tl" style="background: #f4bf4f;"></div>
+        <div class="tl" style="background: #61c554;"></div>
+        <div class="url">localhost:7777 · live simulation</div>
+      </div>
+      <div class="shot-body">
+        <div class="shot-stage">
+          <div style="font-family: var(--f-mono); font-size: 10px; color: var(--mute); letter-spacing: 1.5px;">ROUND 2 · "SHOULD WE SHIP THE BETA?"</div>
+          <div class="shot-msg" style="margin-top: 8px;">
+            <div class="a" style="background: oklch(0.70 0.11 28);">PG</div>
+            <div class="t">
+              <div class="who">paul_graham · 0:14</div>
+              <div class="body">"Ship it broken. You learn more from one confused user than ten surveys."</div>
+            </div>
+          </div>
+          <div class="shot-msg">
+            <div class="a" style="background: oklch(0.70 0.11 350);">DH</div>
+            <div class="t">
+              <div class="who">dhh · 0:22</div>
+              <div class="body">"That's fine advice for a toy. Not for software people pay for."</div>
+            </div>
+          </div>
+          <div class="shot-msg">
+            <div class="a" style="background: oklch(0.70 0.11 195);">NR</div>
+            <div class="t">
+              <div class="who">naval · 0:29 · <span style="color: var(--accent);">● speaking</span></div>
+              <div class="body">"Both true. The question is which failure mode is cheaper to recover from."</div>
+            </div>
+          </div>
+        </div>
+        <div class="shot-side">
+          <div style="font-family: var(--f-mono); font-size: 10px; color: var(--mute); letter-spacing: 1.5px;">RALPH SCORE · TARGET 7.0</div>
+          <div class="shot-ring">
+            <svg width="180" height="180" viewBox="0 0 180 180">
+              <circle cx="90" cy="90" r="80" fill="none" stroke="rgba(255,255,255,0.08)" stroke-width="8"/>
+              <circle cx="90" cy="90" r="80" fill="none" stroke="#8fb48f" stroke-width="8" stroke-linecap="round"
+                stroke-dasharray="410 502"/>
+            </svg>
+            <div class="score">
+              <div class="n">8.1</div>
+              <div class="l">PASSED</div>
+            </div>
+          </div>
+          <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 10px; font-family: var(--f-mono); font-size: 11px;">
+            <div style="background: rgba(255,255,255,0.05); padding: 10px; border-radius: 8px;">
+              <div style="color: var(--mute); font-size: 9px; letter-spacing: 1px;">LATENCY</div>
+              <div style="margin-top: 4px; font-size: 14px;">480ms</div>
+            </div>
+            <div style="background: rgba(255,255,255,0.05); padding: 10px; border-radius: 8px;">
+              <div style="color: var(--mute); font-size: 9px; letter-spacing: 1px;">TOKENS</div>
+              <div style="margin-top: 4px; font-size: 14px;">2,140</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FEATURES -->
+<section id="features">
+  <div class="container">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">Features</div>
+        <h2>Built for the way you<br/>actually <em>think.</em></h2>
+      </div>
+    </div>
+    <div class="features">
+      <div class="feature">
+        <div class="ico">✻</div>
+        <h4>Bring your own model</h4>
+        <p>Anthropic, OpenAI, Ollama, llama.cpp. Swap providers per-persona. Run entirely local if you need to.</p>
+      </div>
+      <div class="feature">
+        <div class="ico">◷</div>
+        <h4>Live round-table</h4>
+        <p>Personas interrupt, agree, derail. Pace and voice are preserved. You can jump in at any turn.</p>
+      </div>
+      <div class="feature">
+        <div class="ico">◉</div>
+        <h4>Ralph scoring</h4>
+        <p>Define a rubric, watch responses graded against it in real time. Iterate until the answer clears your bar.</p>
+      </div>
+      <div class="feature">
+        <div class="ico">⟡</div>
+        <h4>Private corpora</h4>
+        <p>Your own notes, journals, Slack exports — build personas from anything. Nothing leaves your machine.</p>
+      </div>
+      <div class="feature">
+        <div class="ico">⌘</div>
+        <h4>Keyboard first</h4>
+        <p>⌘K for everything. Every action is scriptable from the CLI. Designed for people who live in terminals.</p>
+      </div>
+      <div class="feature">
+        <div class="ico">↯</div>
+        <h4>JSON-first</h4>
+        <p>Personas, simulations, results — all plain JSON. Git-friendly, diff-able, grep-able, yours.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- OPEN SOURCE -->
+<section id="oss">
+  <div class="container">
+    <div class="oss">
+      <div class="oss-left">
+        <div class="eyebrow">Open source</div>
+        <h2>Source-available,<br/><em>sustainably.</em></h2>
+        <p>We're licensed under Elastic License 2.0 — permissive for almost every real-world use, with one narrow exception to keep the project alive.</p>
+        <ul class="oss-list">
+          <li><span class="yes">✓ YES</span>Use it at work, on your own product, in research.</li>
+          <li><span class="yes">✓ YES</span>Fork it, modify it, self-host it, embed it.</li>
+          <li><span class="yes">✓ YES</span>Contribute back — PRs, issues, plugins, docs.</li>
+          <li><span class="no">✗ NO</span>Resell it as a hosted service that competes with us.</li>
+        </ul>
+        <div class="contrib">
+          <div class="stack">
+            <div style="background: oklch(0.70 0.11 28);"></div>
+            <div style="background: oklch(0.70 0.11 195);"></div>
+            <div style="background: oklch(0.70 0.11 350);"></div>
+            <div style="background: oklch(0.70 0.11 142);"></div>
+            <div style="background: oklch(0.70 0.11 260);"></div>
+            <div style="background: oklch(0.70 0.11 90);"></div>
+            <div style="background: oklch(0.70 0.11 322);"></div>
+          </div>
+          <span class="count">43 contributors · 2,430 stars · 184 PRs merged</span>
+        </div>
+      </div>
+      <div class="oss-right">
+        <span class="c"># clone and run</span><br/>
+        <span class="h">$</span> git clone https://github.com/persona-studio/persona-studio<br/>
+        <span class="h">$</span> cd persona-studio<br/>
+        <span class="h">$</span> pnpm install && pnpm dev<br/><br/>
+        <span class="c"># or one-line self-host</span><br/>
+        <span class="h">$</span> curl -fsSL get.persona-studio.dev | sh<br/><br/>
+        <span class="s">✓</span> <span class="c">server running at</span> localhost:7777<br/>
+        <span class="s">✓</span> <span class="c">no account needed</span><br/>
+        <span class="s">✓</span> <span class="c">data lives in ./data/</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="cta">
+  <div class="container cta-inner">
+    <div class="eyebrow">Ready?</div>
+    <h2>The room is<br/><em>waiting.</em></h2>
+    <p>Five minutes to your first simulation. No credit card, no "book a demo," no sales call.</p>
+    <div class="cta-actions">
+      <a class="btn btn-primary" style="padding: 14px 24px; font-size: 15px;">Try the hosted demo →</a>
+      <a class="btn btn-ghost" style="padding: 14px 24px; font-size: 15px;">★ View on GitHub</a>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer>
+  <div class="container">
+    <div class="foot-grid">
+      <div class="foot-col">
+        <div class="logo" style="margin-bottom: 10px;">
+          <div class="logo-mark"></div>
+          Persona Studio
+        </div>
+        <div style="color: var(--mute); font-size: 13px; line-height: 1.5; max-width: 320px;">
+          Open-source AI roundtables. Built in the open, licensed under ELv2.
+        </div>
+      </div>
+      <div class="foot-col">
+        <h5>Product</h5>
+        <a href="#">Features</a>
+        <a href="#">Changelog</a>
+        <a href="#">Roadmap</a>
+        <a href="#">Self-host</a>
+      </div>
+      <div class="foot-col">
+        <h5>Community</h5>
+        <a href="#">GitHub ↗</a>
+        <a href="#">Discord ↗</a>
+        <a href="#">Twitter ↗</a>
+        <a href="#">Office hours</a>
+      </div>
+      <div class="foot-col">
+        <h5>Resources</h5>
+        <a href="#">Docs</a>
+        <a href="#">API reference</a>
+        <a href="#">Blog</a>
+        <a href="#">License (ELv2)</a>
+      </div>
+    </div>
+    <div class="foot-bottom">
+      <div>© 2026 · ELASTIC LICENSE 2.0 · BUILT BY HUMANS + A FEW ROBOTS</div>
+      <div>v0.5.3-alpha · commit 4a2f91c</div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/web/wireframes-screens.jsx
+++ b/web/wireframes-screens.jsx
@@ -1,0 +1,1334 @@
+// wireframes-screens.jsx — low-fi sketch screens for Persona Studio
+// Exposed on window.Screens.
+
+const C_ACCENT = '#c96442';
+const C_INK = '#1a1a1a';
+const C_PAPER = '#fdfcfa';
+const C_SOFT = '#eeeae3';
+const C_MUTE = '#8a857c';
+
+const P = [
+  { id: 'pg',  name: 'Paul Graham',       role: 'Essayist · YC',     hue: 28  },
+  { id: 'nv',  name: 'Naval Ravikant',    role: 'AngelList',         hue: 195 },
+  { id: 'dhh', name: 'DHH',               role: 'Rails · Basecamp',  hue: 350 },
+  { id: 'jhb', name: 'JH Baek',           role: 'Engineer',          hue: 142 },
+  { id: 'dv',  name: 'Devesh Upadhyay',   role: 'Engineer',          hue: 260 },
+  { id: 'wb',  name: 'Wes Bailey',        role: 'PM',                hue: 90  },
+  { id: 'sp',  name: 'sample_private',    role: 'Fictional · KR',    hue: 322 },
+];
+
+const hueBg = (h) => `oklch(0.72 0.10 ${h})`;
+const hueBgSoft = (h) => `oklch(0.92 0.05 ${h})`;
+const hueInk = (h) => `oklch(0.35 0.10 ${h})`;
+
+// ── Atoms ────────────────────────────────────────────────────────────────
+const Av = ({ p, size = 40, ring }) => (
+  <div className="av" style={{
+    width: size, height: size, borderRadius: '50%',
+    background: hueBg(p.hue), color: '#fff',
+    fontSize: size * 0.38, fontWeight: 600,
+    display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+    boxShadow: ring ? `0 0 0 3px ${C_PAPER}, 0 0 0 4.5px ${hueBg(p.hue)}` : 'none',
+    flexShrink: 0,
+  }}>
+    {p.name.split(' ').map(w => w[0]).slice(0,2).join('').toUpperCase()}
+  </div>
+);
+
+const Line = ({ w = '100%', op = 0.14, h = 8, mb = 8 }) => (
+  <div style={{ height: h, width: w, background: C_INK, opacity: op, borderRadius: 2, marginBottom: mb }} />
+);
+
+const Lines = ({ n = 3, widths }) => (
+  <div>{Array.from({length: n}).map((_,i) => (
+    <Line key={i} w={(widths && widths[i]) || (['96%','88%','72%','80%','92%'][i%5])} op={0.12} h={7} mb={8}/>
+  ))}</div>
+);
+
+const Placeholder = ({ label, w, h, style, heavy }) => (
+  <div className={heavy ? 'ph-heavy' : 'ph'} style={{
+    width: w, height: h, border: '1.5px dashed #c7c4be', borderRadius: 8,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    color: '#8a857c', fontFamily: 'ui-monospace, monospace', fontSize: 11,
+    letterSpacing: 0.5, ...style
+  }}>
+    {label}
+  </div>
+);
+
+const Note = ({ children, top, left, right, bottom, w = 180, rot = -2 }) => (
+  <div className="note hand" style={{ position: 'absolute', top, left, right, bottom, width: w, transform: `rotate(${rot}deg)` }}>
+    {children}
+  </div>
+);
+
+const Bar = ({ w, h = 4, op = 0.14 }) => (
+  <div style={{ width: w, height: h, background: C_INK, opacity: op, borderRadius: 2 }} />
+);
+
+// App chrome: top nav seen in all screens
+const AppNav = ({ active = 'home' }) => (
+  <div style={{
+    height: 52, padding: '0 28px', display: 'flex', alignItems: 'center', gap: 28,
+    borderBottom: '1px solid #e8e4dd', background: C_PAPER,
+  }}>
+    <div style={{ fontWeight: 600, letterSpacing: -0.3, fontSize: 14, display: 'flex', alignItems: 'center', gap: 8 }}>
+      <div style={{ width: 18, height: 18, background: C_INK, borderRadius: 4 }}/>
+      Persona Studio
+    </div>
+    {[
+      ['home','Home'],
+      ['library','Library'],
+      ['create','New avatar'],
+      ['sim','Simulate'],
+      ['results','Results'],
+    ].map(([k,t]) => (
+      <div key={k} style={{
+        fontSize: 13,
+        color: active === k ? C_INK : C_MUTE,
+        fontWeight: active === k ? 600 : 400,
+        borderBottom: active === k ? `2px solid ${C_INK}` : '2px solid transparent',
+        paddingBottom: 14, marginBottom: -1, marginTop: 14,
+      }}>{t}</div>
+    ))}
+    <div style={{ flex: 1 }}/>
+    <div style={{ fontSize: 11, color: C_MUTE, fontFamily: 'ui-monospace, monospace' }}>localhost:7777</div>
+    <div style={{ width: 24, height: 24, borderRadius: '50%', background: C_SOFT }}/>
+  </div>
+);
+
+const Browser = ({ url = 'localhost:7777', children }) => (
+  <div style={{ height: '100%', background: C_PAPER, display: 'flex', flexDirection: 'column' }}>
+    <div className="chrome-bar">
+      <div className="chrome-dot" style={{ background: '#e8ac5f' }}/>
+      <div className="chrome-dot" style={{ background: '#d3d0ca' }}/>
+      <div className="chrome-dot" style={{ background: '#d3d0ca' }}/>
+      <div className="chrome-url">{url}</div>
+    </div>
+    {children}
+  </div>
+);
+
+// ── Legend ────────────────────────────────────────────────────────────────
+function Legend() {
+  return (
+    <div className="wf" style={{ padding: 32 }}>
+      <div className="hand" style={{ fontSize: 28, marginBottom: 6, color: C_INK }}>How to read these</div>
+      <div style={{ fontSize: 13, color: C_MUTE, marginBottom: 24 }}>
+        Low-fi on purpose. Pick the structure you like per row; we hi-fi the winning combination next.
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 24 }}>
+        <div>
+          <div className="hand accent" style={{ fontSize: 14, marginBottom: 8 }}>hand-written labels</div>
+          <div style={{ fontSize: 12, color: C_MUTE, lineHeight: 1.6 }}>Anything in orange cursive is my margin-note to you, not part of the UI.</div>
+        </div>
+        <div>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 8 }}>
+            <Placeholder label="PHOTO" w={60} h={30}/>
+            <span style={{ fontSize: 12, color: C_MUTE }}>= image we'll drop in later</span>
+          </div>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 8 }}>
+            <div style={{ width: 60, display:'flex', flexDirection:'column', gap: 5 }}><Line w="90%"/><Line w="70%"/></div>
+            <span style={{ fontSize: 12, color: C_MUTE }}>= body copy</span>
+          </div>
+        </div>
+        <div>
+          <div style={{ fontSize: 12, color: C_MUTE, marginBottom: 6 }}>each avatar gets a hue:</div>
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            {P.map(p => <Av key={p.id} p={p} size={28}/>)}
+          </div>
+        </div>
+      </div>
+      <Note top={170} right={20} rot={-3}>drag cards ·<br/>click label → focus</Note>
+    </div>
+  );
+}
+
+// ── 1. HOME ──────────────────────────────────────────────────────────────
+function HomeA() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="home" />
+        <div style={{ flex: 1, padding: '120px 140px 0', position: 'relative' }}>
+          <div style={{ fontSize: 11, color: C_MUTE, letterSpacing: 2, textTransform: 'uppercase', marginBottom: 20 }}>Persona Studio · 0.5</div>
+          <div style={{ fontSize: 56, lineHeight: 1.05, letterSpacing: -1.5, fontWeight: 600, maxWidth: 820, marginBottom: 18 }}>
+            Rehearse tomorrow's meeting today.<br/>
+            <span style={{ color: C_MUTE }}>With everyone in the room.</span>
+          </div>
+          <div style={{ fontSize: 17, color: '#555', maxWidth: 640, lineHeight: 1.5, marginBottom: 40 }}>
+            Build AI avatars of real people, then put them in a room together and listen to them argue.
+          </div>
+          <div style={{ display: 'flex', gap: 12 }}>
+            <div className="btn primary" style={{ padding: '12px 22px', fontSize: 14 }}>Start a simulation →</div>
+            <div className="btn" style={{ padding: '12px 22px', fontSize: 14 }}>Build an avatar</div>
+          </div>
+          <div style={{ position: 'absolute', bottom: 60, left: 140, right: 140, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div>
+              <div style={{ fontSize: 11, color: C_MUTE, letterSpacing: 1, marginBottom: 10 }}>YOUR CAST · 7 AVATARS</div>
+              <div style={{ display: 'flex', gap: -8 }}>
+                {P.slice(0,6).map((p,i) => <div key={p.id} style={{ marginLeft: i === 0 ? 0 : -10 }}><Av p={p} size={40} ring /></div>)}
+              </div>
+            </div>
+            <div style={{ fontSize: 12, color: C_MUTE }}>Last run · 12 hours ago · <span className="accent">Should we ship the beta?</span></div>
+          </div>
+        </div>
+      </Browser>
+      <Note top={110} right={30} rot={3} w={150}>Apple-style<br/>restraint. Huge<br/>type, tons of air.</Note>
+    </div>
+  );
+}
+
+function HomeB() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="home" />
+        <div style={{ padding: '48px 80px 0' }}>
+          <div style={{ fontSize: 34, fontWeight: 600, letterSpacing: -0.8, marginBottom: 8 }}>Good afternoon.</div>
+          <div style={{ fontSize: 15, color: C_MUTE, marginBottom: 40 }}>Who do you want to hear from?</div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 20, marginBottom: 48 }}>
+            {P.slice(0,4).map(p => (
+              <div key={p.id} style={{ padding: 24, borderRadius: 14, border: '1px solid #e6e2db', background: '#fff' }}>
+                <Av p={p} size={56}/>
+                <div style={{ fontSize: 15, fontWeight: 600, marginTop: 14 }}>{p.name}</div>
+                <div style={{ fontSize: 12, color: C_MUTE, marginTop: 2 }}>{p.role}</div>
+                <div style={{ marginTop: 14 }}><Line w="90%" op={0.08}/><Line w="62%" op={0.08}/></div>
+              </div>
+            ))}
+          </div>
+
+          <div style={{ display: 'flex', gap: 20 }}>
+            <div style={{ flex: 1, padding: 24, borderRadius: 14, background: C_SOFT }}>
+              <div className="hand" style={{ fontSize: 18, marginBottom: 8 }}>Recent</div>
+              <Lines n={3}/>
+            </div>
+            <div style={{ flex: 1, padding: 24, borderRadius: 14, background: C_INK, color: '#fff' }}>
+              <div style={{ fontSize: 13, opacity: 0.6, marginBottom: 6 }}>QUICKSTART</div>
+              <div style={{ fontSize: 22, fontWeight: 600, lineHeight: 1.25 }}>Start from three thinkers who disagree →</div>
+            </div>
+          </div>
+        </div>
+      </Browser>
+      <Note top={140} right={30} rot={-2}>warmer,<br/>people-first<br/>landing</Note>
+    </div>
+  );
+}
+
+function HomeC() {
+  return (
+    <div className="wf" style={{ background: C_PAPER }}>
+      <Browser>
+        <AppNav active="home" />
+        <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', flexDirection: 'column', padding: 60 }}>
+          <div style={{ fontSize: 13, color: C_MUTE, letterSpacing: 2, marginBottom: 28, textTransform: 'uppercase' }}>Press ⌘K to begin</div>
+          <div style={{
+            width: 720, padding: '20px 24px', borderRadius: 14,
+            background: '#fff', border: '1.5px solid #1a1a1a',
+            boxShadow: '0 20px 60px rgba(0,0,0,0.08)',
+            display: 'flex', alignItems: 'center', gap: 16,
+          }}>
+            <div style={{ fontFamily: 'ui-monospace, monospace', color: C_ACCENT, fontSize: 16 }}>›</div>
+            <div style={{ fontSize: 17 }}>
+              Simulate <span style={{ color: C_MUTE }}>a meeting with</span> <span className="accent">paul_graham</span>, <span className="accent">naval_ravikant</span> <span style={{ color: C_MUTE }}>about</span>…
+            </div>
+            <div style={{ marginLeft: 'auto', width: 1.5, height: 18, background: C_INK, animation: 'none' }}/>
+          </div>
+
+          <div style={{ marginTop: 28, width: 720 }}>
+            {[
+              ['Simulate meeting', 'paul_graham, naval_ravikant, dhh · Should we raise?'],
+              ['Simulate debate',  'jh-baek, wes-bailey · Monolith vs microservices'],
+              ['Create avatar',    'from podcast + linkedin'],
+              ['Browse library',   '7 avatars · local'],
+            ].map(([t, s], i) => (
+              <div key={i} style={{
+                display: 'flex', alignItems: 'center', gap: 14, padding: '14px 20px',
+                borderBottom: '1px solid #efece5',
+                background: i === 0 ? C_SOFT : 'transparent',
+              }}>
+                <div style={{ width: 24, height: 24, borderRadius: 6, background: i === 0 ? C_INK : 'transparent', border: i === 0 ? 'none' : '1px solid #d8d3cb' }}/>
+                <div>
+                  <div style={{ fontSize: 14, fontWeight: 500 }}>{t}</div>
+                  <div style={{ fontSize: 12, color: C_MUTE, marginTop: 2 }}>{s}</div>
+                </div>
+                <div style={{ marginLeft: 'auto', fontFamily: 'ui-monospace, monospace', fontSize: 11, color: C_MUTE }}>↵</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Browser>
+      <Note top={120} right={30} rot={2}>keyboard-first.<br/>powerful users<br/>will love this</Note>
+    </div>
+  );
+}
+
+// ── 2. LIBRARY ──────────────────────────────────────────────────────────
+function LibraryA() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="library" />
+        <div style={{ padding: '40px 56px' }}>
+          <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 28 }}>
+            <div>
+              <div style={{ fontSize: 34, fontWeight: 600, letterSpacing: -0.7 }}>Library</div>
+              <div style={{ fontSize: 13, color: C_MUTE, marginTop: 4 }}>7 avatars · 4 local · 3 global</div>
+            </div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <div style={{ padding: '8px 14px', borderRadius: 999, background: C_SOFT, fontSize: 12 }}>All</div>
+              <div style={{ padding: '8px 14px', borderRadius: 999, fontSize: 12, color: C_MUTE }}>Local</div>
+              <div style={{ padding: '8px 14px', borderRadius: 999, fontSize: 12, color: C_MUTE }}>Global</div>
+              <div style={{ padding: '8px 14px', borderRadius: 999, fontSize: 12, color: C_MUTE }}>Private</div>
+              <div className="btn primary" style={{ marginLeft: 12 }}>+ New avatar</div>
+            </div>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 20 }}>
+            {P.map(p => (
+              <div key={p.id} style={{ padding: 22, borderRadius: 12, border: '1px solid #e6e2db', background: '#fff', position: 'relative' }}>
+                <div style={{ display:'flex', justifyContent:'space-between', alignItems:'flex-start', marginBottom: 14 }}>
+                  <Av p={p} size={52}/>
+                  <div style={{ fontSize: 10, color: C_MUTE, fontFamily: 'ui-monospace, monospace', padding: '3px 7px', border: '1px solid #e6e2db', borderRadius: 4 }}>
+                    {p.id === 'sp' ? 'PRIVATE' : 'PUBLIC'}
+                  </div>
+                </div>
+                <div style={{ fontSize: 15, fontWeight: 600 }}>{p.name}</div>
+                <div style={{ fontSize: 12, color: C_MUTE, marginTop: 2, marginBottom: 14 }}>{p.role}</div>
+                <Lines n={2}/>
+                <div style={{ display: 'flex', gap: 6, marginTop: 14, flexWrap: 'wrap' }}>
+                  <div style={{ fontSize: 10, color: C_MUTE, padding: '2px 7px', border: '1px solid #eee', borderRadius: 4 }}>essay</div>
+                  <div style={{ fontSize: 10, color: C_MUTE, padding: '2px 7px', border: '1px solid #eee', borderRadius: 4 }}>founder</div>
+                </div>
+              </div>
+            ))}
+            <div style={{ padding: 22, borderRadius: 12, border: '1.5px dashed #c7c4be', background: 'transparent', display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: 180, color: C_MUTE, fontSize: 13 }}>
+              +  Add avatar
+            </div>
+          </div>
+        </div>
+      </Browser>
+    </div>
+  );
+}
+
+function LibraryB() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="library" />
+        <div style={{ padding: '40px 56px' }}>
+          <div style={{ fontSize: 34, fontWeight: 600, letterSpacing: -0.7, marginBottom: 24 }}>Library</div>
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 18 }}>
+            <div style={{ flex: 1, padding: '10px 14px', border: '1px solid #e6e2db', borderRadius: 8, fontSize: 13, color: C_MUTE, fontFamily: 'ui-monospace, monospace' }}>
+              ⌕  Filter by name, tag, mode…
+            </div>
+            <div className="btn primary">+ New avatar</div>
+          </div>
+
+          <div style={{ background: '#fff', border: '1px solid #e6e2db', borderRadius: 10 }}>
+            <div style={{ display: 'grid', gridTemplateColumns: '36px 1fr 140px 120px 120px 120px', padding: '10px 16px', fontSize: 11, color: C_MUTE, letterSpacing: 1, borderBottom: '1px solid #efece5', textTransform: 'uppercase' }}>
+              <div/>
+              <div>Name</div>
+              <div>Role</div>
+              <div>Mode</div>
+              <div>Scope</div>
+              <div>Last used</div>
+            </div>
+            {P.map((p,i) => (
+              <div key={p.id} style={{ display: 'grid', gridTemplateColumns: '36px 1fr 140px 120px 120px 120px', padding: '14px 16px', alignItems: 'center', borderBottom: i < P.length-1 ? '1px solid #efece5' : 'none', fontSize: 13 }}>
+                <Av p={p} size={28}/>
+                <div>
+                  <div style={{ fontWeight: 500 }}>{p.name}</div>
+                  <div style={{ fontSize: 11, color: C_MUTE, fontFamily: 'ui-monospace, monospace' }}>{p.id}</div>
+                </div>
+                <div style={{ color: C_MUTE }}>{p.role}</div>
+                <div>{p.id === 'sp' ? 'Private' : 'Celebrity'}</div>
+                <div style={{ color: C_MUTE }}>{i % 2 ? 'global' : 'local'}</div>
+                <div style={{ color: C_MUTE, fontFamily: 'ui-monospace, monospace', fontSize: 11 }}>{['2h','1d','3d','5d','1w','2w','—'][i]}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Browser>
+      <Note top={50} right={40} rot={-2}>for power<br/>users with<br/>30+ avatars</Note>
+    </div>
+  );
+}
+
+function LibraryC() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="library" />
+        <div style={{ padding: '60px 80px' }}>
+          <div style={{ fontSize: 14, color: C_MUTE, letterSpacing: 2, textTransform: 'uppercase', marginBottom: 8 }}>THE CAST</div>
+          <div style={{ fontSize: 40, fontWeight: 600, letterSpacing: -1, marginBottom: 40 }}>7 voices, ready to argue.</div>
+
+          <div style={{ display: 'flex', gap: 32, overflow: 'hidden', alignItems: 'flex-end' }}>
+            {P.map((p, i) => (
+              <div key={p.id} style={{ flex: '0 0 auto', width: 180, textAlign: 'center' }}>
+                <div style={{
+                  width: 180, height: 240, borderRadius: 8, background: hueBgSoft(p.hue),
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  transform: `rotate(${(i % 2 ? 1 : -1) * (0.5 + (i%3)*0.3)}deg)`,
+                }}>
+                  <div style={{ width: 100, height: 100, borderRadius: '50%', background: hueBg(p.hue), color: '#fff', display: 'flex', alignItems:'center', justifyContent:'center', fontSize: 36, fontWeight: 600 }}>
+                    {p.name.split(' ').map(w=>w[0]).slice(0,2).join('')}
+                  </div>
+                </div>
+                <div style={{ fontSize: 14, fontWeight: 600, marginTop: 14 }}>{p.name}</div>
+                <div style={{ fontSize: 11, color: C_MUTE, marginTop: 2 }}>{p.role}</div>
+              </div>
+            ))}
+          </div>
+
+          <div style={{ marginTop: 60, display: 'flex', gap: 16, alignItems: 'center' }}>
+            <div className="btn primary" style={{ padding: '12px 22px', fontSize: 14 }}>+ Add new voice</div>
+            <div style={{ fontSize: 12, color: C_MUTE }}>or drag a folder here to build one automatically</div>
+          </div>
+        </div>
+      </Browser>
+      <Note top={60} right={30} rot={3}>editorial / museum<br/>vibe. risky but<br/>memorable.</Note>
+    </div>
+  );
+}
+
+// ── 3. AVATAR DETAIL ────────────────────────────────────────────────────
+function DetailA() {
+  const p = P[0];
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="library" />
+        <div style={{ padding: '32px 56px', display: 'grid', gridTemplateColumns: '300px 1fr', gap: 40 }}>
+          <div>
+            <div style={{ fontSize: 11, color: C_MUTE, marginBottom: 12 }}>← Library</div>
+            <Av p={p} size={120}/>
+            <div style={{ fontSize: 26, fontWeight: 600, letterSpacing: -0.5, marginTop: 18 }}>{p.name}</div>
+            <div style={{ fontSize: 12, color: C_MUTE, marginTop: 4 }}>{p.role}</div>
+            <div style={{ marginTop: 18, fontFamily: 'ui-monospace, monospace', fontSize: 11, color: C_MUTE, lineHeight: 1.7 }}>
+              born_year: 1964<br/>
+              mode: public<br/>
+              created: 2026-04-19<br/>
+              corpus: 84k tokens
+            </div>
+            <div style={{ marginTop: 20, display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <div className="btn primary">Start simulation →</div>
+              <div className="btn">Edit persona</div>
+              <div className="btn ghost" style={{ color: C_MUTE, fontSize: 11 }}>↗ open personas/paul_graham.md</div>
+            </div>
+          </div>
+
+          <div>
+            <div style={{ display: 'flex', gap: 24, borderBottom: '1px solid #e6e2db', marginBottom: 24 }}>
+              {['Voice','Experiences','Positions','Corpus','Raw files'].map((t,i) => (
+                <div key={t} style={{ padding: '12px 0', fontSize: 13, fontWeight: i === 0 ? 600 : 400, color: i === 0 ? C_INK : C_MUTE, borderBottom: i === 0 ? `2px solid ${C_INK}` : 'none', marginBottom: -1 }}>{t}</div>
+              ))}
+            </div>
+
+            <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 10 }}>Signature phrasings</div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 28 }}>
+              {['make something people want','default alive or default dead','ramen profitable','schlep blindness','the wave of the future','this is going to sound counterintuitive'].map(t => (
+                <div key={t} style={{ fontSize: 12, padding: '6px 10px', border: '1px solid #e6e2db', borderRadius: 999, background: '#fff' }}>"{t}"</div>
+              ))}
+            </div>
+
+            <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 10 }}>Rhetorical frame</div>
+            <Lines n={4}/>
+
+            <div style={{ fontSize: 16, fontWeight: 600, margin: '28px 0 10px' }}>What he avoids</div>
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+              {['jargon','decks','"monetize"','frameworks w/ caps'].map(t => (
+                <div key={t} style={{ fontSize: 11, padding: '4px 10px', border: '1px dashed #c7c4be', borderRadius: 4, color: C_MUTE }}>{t}</div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </Browser>
+    </div>
+  );
+}
+
+function DetailB() {
+  const p = P[1];
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="library" />
+        <div style={{ padding: '60px 140px', maxWidth: 900, margin: '0 auto' }}>
+          <div style={{ fontSize: 11, color: C_MUTE, marginBottom: 24 }}>← Library</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 20, marginBottom: 40 }}>
+            <Av p={p} size={80}/>
+            <div>
+              <div style={{ fontSize: 11, color: C_MUTE, letterSpacing: 2, textTransform: 'uppercase' }}>AVATAR · PUBLIC</div>
+              <div style={{ fontSize: 36, fontWeight: 600, letterSpacing: -0.8 }}>{p.name}</div>
+              <div style={{ fontSize: 14, color: C_MUTE, marginTop: 4 }}>{p.role} · b. 1974</div>
+            </div>
+          </div>
+
+          <div style={{ fontSize: 22, lineHeight: 1.55, color: '#2c2822', marginBottom: 28 }}>
+            Near-monk-like aphorist of leverage, judgment, and long-term games. Emphasizes being "unmistakable" over being "heard."
+          </div>
+
+          <div style={{ fontSize: 13, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 8 }}>SIGNATURE EXPERIENCES</div>
+          <Lines n={3}/>
+          <div style={{ marginTop: 6, fontSize: 13, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase' }}>POSITIONS</div>
+          <Lines n={4}/>
+
+          <div style={{ marginTop: 40, padding: '20px 24px', background: C_SOFT, borderRadius: 10, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <div style={{ fontSize: 13, color: C_MUTE }}>This persona has been in <b style={{ color: C_INK }}>4 simulations</b></div>
+            <div className="btn">See history →</div>
+          </div>
+        </div>
+      </Browser>
+      <Note top={70} right={30} rot={-2}>reads like<br/>New Yorker<br/>profile</Note>
+    </div>
+  );
+}
+
+function DetailC() {
+  const p = P[2];
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="library" />
+        <div style={{ display: 'grid', gridTemplateColumns: '240px 1fr 320px', height: 'calc(100% - 80px)' }}>
+          <div style={{ borderRight: '1px solid #e6e2db', padding: 20 }}>
+            <div style={{ fontSize: 11, color: C_MUTE, marginBottom: 16, letterSpacing: 1, textTransform: 'uppercase' }}>SECTIONS</div>
+            {['Background','Signature experiences','Vocabulary','Positions (5)','Red flags','Relationships'].map((t,i) => (
+              <div key={t} style={{ fontSize: 13, padding: '8px 10px', borderRadius: 6, marginBottom: 2, background: i === 2 ? C_SOFT : 'transparent', fontWeight: i === 2 ? 500 : 400 }}>{t}</div>
+            ))}
+          </div>
+
+          <div style={{ padding: 32, overflow: 'hidden' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 20 }}>
+              <Av p={p} size={36}/>
+              <div style={{ fontSize: 17, fontWeight: 600 }}>{p.name}</div>
+              <div style={{ fontSize: 10, color: C_ACCENT, background: '#fcece6', padding: '3px 8px', borderRadius: 4 }}>EDITING</div>
+            </div>
+            <div style={{ fontSize: 13, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 12 }}>VOCABULARY & RHETORICAL PATTERNS</div>
+            <div style={{ border: '1px solid #e6e2db', borderRadius: 8, background: '#fff', padding: 20, fontFamily: 'ui-monospace, monospace', fontSize: 12, lineHeight: 1.8, color: '#2c2822' }}>
+              <div><span style={{ color: C_ACCENT }}>**Signature phrasings**:</span> "make it boring", "REST done right", "type system as vibes", "majestic monolith"…</div>
+              <div style={{ marginTop: 14 }}><span style={{ color: C_ACCENT }}>**Frame**:</span> combative, blog-post voice. Drops Latinate when angry.</div>
+              <div style={{ marginTop: 14 }}><span style={{ color: C_ACCENT }}>**Avoids**:</span> microservices zealotry, AWS worship, TypeScript supremacy</div>
+            </div>
+            <div style={{ marginTop: 16, fontSize: 12, color: C_MUTE }}>Tip: edit directly. Claude will refine prose & re-validate schema on save.</div>
+          </div>
+
+          <div style={{ borderLeft: '1px solid #e6e2db', padding: 20, background: C_SOFT }}>
+            <div style={{ fontSize: 11, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 12 }}>RAW FILES · 12</div>
+            {[
+              ['hh-interview-2024.mp3', '47 min'],
+              ['rework-book-ch1.pdf', '18 pg'],
+              ['dhh-blog-2020..txt', '48 posts'],
+              ['twitter-dump.json', '8.2k lines'],
+            ].map(([n, s]) => (
+              <div key={n} style={{ padding: '10px 0', borderBottom: '1px solid #e0dbd4', display: 'flex', justifyContent: 'space-between' }}>
+                <div style={{ fontFamily: 'ui-monospace, monospace', fontSize: 11 }}>{n}</div>
+                <div style={{ fontSize: 11, color: C_MUTE }}>{s}</div>
+              </div>
+            ))}
+            <div className="btn" style={{ marginTop: 16, width: '100%', justifyContent: 'center' }}>+ Add material</div>
+            <div style={{ marginTop: 20, padding: 12, background: '#fff', borderRadius: 8, fontSize: 11, color: C_MUTE, lineHeight: 1.5 }}>
+              💡 Re-ingest will rebuild the persona from current files. Current version saved as <span className="mono">v7</span>.
+            </div>
+          </div>
+        </div>
+      </Browser>
+      <Note top={80} right={30} rot={2}>editor-first.<br/>for power-users<br/>who tune often.</Note>
+    </div>
+  );
+}
+
+// ── 4. CREATE AVATAR ────────────────────────────────────────────────────
+function CreateA() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="create" />
+        <div style={{ padding: '48px 140px' }}>
+          <div style={{ fontSize: 11, color: C_MUTE, letterSpacing: 2, textTransform: 'uppercase', marginBottom: 8 }}>STEP 2 OF 4</div>
+          <div style={{ fontSize: 32, fontWeight: 600, letterSpacing: -0.6, marginBottom: 32 }}>Drop in their material.</div>
+
+          <div style={{ display: 'flex', gap: 8, marginBottom: 40 }}>
+            {['Mode','Material','Review','Build'].map((s, i) => (
+              <div key={s} style={{ flex: 1, paddingTop: 8, borderTop: `3px solid ${i <= 1 ? C_INK : '#e6e2db'}`, fontSize: 12, color: i <= 1 ? C_INK : C_MUTE, fontWeight: i === 1 ? 600 : 400 }}>
+                {String(i+1).padStart(2, '0')} · {s}
+              </div>
+            ))}
+          </div>
+
+          <div style={{ border: '2px dashed #c7c4be', borderRadius: 14, padding: 60, textAlign: 'center', background: C_SOFT }}>
+            <div style={{ fontSize: 40, marginBottom: 12, color: C_MUTE }}>⤓</div>
+            <div style={{ fontSize: 18, fontWeight: 500 }}>Drop PDFs, audio, transcripts, or URLs</div>
+            <div style={{ fontSize: 13, color: C_MUTE, marginTop: 6 }}>or <span className="accent" style={{ textDecoration: 'underline' }}>browse files</span> · paste URLs one per line</div>
+          </div>
+
+          <div style={{ marginTop: 24, fontSize: 12, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 8 }}>QUEUED · 3</div>
+          {[
+            ['lex-fridman-episode-412.mp3', 'audio · transcribing…', 0.4],
+            ['linkedin-profile.html', 'web · done', 1],
+            ['urls.txt', 'web · 7 articles done', 1],
+          ].map(([n, s, p]) => (
+            <div key={n} style={{ padding: '10px 0', borderBottom: '1px solid #efece5' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
+                <div style={{ fontFamily: 'ui-monospace, monospace', fontSize: 12 }}>{n}</div>
+                <div style={{ fontSize: 11, color: C_MUTE }}>{s}</div>
+              </div>
+              <div style={{ height: 3, background: '#efece5', borderRadius: 2 }}>
+                <div style={{ height: '100%', width: `${p*100}%`, background: p === 1 ? C_INK : C_ACCENT, borderRadius: 2 }}/>
+              </div>
+            </div>
+          ))}
+
+          <div style={{ marginTop: 32, display: 'flex', justifyContent: 'space-between' }}>
+            <div className="btn ghost" style={{ color: C_MUTE }}>← Back</div>
+            <div className="btn primary">Continue →</div>
+          </div>
+        </div>
+      </Browser>
+    </div>
+  );
+}
+
+function CreateB() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="create" />
+        <div style={{ height: 'calc(100% - 80px)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 60 }}>
+          <div style={{ width: '100%', maxWidth: 720, textAlign: 'center' }}>
+            <div style={{ fontSize: 36, fontWeight: 600, letterSpacing: -0.8, marginBottom: 12 }}>Who do you want to simulate?</div>
+            <div style={{ fontSize: 15, color: C_MUTE, marginBottom: 40 }}>Drop anything. We figure out the rest.</div>
+
+            <div style={{
+              border: '2px dashed #c7c4be', borderRadius: 20, padding: '80px 40px',
+              background: '#fff', position: 'relative',
+            }}>
+              <Placeholder label="FACE / AVATAR PLACEHOLDER" w={120} h={120} style={{ margin: '0 auto 24px', borderRadius: '50%' }}/>
+              <div style={{ fontSize: 18 }}>Drop <span style={{ fontFamily: 'ui-monospace, monospace', color: C_ACCENT }}>PDF · MP3 · DOCX · URLs</span> here</div>
+              <div style={{ fontSize: 13, color: C_MUTE, marginTop: 10 }}>or type a public figure's name</div>
+              <div style={{ marginTop: 24, display: 'inline-flex', alignItems: 'center', gap: 10, padding: '10px 18px', border: `1.5px solid ${C_INK}`, borderRadius: 999, fontSize: 13, fontFamily: 'ui-monospace, monospace' }}>
+                <span style={{ color: C_MUTE }}>⌕</span>  type a name…
+              </div>
+            </div>
+          </div>
+        </div>
+      </Browser>
+      <Note top={60} right={30} rot={-3}>one surface,<br/>no modes.<br/>Jony-Ive pure.</Note>
+    </div>
+  );
+}
+
+function CreateC() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="create" />
+        <div style={{ padding: '60px 100px' }}>
+          <div style={{ fontSize: 32, fontWeight: 600, letterSpacing: -0.6, marginBottom: 10 }}>New avatar</div>
+          <div style={{ fontSize: 14, color: C_MUTE, marginBottom: 40 }}>Choose a starting point.</div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>
+            <div style={{ padding: 32, border: '1.5px solid #1a1a1a', borderRadius: 14, background: '#fff' }}>
+              <div style={{ fontSize: 11, letterSpacing: 2, textTransform: 'uppercase', color: C_MUTE, marginBottom: 14 }}>MODE A</div>
+              <div style={{ fontSize: 24, fontWeight: 600, marginBottom: 10 }}>Private</div>
+              <div style={{ fontSize: 14, color: '#555', lineHeight: 1.55, marginBottom: 24 }}>
+                Your files. Your colleague, your interviewer, yourself. Stays local.
+              </div>
+              <div style={{ fontSize: 12, color: C_MUTE, fontFamily: 'ui-monospace, monospace', lineHeight: 1.8 }}>
+                PDF · DOCX · TXT · MP3 · WAV<br/>
+                urls.txt · youtube_urls.txt
+              </div>
+              <div className="btn primary" style={{ marginTop: 24 }}>Upload files →</div>
+            </div>
+            <div style={{ padding: 32, border: '1.5px solid #e6e2db', borderRadius: 14, background: C_SOFT }}>
+              <div style={{ fontSize: 11, letterSpacing: 2, textTransform: 'uppercase', color: C_MUTE, marginBottom: 14 }}>MODE B</div>
+              <div style={{ fontSize: 24, fontWeight: 600, marginBottom: 10 }}>Celebrity</div>
+              <div style={{ fontSize: 14, color: '#555', lineHeight: 1.55, marginBottom: 24 }}>
+                Just a name and a hint. We harvest public material.
+              </div>
+              <div style={{ padding: '12px 14px', borderRadius: 8, background: '#fff', fontSize: 13, fontFamily: 'ui-monospace, monospace', color: C_MUTE }}>
+                e.g. "Bong Joon-ho · Korean film director"
+              </div>
+              <div className="btn" style={{ marginTop: 24 }}>Search & build →</div>
+            </div>
+          </div>
+
+          <div style={{ marginTop: 40, padding: 18, border: '1px solid #e6e2db', borderRadius: 10, fontSize: 12, color: C_MUTE, display: 'flex', gap: 10, alignItems: 'center' }}>
+            <span style={{ color: C_ACCENT }}>⚠</span> Celebrity avatars never impersonate; review the generated profile before using.
+          </div>
+        </div>
+      </Browser>
+    </div>
+  );
+}
+
+// ── 5. SIMULATION SETUP ─────────────────────────────────────────────────
+function SetupA() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="sim" />
+        <div style={{ padding: '40px 80px' }}>
+          <div style={{ fontSize: 32, fontWeight: 600, letterSpacing: -0.6, marginBottom: 28 }}>New simulation</div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 320px', gap: 40 }}>
+            <div>
+              <div style={{ fontSize: 12, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 8 }}>TOPIC</div>
+              <div style={{ padding: 18, border: '1.5px solid #1a1a1a', borderRadius: 10, fontSize: 18, marginBottom: 4 }}>
+                Should a two-person team build mobile or web first in 2026?
+              </div>
+              <div style={{ fontSize: 11, color: C_MUTE, marginBottom: 28 }}>A clear question produces a better simulation.</div>
+
+              <div style={{ fontSize: 12, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 12 }}>PARTICIPANTS · 3</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, marginBottom: 24 }}>
+                {P.slice(0,3).map(p => (
+                  <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 12px 6px 6px', background: '#fff', border: '1px solid #e6e2db', borderRadius: 999 }}>
+                    <Av p={p} size={28}/>
+                    <div style={{ fontSize: 13 }}>{p.name}</div>
+                    <span style={{ color: C_MUTE, fontSize: 14, cursor: 'pointer' }}>×</span>
+                  </div>
+                ))}
+                <div style={{ padding: '8px 14px', border: '1.5px dashed #c7c4be', borderRadius: 999, fontSize: 13, color: C_MUTE }}>+ Add</div>
+              </div>
+
+              <div style={{ fontSize: 12, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 12 }}>FORMAT</div>
+              <div style={{ display: 'flex', gap: 10, marginBottom: 28 }}>
+                <div style={{ flex: 1, padding: 16, border: '1.5px solid #1a1a1a', borderRadius: 10, background: '#fff' }}>
+                  <div style={{ fontSize: 14, fontWeight: 600 }}>Meeting</div>
+                  <div style={{ fontSize: 12, color: C_MUTE, marginTop: 4 }}>Facilitator leads. Agenda-driven.</div>
+                </div>
+                <div style={{ flex: 1, padding: 16, border: '1px solid #e6e2db', borderRadius: 10 }}>
+                  <div style={{ fontSize: 14, fontWeight: 600 }}>Debate</div>
+                  <div style={{ fontSize: 12, color: C_MUTE, marginTop: 4 }}>Round-robin. Everyone weighs in.</div>
+                </div>
+              </div>
+
+              <div style={{ fontSize: 12, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 12 }}>RALPH LOOP</div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 16, padding: 14, background: C_SOFT, borderRadius: 10 }}>
+                <div style={{ width: 36, height: 20, borderRadius: 999, background: C_INK, position: 'relative' }}>
+                  <div style={{ position: 'absolute', right: 2, top: 2, width: 16, height: 16, borderRadius: '50%', background: '#fff' }}/>
+                </div>
+                <div style={{ fontSize: 13 }}>Retry until score ≥ <b>7</b>, max <b>3</b> iterations</div>
+                <div style={{ marginLeft: 'auto', fontSize: 11, color: C_MUTE, fontFamily: 'ui-monospace, monospace' }}>edit criteria</div>
+              </div>
+            </div>
+
+            <div>
+              <div style={{ padding: 20, background: C_INK, color: '#fff', borderRadius: 14 }}>
+                <div style={{ fontSize: 11, opacity: 0.6, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 8 }}>PREVIEW</div>
+                <div style={{ fontSize: 15, lineHeight: 1.5, marginBottom: 16 }}>A meeting with 3 people about mobile vs web in 2026. Up to 3 rounds.</div>
+                <div className="btn primary" style={{ width: '100%', justifyContent: 'center', background: '#fff', color: C_INK, borderColor: '#fff' }}>Start simulation →</div>
+                <div style={{ fontSize: 10, opacity: 0.5, marginTop: 8, textAlign: 'center' }}>⌘↵</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Browser>
+    </div>
+  );
+}
+
+function SetupB() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="sim" />
+        <div style={{ padding: '40px 80px' }}>
+          <div style={{ fontSize: 32, fontWeight: 600, letterSpacing: -0.6, marginBottom: 8 }}>Seat the room</div>
+          <div style={{ fontSize: 14, color: C_MUTE, marginBottom: 36 }}>Drag avatars onto the table. Leave empty seats if you want.</div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 280px', gap: 40 }}>
+            <div>
+              <div style={{ position: 'relative', padding: 40, background: C_SOFT, borderRadius: 20, minHeight: 420 }}>
+                <div style={{ width: 280, height: 180, margin: '80px auto', border: '2px solid #1a1a1a', borderRadius: 140, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'Kalam', color: C_MUTE, fontSize: 16 }}>
+                  the table
+                </div>
+                {[
+                  { p: P[0], top: 20, left: '30%' },
+                  { p: P[1], top: 20, right: '30%' },
+                  { p: P[2], bottom: 40, left: '30%' },
+                  { p: null, bottom: 40, right: '30%' },
+                ].map(({p, ...pos}, i) => (
+                  <div key={i} style={{ position: 'absolute', ...pos, textAlign: 'center' }}>
+                    {p ? (
+                      <><Av p={p} size={60}/><div style={{ fontSize: 11, marginTop: 4, color: C_MUTE }}>{p.name}</div></>
+                    ) : (
+                      <div style={{ width: 60, height: 60, borderRadius: '50%', border: '1.5px dashed #c7c4be', display: 'flex', alignItems: 'center', justifyContent: 'center', color: C_MUTE, fontSize: 20 }}>+</div>
+                    )}
+                  </div>
+                ))}
+                <div style={{ position: 'absolute', top: 40, left: 40, fontSize: 11, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase' }}>FACILITATOR</div>
+                <div style={{ position: 'absolute', top: 60, left: 40, fontSize: 13, fontFamily: 'ui-monospace, monospace' }}>claude-opus</div>
+              </div>
+
+              <div style={{ marginTop: 24, padding: 18, border: '1.5px solid #1a1a1a', borderRadius: 10 }}>
+                <div style={{ fontSize: 11, color: C_MUTE, letterSpacing: 1, marginBottom: 8 }}>ON THE AGENDA</div>
+                <div style={{ fontSize: 16 }}>Should we ship the beta this quarter?</div>
+              </div>
+            </div>
+
+            <div>
+              <div style={{ fontSize: 11, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 10 }}>BENCH · 7 AVAILABLE</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+                {P.map(p => (
+                  <div key={p.id} style={{ width: 80, textAlign: 'center' }}>
+                    <Av p={p} size={46}/>
+                    <div style={{ fontSize: 10, color: C_MUTE, marginTop: 3, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{p.name.split(' ')[0]}</div>
+                  </div>
+                ))}
+              </div>
+              <div style={{ marginTop: 30, padding: 18, background: C_INK, color: '#fff', borderRadius: 12 }}>
+                <div style={{ fontSize: 11, opacity: 0.5, letterSpacing: 1, marginBottom: 6 }}>FORMAT</div>
+                <div style={{ fontSize: 14, marginBottom: 14 }}>Meeting · Ralph ≥ 7 · max 3 iterations</div>
+                <div className="btn primary" style={{ width: '100%', justifyContent: 'center', background: '#fff', color: C_INK }}>Begin →</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Browser>
+      <Note top={80} right={20} rot={3}>spatial metaphor,<br/>drag-drop.<br/>playful.</Note>
+    </div>
+  );
+}
+
+function SetupC() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="sim" />
+        <div style={{ padding: '60px 100px', maxWidth: 780, margin: '0 auto' }}>
+          <div style={{ fontSize: 13, color: C_MUTE, marginBottom: 36 }}>Step by step. Press ↵ after each line.</div>
+
+          <div style={{ marginBottom: 24 }}>
+            <div style={{ fontSize: 13, color: C_MUTE, marginBottom: 6 }}>What's the meeting about?</div>
+            <div style={{ fontSize: 22, lineHeight: 1.4, color: C_INK }}>
+              Should we raise a seed round or bootstrap?
+            </div>
+          </div>
+          <div style={{ marginBottom: 24 }}>
+            <div style={{ fontSize: 13, color: C_MUTE, marginBottom: 6 }}>Who should be in the room?</div>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <Av p={P[0]} size={36}/>
+              <Av p={P[1]} size={36}/>
+              <Av p={P[2]} size={36}/>
+              <div style={{ fontSize: 22, color: C_INK, marginLeft: 6 }}>paul, naval, dhh</div>
+            </div>
+          </div>
+          <div style={{ marginBottom: 24 }}>
+            <div style={{ fontSize: 13, color: C_MUTE, marginBottom: 6 }}>Debate or meeting?</div>
+            <div style={{ fontSize: 22, color: C_INK }}>meeting <span style={{ color: C_MUTE }}>· agenda-driven</span></div>
+          </div>
+          <div style={{ marginBottom: 40 }}>
+            <div style={{ fontSize: 13, color: C_MUTE, marginBottom: 6 }}>Retry until satisfied?</div>
+            <div style={{ fontSize: 22, color: C_INK }}>yes, <span className="accent">score ≥ 7</span>, up to 3 times.</div>
+          </div>
+
+          <div style={{ padding: 20, border: '1.5px solid #1a1a1a', borderRadius: 12, display: 'flex', alignItems: 'center' }}>
+            <div style={{ fontFamily: 'ui-monospace, monospace', color: C_ACCENT, marginRight: 12 }}>›</div>
+            <div style={{ fontSize: 14, color: C_MUTE }}>anything else to set?</div>
+            <div style={{ marginLeft: 'auto' }} className="btn primary">Start →</div>
+          </div>
+        </div>
+      </Browser>
+      <Note top={80} right={30} rot={-2}>feels like<br/>iMessage with<br/>a robot host.</Note>
+    </div>
+  );
+}
+
+// ── 6. LIVE VIEW (the core new experience) ──────────────────────────────
+function LivePane({ p, active, text, pending }) {
+  return (
+    <div style={{
+      padding: 20, borderRadius: 12, background: '#fff',
+      border: active ? `2px solid ${hueBg(p.hue)}` : '1px solid #e6e2db',
+      height: '100%', display: 'flex', flexDirection: 'column',
+      boxShadow: active ? `0 0 0 4px ${hueBgSoft(p.hue)}` : 'none',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+        <Av p={p} size={32}/>
+        <div>
+          <div style={{ fontSize: 13, fontWeight: 600 }}>{p.name}</div>
+          <div style={{ fontSize: 10, color: active ? hueInk(p.hue) : C_MUTE, fontFamily: 'ui-monospace, monospace' }}>
+            {active ? '● speaking' : pending ? 'thinking…' : 'idle'}
+          </div>
+        </div>
+        {active && (
+          <div className="wav" style={{ marginLeft: 'auto', color: hueBg(p.hue) }}>
+            {[5,9,14,7,11,5,13,8].map((h,i) => <b key={i} style={{ height: h }}/>)}
+          </div>
+        )}
+      </div>
+      <div style={{ flex: 1, fontSize: 13, lineHeight: 1.55, color: active ? C_INK : '#555', overflow: 'hidden' }}>
+        {text}
+        {active && <span style={{ display: 'inline-block', width: 1.5, height: 14, background: hueBg(p.hue), verticalAlign: 'middle', marginLeft: 2 }}/>}
+      </div>
+      <div style={{ marginTop: 12, display: 'flex', gap: 6, fontSize: 10, color: C_MUTE }}>
+        <div style={{ padding: '3px 8px', border: '1px solid #efece5', borderRadius: 4, fontFamily: 'ui-monospace, monospace' }}>turn 3</div>
+        <div style={{ padding: '3px 8px', border: '1px solid #efece5', borderRadius: 4, fontFamily: 'ui-monospace, monospace' }}>iter 1/3</div>
+      </div>
+    </div>
+  );
+}
+
+function LiveA() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="sim" />
+        <div style={{ padding: '20px 32px 28px', display: 'flex', flexDirection: 'column', height: 'calc(100% - 52px)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 16 }}>
+            <div>
+              <div style={{ fontSize: 18, fontWeight: 600 }}>Mobile vs web first in 2026</div>
+              <div style={{ fontSize: 11, color: C_MUTE, marginTop: 2 }}>Meeting · iter 1/3 · turn 3 of 8 · 00:04:12</div>
+            </div>
+            <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+              <div className="btn ghost" style={{ color: C_MUTE, fontSize: 12 }}>▣ pause</div>
+              <div className="btn">interrupt</div>
+              <div className="btn primary">stop</div>
+            </div>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 14, flex: 1 }}>
+            <LivePane p={P[0]} active text={'"Most of what sounds sophisticated about mobile-first is just imitation. If two of you can\'t ship a web app in a weekend, two of you can\'t ship an iOS app in a month."'} />
+            <LivePane p={P[1]} pending text={'(drafting a reply — leverage angle)'} />
+            <LivePane p={P[2]} text={'"Monoliths ship. Whatever form. Next."'} />
+          </div>
+
+          <div style={{ marginTop: 14, padding: '12px 16px', background: C_SOFT, borderRadius: 10, display: 'flex', alignItems: 'center', gap: 16, fontSize: 12, color: C_MUTE }}>
+            <div className="mono" style={{ color: C_INK }}>Facilitator</div>
+            <div>calling on Naval next · topic depth · OK to go long</div>
+            <div style={{ marginLeft: 'auto', display: 'flex', gap: 12 }}>
+              <div>avg response <span className="mono" style={{ color: C_INK }}>7.2s</span></div>
+              <div>tokens <span className="mono" style={{ color: C_INK }}>4.1k</span></div>
+            </div>
+          </div>
+        </div>
+      </Browser>
+      <Note top={60} right={20} rot={2}>closest<br/>to tmux —<br/>still legible.</Note>
+    </div>
+  );
+}
+
+function LiveB() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="sim" />
+        <div style={{ display: 'grid', gridTemplateColumns: '220px 1fr 280px', height: 'calc(100% - 52px)' }}>
+          <div style={{ borderRight: '1px solid #e6e2db', padding: 20 }}>
+            <div style={{ fontSize: 11, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 14 }}>ROOM</div>
+            {P.slice(0,3).map(p => (
+              <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 0' }}>
+                <Av p={p} size={36}/>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 13, fontWeight: 500 }}>{p.name}</div>
+                  <div style={{ fontSize: 10, color: C_MUTE, fontFamily: 'ui-monospace, monospace' }}>
+                    {p.id === 'nv' ? '● speaking' : 'idle'}
+                  </div>
+                </div>
+              </div>
+            ))}
+            <div style={{ marginTop: 20, padding: 12, background: C_SOFT, borderRadius: 8, fontSize: 11, color: C_MUTE, lineHeight: 1.5 }}>
+              Click a name to mute<br/>that voice mid-flight.
+            </div>
+          </div>
+
+          <div style={{ padding: '20px 40px', overflow: 'hidden', display: 'flex', flexDirection: 'column', gap: 18 }}>
+            {[
+              { p: P[0], text: '"Make something people want" is the test. Not platform, not modality.', done: true },
+              { p: P[2], text: 'Ship whatever the hell gets used. Stop theorizing.', done: true },
+              { p: P[1], text: 'Consider leverage. Web ships to every phone already — why not start there and let the winners demand native?', done: true },
+              { p: P[0], text: 'And web is the ramen-profitable version. You can go from zero to users in a day…', active: true },
+            ].map((m, i) => (
+              <div key={i} style={{ display: 'flex', gap: 14, opacity: m.done ? 0.85 : 1 }}>
+                <Av p={m.p} size={32}/>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 12, color: hueInk(m.p.hue), fontWeight: 600, marginBottom: 4 }}>{m.p.name}</div>
+                  <div style={{ fontSize: 15, lineHeight: 1.55 }}>
+                    {m.text}
+                    {m.active && <span style={{ display: 'inline-block', width: 1.5, height: 14, background: C_INK, verticalAlign: 'middle', marginLeft: 2 }}/>}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div style={{ borderLeft: '1px solid #e6e2db', padding: 20, background: C_SOFT }}>
+            <div style={{ fontSize: 11, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 12 }}>FACILITATOR</div>
+            <Lines n={3}/>
+            <div style={{ marginTop: 24, fontSize: 11, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 8 }}>AGENDA · 3/8</div>
+            {['Cost & staffing','Distribution reality','User expectations'].map((t, i) => (
+              <div key={t} style={{ fontSize: 12, padding: '6px 0', color: i < 2 ? C_MUTE : C_INK }}>
+                {i < 2 ? '✓' : '○'} {t}
+              </div>
+            ))}
+          </div>
+        </div>
+      </Browser>
+      <Note top={60} right={20} rot={-2}>Slack-like.<br/>linear flow,<br/>less chaotic.</Note>
+    </div>
+  );
+}
+
+function LiveC() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="sim" />
+        <div style={{ padding: '30px 40px', display: 'flex', flexDirection: 'column', height: 'calc(100% - 52px)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 20 }}>
+            <div style={{ fontSize: 16, fontWeight: 600 }}>Mobile vs web first in 2026</div>
+            <div style={{ fontSize: 11, color: C_MUTE, fontFamily: 'ui-monospace, monospace' }}>iter 1/3 · 00:04:12</div>
+          </div>
+
+          <div style={{ flex: 1, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            {/* Spotlight speaker */}
+            <div style={{ textAlign: 'center', maxWidth: 600 }}>
+              <Av p={P[0]} size={140} ring/>
+              <div style={{ fontSize: 22, fontWeight: 600, marginTop: 18, marginBottom: 2 }}>{P[0].name}</div>
+              <div className="wav" style={{ color: hueBg(P[0].hue), marginBottom: 20, justifyContent: 'center' }}>
+                {[6,12,18,8,14,7,16,11,20,9,15,6].map((h,i) => <b key={i} style={{ height: h, width: 3 }}/>)}
+              </div>
+              <div style={{ fontSize: 22, lineHeight: 1.4, color: C_INK, fontWeight: 400 }}>
+                "Most sophisticated-sounding advice about mobile-first is imitation. If you can't ship web in a weekend, you can't ship iOS in a month."
+              </div>
+            </div>
+
+            {/* Side presence: other participants */}
+            <div style={{ position: 'absolute', left: 40, top: '50%', transform: 'translateY(-50%)', textAlign: 'center', opacity: 0.5 }}>
+              <Av p={P[1]} size={64}/>
+              <div style={{ fontSize: 11, color: C_MUTE, marginTop: 6, fontFamily: 'ui-monospace, monospace' }}>thinking…</div>
+            </div>
+            <div style={{ position: 'absolute', right: 40, top: '50%', transform: 'translateY(-50%)', textAlign: 'center', opacity: 0.5 }}>
+              <Av p={P[2]} size={64}/>
+              <div style={{ fontSize: 11, color: C_MUTE, marginTop: 6, fontFamily: 'ui-monospace, monospace' }}>idle</div>
+            </div>
+          </div>
+
+          <div style={{ padding: '12px 20px', background: C_SOFT, borderRadius: 10, display: 'flex', alignItems: 'center', gap: 16, fontSize: 12, color: C_MUTE }}>
+            <div className="mono" style={{ color: C_INK }}>‹ turn 3 / 8 ›</div>
+            <div style={{ flex: 1 }}>Facilitator: agenda item "cost & staffing" done, moving to distribution reality.</div>
+            <div className="btn">interrupt</div>
+            <div className="btn primary">stop</div>
+          </div>
+        </div>
+      </Browser>
+      <Note top={60} right={30} rot={3}>Apple Keynote<br/>stage energy.<br/>one voice at a time.</Note>
+    </div>
+  );
+}
+
+function LiveD() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="sim" />
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 420px', height: 'calc(100% - 52px)' }}>
+          <div style={{ padding: '20px 32px' }}>
+            <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 14 }}>Room · 3 speakers</div>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 14 }}>
+              {[
+                { p: P[0], active: true,  text: '"If you can\'t ship web in a weekend you can\'t ship mobile in a month."' },
+                { p: P[1], pending: true, text: '(drafting · leverage framing)' },
+                { p: P[2], text: '"Monoliths ship. Whatever form. Next."' },
+                { p: P[3], text: '(muted for this topic)' },
+              ].map(({p,...r}) => (
+                <div key={p.id} style={{ height: 180 }}>
+                  <LivePane p={p} {...r}/>
+                </div>
+              ))}
+            </div>
+            <div style={{ marginTop: 14, padding: 12, background: C_SOFT, borderRadius: 10, fontSize: 12, color: C_MUTE, display: 'flex', gap: 20 }}>
+              <div>agenda <b style={{ color: C_INK }}>3/8</b></div>
+              <div>tokens <b style={{ color: C_INK }}>4.1k</b></div>
+              <div style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}>
+                <div className="btn">interrupt</div>
+                <div className="btn primary">stop</div>
+              </div>
+            </div>
+          </div>
+
+          <div style={{ borderLeft: '1px solid #e6e2db', display: 'flex', flexDirection: 'column' }}>
+            <div style={{ padding: '16px 20px', borderBottom: '1px solid #efece5', display: 'flex', justifyContent: 'space-between' }}>
+              <div style={{ fontSize: 12, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase' }}>TRANSCRIPT</div>
+              <div style={{ fontSize: 11, color: C_MUTE, fontFamily: 'ui-monospace, monospace' }}>auto-scroll</div>
+            </div>
+            <div style={{ flex: 1, padding: 20, overflow: 'hidden', display: 'flex', flexDirection: 'column', gap: 14 }}>
+              {[
+                { p: P[0], t: '"Make something people want." is the test. Not modality.' },
+                { p: P[2], t: 'Ship whatever the hell gets used. Stop theorizing.' },
+                { p: P[1], t: 'Web ships to every phone already — let the winners demand native.' },
+                { p: P[0], t: 'And web is ramen-profitable. Zero to users in a day.' },
+              ].map((m,i) => (
+                <div key={i} style={{ display: 'flex', gap: 10 }}>
+                  <Av p={m.p} size={22}/>
+                  <div style={{ flex: 1, fontSize: 12, lineHeight: 1.55 }}>
+                    <b style={{ color: hueInk(m.p.hue) }}>{m.p.name.split(' ')[0]}</b> {m.t}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </Browser>
+      <Note top={60} right={30} rot={-2}>combo mode.<br/>probably the<br/>right default?</Note>
+    </div>
+  );
+}
+
+// ── 7. RESULTS ──────────────────────────────────────────────────────────
+function ResultsA() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="results" />
+        <div style={{ padding: '40px 80px' }}>
+          <div style={{ fontSize: 11, color: C_MUTE, marginBottom: 8 }}>simulations / mobile-vs-web-2026 / 2026-04-21_18-42</div>
+          <div style={{ fontSize: 32, fontWeight: 600, letterSpacing: -0.6, marginBottom: 6 }}>Mobile or web first in 2026?</div>
+          <div style={{ fontSize: 14, color: C_MUTE, marginBottom: 32 }}>Meeting · 3 participants · 2 iterations · 11min 34s</div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 16, marginBottom: 36 }}>
+            <div style={{ padding: 20, background: C_INK, color: '#fff', borderRadius: 12 }}>
+              <div style={{ fontSize: 10, opacity: 0.5, letterSpacing: 1 }}>SATISFACTION</div>
+              <div style={{ fontSize: 56, fontWeight: 600, letterSpacing: -2, marginTop: 2, lineHeight: 1 }}>7.8</div>
+              <div style={{ fontSize: 11, opacity: 0.6, marginTop: 4 }}>goal ≥ 7 · reached at iter 2</div>
+            </div>
+            <div style={{ padding: 20, border: '1px solid #e6e2db', borderRadius: 12, background: '#fff' }}>
+              <div style={{ fontSize: 10, color: C_MUTE, letterSpacing: 1 }}>CONCLUSION</div>
+              <div style={{ fontSize: 14, marginTop: 8, lineHeight: 1.5 }}>Ship web first, port native once retention demands it. 2 of 3 aligned.</div>
+            </div>
+            <div style={{ padding: 20, border: '1px solid #e6e2db', borderRadius: 12, background: '#fff' }}>
+              <div style={{ fontSize: 10, color: C_MUTE, letterSpacing: 1 }}>ACTION ITEMS</div>
+              <div style={{ fontSize: 13, marginTop: 8, lineHeight: 1.6 }}>
+                <div>□ Ship MVP in 2w · @you</div>
+                <div>□ Rev revisit in 8w · @you</div>
+              </div>
+            </div>
+          </div>
+
+          <div style={{ fontSize: 12, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 12 }}>CRITERIA</div>
+          {[
+            ['Realistic pushback',            8.5],
+            ['Characters stay in voice',      9.0],
+            ['Concrete action items',         6.5],
+            ['Dissent is genuine, not staged', 7.0],
+          ].map(([t, v]) => (
+            <div key={t} style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 8 }}>
+              <div style={{ width: 220, fontSize: 13 }}>{t}</div>
+              <div style={{ flex: 1, height: 6, background: '#efece5', borderRadius: 3 }}>
+                <div style={{ width: `${v*10}%`, height: '100%', background: C_INK, borderRadius: 3 }}/>
+              </div>
+              <div style={{ fontFamily: 'ui-monospace, monospace', fontSize: 13, width: 36, textAlign: 'right' }}>{v.toFixed(1)}</div>
+            </div>
+          ))}
+
+          <div style={{ marginTop: 32, display: 'flex', gap: 10 }}>
+            <div className="btn primary">Read transcript →</div>
+            <div className="btn">↓ Word</div>
+            <div className="btn">↓ PowerPoint</div>
+            <div className="btn">↓ Markdown</div>
+            <div className="btn ghost" style={{ marginLeft: 'auto', color: C_MUTE }}>Re-run with feedback</div>
+          </div>
+        </div>
+      </Browser>
+    </div>
+  );
+}
+
+function ResultsB() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="results" />
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 320px', height: 'calc(100% - 52px)' }}>
+          <div style={{ padding: '32px 60px', overflow: 'hidden' }}>
+            <div style={{ fontSize: 11, color: C_MUTE, marginBottom: 4 }}>2026-04-21 · 11min 34s</div>
+            <div style={{ fontSize: 26, fontWeight: 600, letterSpacing: -0.5, marginBottom: 24 }}>Mobile or web first in 2026?</div>
+
+            {[
+              { p: P[0], t: 'Let me start with the simple version: make something people want. The mobile-vs-web question is almost always downstream of that.' },
+              { p: P[2], t: 'Correct. And "downstream" is a polite word for "irrelevant for 90% of you."' },
+              { p: P[1], t: 'I\'d frame it as leverage. Code runs on every browser already; you spend your scarce hours on product, not on App Store review.' },
+              { p: P[0], t: 'There\'s a second-order thing, too. Web gets you embarrassing-fast. Your first users won\'t mind, and they\'ll tell you what to build next.' },
+            ].map((m, i) => (
+              <div key={i} style={{ display: 'flex', gap: 14, marginBottom: 18 }}>
+                <Av p={m.p} size={30}/>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 12, color: hueInk(m.p.hue), fontWeight: 600, marginBottom: 4 }}>{m.p.name}</div>
+                  <div style={{ fontSize: 14, lineHeight: 1.6, color: '#222' }}>{m.t}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div style={{ borderLeft: '1px solid #e6e2db', padding: 24, background: C_SOFT }}>
+            <div style={{ fontSize: 11, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 12 }}>SCORE</div>
+            <div style={{ fontSize: 44, fontWeight: 600, letterSpacing: -1 }}>7.8</div>
+            <div style={{ fontSize: 11, color: C_MUTE }}>goal ≥ 7 · reached iter 2/3</div>
+
+            <div style={{ marginTop: 28, fontSize: 11, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 10 }}>DOWNLOAD</div>
+            {[
+              ['conversation.md', '48kb'],
+              ['conversation.docx', '220kb'],
+              ['summary.pptx', '1.4mb'],
+            ].map(([n, s]) => (
+              <div key={n} style={{ display: 'flex', justifyContent: 'space-between', padding: '10px 0', borderBottom: '1px solid #e0dbd4', fontSize: 12 }}>
+                <span className="mono">{n}</span>
+                <span style={{ color: C_MUTE }}>{s}</span>
+              </div>
+            ))}
+
+            <div style={{ marginTop: 28, padding: 14, background: '#fff', borderRadius: 8, fontSize: 12, lineHeight: 1.5 }}>
+              <b>Jump to:</b><br/>
+              <span className="accent">Conclusion</span> · Satisfaction · System feedback
+            </div>
+          </div>
+        </div>
+      </Browser>
+      <Note top={60} right={30} rot={2}>reading mode<br/>centric. best for<br/>post-mortem.</Note>
+    </div>
+  );
+}
+
+function ResultsC() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="results" />
+        <div style={{ padding: '40px 60px' }}>
+          <div style={{ fontSize: 26, fontWeight: 600, letterSpacing: -0.5, marginBottom: 4 }}>Iterations · 3 runs</div>
+          <div style={{ fontSize: 13, color: C_MUTE, marginBottom: 32 }}>Mobile or web first in 2026 · Ralph loop</div>
+
+          <div style={{ position: 'relative', paddingLeft: 32, borderLeft: '2px solid #e6e2db' }}>
+            {[
+              { v: 5.4, note: 'Weak on concrete action items. Auto-feedback: "demand owner + deadline for each take-away."', t: '18:12', iter: 'iter 1', done: true },
+              { v: 7.8, note: 'Goal reached. Paul anchored action items with deadlines; Naval added a probe.', t: '18:28', iter: 'iter 2', done: true, reached: true },
+              { v: null, note: 'Idle · you can still re-run with a new criterion', t: '—', iter: 'iter 3', done: false },
+            ].map((r, i) => (
+              <div key={i} style={{ position: 'relative', paddingBottom: 34 }}>
+                <div style={{ position: 'absolute', left: -41, top: 4, width: 18, height: 18, borderRadius: '50%', background: r.reached ? C_ACCENT : (r.done ? C_INK : '#fff'), border: r.done ? 'none' : '2px dashed #c7c4be' }}/>
+                <div style={{ display: 'flex', alignItems: 'baseline', gap: 14 }}>
+                  <div style={{ fontSize: 17, fontWeight: 600 }}>{r.iter}</div>
+                  <div style={{ fontSize: 11, color: C_MUTE, fontFamily: 'ui-monospace, monospace' }}>{r.t}</div>
+                  {r.v !== null && <div style={{ fontSize: 26, fontWeight: 600, letterSpacing: -0.5, marginLeft: 'auto', color: r.reached ? C_ACCENT : C_INK }}>{r.v.toFixed(1)}</div>}
+                </div>
+                <div style={{ fontSize: 13, color: '#444', marginTop: 6, maxWidth: 640 }}>{r.note}</div>
+                {r.done && (
+                  <div style={{ marginTop: 10, display: 'flex', gap: 8 }}>
+                    <div className="btn" style={{ fontSize: 11 }}>Read transcript</div>
+                    <div className="btn ghost" style={{ fontSize: 11, color: C_MUTE }}>diff vs prev</div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+
+          <div style={{ marginTop: 24, padding: 20, background: C_SOFT, borderRadius: 12, display: 'flex', alignItems: 'center' }}>
+            <div>
+              <div style={{ fontSize: 14, fontWeight: 600 }}>Re-run with new feedback</div>
+              <div style={{ fontSize: 12, color: C_MUTE, marginTop: 3 }}>Add a criterion or raise the score bar.</div>
+            </div>
+            <div className="btn primary" style={{ marginLeft: 'auto' }}>Configure →</div>
+          </div>
+        </div>
+      </Browser>
+      <Note top={80} right={30} rot={-2}>emphasizes<br/>the Ralph loop —<br/>this is the differentiator.</Note>
+    </div>
+  );
+}
+
+// ── 8. SETTINGS ─────────────────────────────────────────────────────────
+function SettingsA() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="settings" />
+        <div style={{ display: 'grid', gridTemplateColumns: '220px 1fr', height: 'calc(100% - 52px)' }}>
+          <div style={{ borderRight: '1px solid #e6e2db', padding: 24 }}>
+            <div style={{ fontSize: 11, color: C_MUTE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 14 }}>SETTINGS</div>
+            {['General','Model','Library paths','Theme','Tmux','About'].map((t, i) => (
+              <div key={t} style={{ padding: '8px 12px', borderRadius: 6, background: i === 2 ? C_SOFT : 'transparent', fontSize: 13, fontWeight: i === 2 ? 500 : 400, marginBottom: 2 }}>{t}</div>
+            ))}
+          </div>
+          <div style={{ padding: 40, maxWidth: 640 }}>
+            <div style={{ fontSize: 24, fontWeight: 600, letterSpacing: -0.4, marginBottom: 6 }}>Library paths</div>
+            <div style={{ fontSize: 13, color: C_MUTE, marginBottom: 32 }}>Where your avatars and simulations live.</div>
+
+            {[
+              ['Project-local', '~/code/persona-studio', '4 avatars'],
+              ['Global', '~/.persona-studio', '3 avatars'],
+              ['Simulations', '~/code/persona-studio/simulations', '12 runs'],
+            ].map(([l, path, meta]) => (
+              <div key={l} style={{ padding: 16, border: '1px solid #e6e2db', borderRadius: 10, marginBottom: 12, display: 'flex', alignItems: 'center', gap: 16 }}>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 13, fontWeight: 500 }}>{l}</div>
+                  <div style={{ fontSize: 12, color: C_MUTE, fontFamily: 'ui-monospace, monospace', marginTop: 3 }}>{path}</div>
+                </div>
+                <div style={{ fontSize: 11, color: C_MUTE }}>{meta}</div>
+                <div className="btn ghost" style={{ color: C_MUTE, fontSize: 12 }}>change</div>
+              </div>
+            ))}
+
+            <div style={{ marginTop: 28, padding: 14, background: C_SOFT, borderRadius: 10, fontSize: 12, color: C_MUTE, lineHeight: 1.6 }}>
+              Celebrity avatars default to the global library so they travel between projects. Private avatars stay project-local.
+            </div>
+          </div>
+        </div>
+      </Browser>
+    </div>
+  );
+}
+
+function SettingsB() {
+  return (
+    <div className="wf">
+      <Browser>
+        <AppNav active="settings" />
+        <div style={{ padding: '48px 140px', maxWidth: 820, margin: '0 auto' }}>
+          <div style={{ fontSize: 34, fontWeight: 600, letterSpacing: -0.7, marginBottom: 8 }}>Settings</div>
+          <div style={{ fontSize: 13, color: C_MUTE, marginBottom: 40 }}>All the knobs. Scroll through.</div>
+
+          {[
+            ['Theme', 'Light · Dark · System', 'tabs'],
+            ['Model', 'claude-opus-4 · claude-sonnet-4 · claude-haiku-4', 'tabs'],
+            ['Library location', '~/.persona-studio', 'path'],
+            ['Tmux integration', 'Mirror panes to tmux when available', 'toggle'],
+            ['Telemetry', 'Off — stays local', 'toggle'],
+          ].map(([l, v, kind]) => (
+            <div key={l} style={{ padding: '22px 0', borderBottom: '1px solid #efece5', display: 'flex', alignItems: 'center' }}>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 15, fontWeight: 500 }}>{l}</div>
+                <div style={{ fontSize: 12, color: C_MUTE, marginTop: 3, fontFamily: kind === 'path' ? 'ui-monospace, monospace' : 'inherit' }}>{v}</div>
+              </div>
+              {kind === 'toggle' && (
+                <div style={{ width: 36, height: 20, borderRadius: 999, background: l === 'Telemetry' ? '#d8d3cb' : C_INK, position: 'relative' }}>
+                  <div style={{ position: 'absolute', [l === 'Telemetry' ? 'left' : 'right']: 2, top: 2, width: 16, height: 16, borderRadius: '50%', background: '#fff' }}/>
+                </div>
+              )}
+              {kind === 'tabs' && <div className="btn ghost" style={{ color: C_MUTE, fontSize: 12 }}>change</div>}
+              {kind === 'path' && <div className="btn ghost" style={{ color: C_MUTE, fontSize: 12 }}>browse</div>}
+            </div>
+          ))}
+        </div>
+      </Browser>
+      <Note top={60} right={30} rot={2}>minimal, Apple<br/>System Prefs feel.</Note>
+    </div>
+  );
+}
+
+window.Screens = {
+  Legend,
+  HomeA, HomeB, HomeC,
+  LibraryA, LibraryB, LibraryC,
+  DetailA, DetailB, DetailC,
+  CreateA, CreateB, CreateC,
+  SetupA, SetupB, SetupC,
+  LiveA, LiveB, LiveC, LiveD,
+  ResultsA, ResultsB, ResultsC,
+  SettingsA, SettingsB,
+};

--- a/web/wireframes.html
+++ b/web/wireframes.html
@@ -1,0 +1,203 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8" />
+<title>Persona Studio — Wireframes</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Kalam:wght@300;400;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+
+<style>
+  html, body { margin: 0; padding: 0; background: #f0eee9; font-family: 'Inter', -apple-system, system-ui, sans-serif; }
+  * { box-sizing: border-box; }
+
+  /* Sketch primitives ---------------------------------------------------- */
+  .wf {
+    font-family: 'Inter', -apple-system, system-ui, sans-serif;
+    color: #1a1a1a;
+    background: #fdfcfa;
+    width: 100%;
+    height: 100%;
+    position: relative;
+    overflow: hidden;
+  }
+  .wf .hand { font-family: 'Kalam', cursive; }
+  .wf .mono { font-family: ui-monospace, 'SF Mono', Menlo, monospace; }
+
+  /* Basic atoms */
+  .wf .bx { border: 1.5px solid #1a1a1a; }
+  .wf .bx-soft { border: 1.5px solid #c7c4be; }
+  .wf .bx-dashed { border: 1.5px dashed #b8b5af; }
+  .wf .fill-dk { background: #1a1a1a; color: #fdfcfa; }
+  .wf .fill-soft { background: #eeeae3; }
+  .wf .fill-paper { background: #fdfcfa; }
+  .wf .accent { color: #c96442; }
+  .wf .bg-accent { background: #c96442; color: #fff; }
+  .wf .r-sm { border-radius: 6px; }
+  .wf .r-md { border-radius: 10px; }
+  .wf .r-lg { border-radius: 16px; }
+  .wf .r-full { border-radius: 999px; }
+
+  /* Placeholder slashes */
+  .wf .ph {
+    background: repeating-linear-gradient(135deg, transparent 0 9px, rgba(26,26,26,0.08) 9px 10px);
+  }
+  .wf .ph-heavy {
+    background: repeating-linear-gradient(135deg, transparent 0 7px, rgba(26,26,26,0.22) 7px 8px);
+  }
+  .wf .ph-accent {
+    background: repeating-linear-gradient(135deg, transparent 0 9px, rgba(201,100,66,0.25) 9px 10px);
+  }
+
+  /* Scribble text — indicates 'some copy lives here' */
+  .wf .scribble {
+    display: inline-block;
+    height: 0.55em;
+    background: #1a1a1a;
+    border-radius: 2px;
+    opacity: 0.12;
+    vertical-align: middle;
+  }
+
+  /* Title/section shell ------------------------------------------------- */
+  .chrome-bar {
+    height: 28px; display: flex; align-items: center; gap: 6px;
+    padding: 0 10px; background: #eeeae3; border-bottom: 1px solid #d8d3cb;
+  }
+  .chrome-dot { width: 9px; height: 9px; border-radius: 50%; background: #d3d0ca; }
+  .chrome-url {
+    flex: 1; height: 16px; background: #fdfcfa; border-radius: 4px;
+    font-family: ui-monospace, monospace; font-size: 9px; color: #888;
+    display: flex; align-items: center; padding: 0 8px;
+  }
+
+  /* App-level nav in wireframes */
+  .appnav {
+    height: 56px; padding: 0 32px; display: flex; align-items: center; gap: 28px;
+    border-bottom: 1px solid #e6e2db;
+  }
+  .appnav .brand { font-weight: 600; letter-spacing: -0.4px; font-size: 15px; }
+  .appnav .link { font-size: 13px; color: #4a463f; }
+  .appnav .link.active { color: #1a1a1a; font-weight: 500; }
+
+  /* Avatar chip */
+  .av { width: 40px; height: 40px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-weight: 600; font-size: 14px; color: #fff; }
+  .av.sm { width: 28px; height: 28px; font-size: 11px; }
+  .av.lg { width: 64px; height: 64px; font-size: 22px; }
+  .av.xl { width: 96px; height: 96px; font-size: 32px; }
+
+  /* Live waveform bars (simple) */
+  .wav { display: inline-flex; align-items: end; gap: 2px; height: 16px; }
+  .wav b { display: block; width: 2px; background: currentColor; border-radius: 1px; }
+
+  /* Tiny button */
+  .btn { display: inline-flex; align-items: center; justify-content: center; padding: 6px 12px; border-radius: 999px; font-size: 12px; font-weight: 500; border: 1.5px solid #1a1a1a; background: #fdfcfa; }
+  .btn.primary { background: #1a1a1a; color: #fdfcfa; }
+  .btn.accent { background: #c96442; color: #fff; border-color: #c96442; }
+  .btn.ghost { border-color: transparent; background: transparent; }
+
+  /* Hand-drawn arrow annotation */
+  .note { position: absolute; font-family: 'Kalam', cursive; color: #c96442; font-size: 13px; line-height: 1.25; }
+  .note svg { display: block; }
+</style>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+</head>
+<body>
+<div id="root"></div>
+
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="wireframes-screens.jsx"></script>
+<script type="text/babel">
+  const { DesignCanvas, DCSection, DCArtboard, DCPostIt } = window;
+
+  // Personas used throughout
+  const PEOPLE = [
+    { id: 'pg', name: 'Paul Graham', role: 'Essayist · YC', hue: 28 },
+    { id: 'nv', name: 'Naval Ravikant', role: 'AngelList', hue: 195 },
+    { id: 'dhh', name: 'DHH', role: 'Rails · Basecamp', hue: 350 },
+    { id: 'jhb', name: 'JH Baek', role: 'Engineer', hue: 142 },
+    { id: 'dv', name: 'Devesh Upadhyay', role: 'Engineer', hue: 260 },
+    { id: 'wb', name: 'Wes Bailey', role: 'PM', hue: 90 },
+    { id: 'sp', name: 'sample_private', role: 'Fictional · KR', hue: 322 },
+  ];
+
+  const S = window.Screens;
+
+  function App() {
+    return (
+      <DesignCanvas>
+        {/* ─── Top-level intro / reading guide ─────────────────────────── */}
+        <DCSection id="intro" title="Persona Studio — Web UI Wireframes" subtitle="Low-fi sketches. Apple-ish restraint: roomy whitespace, simple type, b&w + one warm accent. Each row = one screen × 2–3 directions.">
+          <DCArtboard id="legend" label="Reading guide" width={720} height={340}>
+            <S.Legend />
+          </DCArtboard>
+        </DCSection>
+
+        {/* ─── 1. Home ──────────────────────────────────────────────────── */}
+        <DCSection id="home" title="1 · Home" subtitle="First screen when you open localhost. What does 'opening the app' feel like?">
+          <DCArtboard id="a" label="A · Quiet hero" width={1200} height={780}><S.HomeA/></DCArtboard>
+          <DCArtboard id="b" label="B · Room of faces" width={1200} height={780}><S.HomeB/></DCArtboard>
+          <DCArtboard id="c" label="C · Command bar" width={1200} height={780}><S.HomeC/></DCArtboard>
+        </DCSection>
+
+        {/* ─── 2. Avatar Library ────────────────────────────────────────── */}
+        <DCSection id="library" title="2 · Avatar Library" subtitle="Browse the cast. Filter local/global, private/public, tag.">
+          <DCArtboard id="a" label="A · Card grid" width={1200} height={780}><S.LibraryA/></DCArtboard>
+          <DCArtboard id="b" label="B · Dense table" width={1200} height={780}><S.LibraryB/></DCArtboard>
+          <DCArtboard id="c" label="C · Museum row" width={1200} height={780}><S.LibraryC/></DCArtboard>
+        </DCSection>
+
+        {/* ─── 3. Avatar Detail ─────────────────────────────────────────── */}
+        <DCSection id="detail" title="3 · Avatar Detail" subtitle="Profile · voice · positions · raw material · edit.">
+          <DCArtboard id="a" label="A · Two-column profile" width={1200} height={820}><S.DetailA/></DCArtboard>
+          <DCArtboard id="b" label="B · Long-read essay" width={1200} height={820}><S.DetailB/></DCArtboard>
+          <DCArtboard id="c" label="C · Editor-first" width={1200} height={820}><S.DetailC/></DCArtboard>
+        </DCSection>
+
+        {/* ─── 4. Create Avatar ─────────────────────────────────────────── */}
+        <DCSection id="create" title="4 · Create Avatar" subtitle="Upload files (Private) or name-only (Celebrity). Show ETL progress.">
+          <DCArtboard id="a" label="A · Wizard steps" width={1200} height={780}><S.CreateA/></DCArtboard>
+          <DCArtboard id="b" label="B · Single drop-zone" width={1200} height={780}><S.CreateB/></DCArtboard>
+          <DCArtboard id="c" label="C · Split mode pick" width={1200} height={780}><S.CreateC/></DCArtboard>
+        </DCSection>
+
+        {/* ─── 5. Simulation Setup ──────────────────────────────────────── */}
+        <DCSection id="setup" title="5 · Simulation Setup" subtitle="Topic, participants, meeting vs debate, Ralph loop.">
+          <DCArtboard id="a" label="A · Form" width={1200} height={820}><S.SetupA/></DCArtboard>
+          <DCArtboard id="b" label="B · Table seat layout" width={1200} height={820}><S.SetupB/></DCArtboard>
+          <DCArtboard id="c" label="C · Conversational" width={1200} height={820}><S.SetupC/></DCArtboard>
+        </DCSection>
+
+        {/* ─── 6. Live View ─────────────────────────────────────────────── */}
+        <DCSection id="live" title="6 · Live Simulation (tmux replacement)" subtitle="The core new experience. Multiple avatars speaking in parallel.">
+          <DCArtboard id="a" label="A · Panel grid (tmux-like)" width={1400} height={880}><S.LiveA/></DCArtboard>
+          <DCArtboard id="b" label="B · Chat river" width={1400} height={880}><S.LiveB/></DCArtboard>
+          <DCArtboard id="c" label="C · Round table (spotlight)" width={1400} height={880}><S.LiveC/></DCArtboard>
+          <DCArtboard id="d" label="D · Cards + transcript" width={1400} height={880}><S.LiveD/></DCArtboard>
+        </DCSection>
+
+        {/* ─── 7. Results ──────────────────────────────────────────────── */}
+        <DCSection id="results" title="7 · Simulation Results" subtitle="Transcript, Ralph scorecard, downloads (md/docx/pptx).">
+          <DCArtboard id="a" label="A · Scorecard hero" width={1200} height={820}><S.ResultsA/></DCArtboard>
+          <DCArtboard id="b" label="B · Transcript-first" width={1200} height={820}><S.ResultsB/></DCArtboard>
+          <DCArtboard id="c" label="C · Iterations timeline" width={1200} height={820}><S.ResultsC/></DCArtboard>
+        </DCSection>
+
+        {/* ─── 8. Settings ─────────────────────────────────────────────── */}
+        <DCSection id="settings" title="8 · Settings" subtitle="Model, paths, library location (local vs global), theme.">
+          <DCArtboard id="a" label="A · Sidebar nav" width={1200} height={720}><S.SettingsA/></DCArtboard>
+          <DCArtboard id="b" label="B · Single scroll" width={1200} height={720}><S.SettingsB/></DCArtboard>
+        </DCSection>
+
+      </DesignCanvas>
+    );
+  }
+
+  ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Lands the [Claude Design](https://claude.ai/design) handoff bundle as a zero-build static web prototype under `web/`. Users can now open a clickable 9-screen mock of the proposed browser UI without any install step beyond a static file server.

Original design URL: https://api.anthropic.com/v1/design/h/aafrY9EzeI5qFFgRlrvmTg (hifi-v2.html)

## How to run

```bash
cd web/
python3 -m http.server 7777
# open http://localhost:7777/hifi-v2.html
```

9 screens (Home, Library, Avatar detail, Create, Setup, Live, Results, Settings, Cloud · soon). Arrow keys navigate; click hotspots follow the Home → Setup → Live → Results happy path.

## What's included

**Prototype entries** (all 3 open cleanly from the static server):
- `hifi-v2.html` — primary entry, the hi-fi clickable flow
- `landing.html` — standalone OSS-style landing page
- `wireframes.html` — earlier low-fi exploration (kept for reference)

**Shared JSX components** loaded via `<script type="text/babel">`:
- `hifi-atoms.jsx` (design tokens + AppNav + primitives)
- `hifi-home.jsx`, `hifi-library.jsx`, `hifi-v2-screens.jsx` (Avatar Detail / Create / Setup)
- `hifi-live-animated.jsx` (default Live view) + `hifi-live.jsx` (static fallback)
- `hifi-results.jsx`, `hifi-auth-screens.jsx` (Settings + hidden Cloud stubs)

**Design intent preservation**:
- `web/docs/HANDOFF.md` — original design README (unedited)
- `web/docs/design-chats/` — 4 conversation transcripts capturing the iteration from low-fi wireframes to this hi-fi v2
- `web/README.md` — design's own README, with a front-matter note clarifying that the ELv2 badge reflects design-time intent while the actual repo license stays MIT

## What works, what doesn't

**Works**:
- 9-screen navigation (pills + arrow keys + happy-path hotspots)
- Import modal with URL / Files / Paste tabs (mock)
- Animated Live view with scripted turns
- `localStorage` persistence for last-visited screen
- "GUEST MODE · LOCAL ONLY" chrome + ★ Star on GitHub chip

**Does NOT work yet** (intentional — follow-up scope):
- No hook into `src/persona_studio/` (all data is mock)
- No real Ralph simulation — Live view animates scripted turns, not actual LLM output
- No write to `data/people/` or `simulations/`
- No auth / account / Cloud — those screens are hidden; Pricing is labeled "Cloud · soon"

## License reconciliation

Design bundle carried an ELv2 recommendation badge. Kept repo MIT because:
1. v0.6.0 already released under MIT
2. Project isn't at a stage where ELv2's "no competing SaaS" clause provides meaningful protection
3. Single license is contributor-friendly

The design's ELv2-badged README is preserved unedited under `web/README.md` with a top-of-file note making the true repo license obvious.

## Top-level README

Added a "Browser prototype (experimental)" section to both `README.md` and `README.ko.md`:
- Install / run commands
- Honest list of what is and isn't wired to the real backend
- Pointer to follow-up scope (Streamlit or FastAPI+React frontend wired to `persona_studio.grounding.audit` + `verify_claims` + SSE/WebSocket for live turns)

## Test plan

- [x] `cd web/ && python3 -m http.server 7778` serves all 9 JSX files + 3 HTML entries with HTTP 200
- [x] No existing tests break (Python side untouched; 247/247 still green)
- [x] Stop-hook safety: staged 25 explicit paths, verified diff stat before commit
- [x] Design bundle LICENSE file deliberately **not** copied — avoids ELv2/MIT collision at repo root

## Next (separate PRs)

- Wire the prototype to `persona_studio.grounding` via Streamlit or FastAPI+React
- SSE/WebSocket endpoint for streaming live simulation turns
- Replace Import modal mock with `persona_studio.cli extract`