### PR TITLE
feat(web): Phase 1 — read-only web dashboard (Library + Results on real data)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -316,32 +316,45 @@ transcript 에 인라인으로 붙는 태그들:
 
 <br/>
 
-## 브라우저 프로토타입 (실험적)
+## 브라우저 프로토타입 (실험적 · 웹 마이그레이션 Phase 1)
 
-지금까지 Persona Studio 는 CLI 플러그인 전용이었지만, 제안된 웹 UI 의 **클릭 가능 프로토타입** 이 [`web/`](web/) 에 추가됐습니다 — 9개 화면 (Home, Library, Avatar 상세, Create, Setup, Live 시뮬레이션, Results, Settings, Cloud · soon), 런타임에 JSX 파일을 로드하는 단일 HTML 페이지. **빌드 단계 없음**.
+지금까지 Persona Studio 는 CLI 플러그인 전용이었지만, [`web/`](web/) 번들 — 9개 화면의 클릭 가능 웹 UI — 가 **primary runtime 으로 전환 중**. **Phase 1 가동**: 2개 화면(Library, Results)은 프로젝트의 실제 데이터에 연결; 나머지 7개는 Phase 2-4 대기 중 mock 유지.
+
+### web extra 설치 (최초 1회)
 
 ```bash
-cd web/
-# 옵션 1 — static server
-python3 -m http.server 7777
-# 옵션 2 — npx serve
-npx --yes serve -l 7777 .
-# 브라우저에서 http://localhost:7777/hifi-v2.html
+.venv/bin/pip install -e '.[web]'
 ```
 
-지금 할 수 있는 것:
+`fastapi`, `uvicorn`, `pyyaml`, `httpx` 추가. TUI 만 쓰는 사용자가 install footprint 비용을 지불하지 않도록 opt-in.
 
-- **완전한 클릭 플로우** — 네비 pill 또는 ← / → 화살표로 9개 화면 이동; 각 화면의 hotspot 을 눌러 happy path (Home → Setup → Live → Results) 전진.
-- **Mock data 만** — 아바타·시뮬레이션·transcript 는 디자인 placeholder. 이 프로토타입은 아직 `src/persona_studio/` 의 Python grounding / simulation 파이프라인을 호출하지 않습니다.
-- **Guest mode 표시** — chrome 에 "GUEST MODE · LOCAL ONLY" 표시로 미래 동작 시사; 현재는 nav 선택만 `localStorage` 에 저장.
+### 실행
 
-아직 안 되는 것:
+```bash
+python -m persona_studio.web
+# 또는 TUI 경유: /persona-studio:studio → "Open in browser (experimental)"
+```
 
-- 실제 Ralph 시뮬레이션 없음 (Live view 는 scripted animated turn 이지 진짜 LLM 출력 아님).
-- `data/people/` · `simulations/` 에 기록 없음.
-- auth / account / Cloud 기능 없음 — 해당 화면은 의도적으로 숨김 + "Cloud · soon" 라벨.
+`http://127.0.0.1:7777` 바인딩 — localhost 전용, LAN 노출 없음. 기본 브라우저 자동 실행. headless 시 `--no-browser`.
 
-프로토타입을 실제 백엔드에 연결하고 싶으시면 다음 단계는 Streamlit 또는 FastAPI+React 프론트엔드로 `persona_studio.grounding.audit`, `verify_claims`, 그리고 live 시뮬레이션 turn 을 스트리밍할 새 SSE/WebSocket 엔드포인트를 호출하는 것. 로드맵 참조.
+### Phase 1 에서 되는 것
+
+- **Library 화면** — `GET /api/personas` fetch, project-local (`./personas/*.md`) + global (`$HOME/.persona-studio/personas/*.md`) 양 scope 에서 실제 persona library 표시 (project 우선 dedup). 서버 닿지 않으면 7-persona mock 으로 fallback.
+- **Results 화면** — `GET /api/simulations` fetch, 가장 최근 시뮬레이션의 topic + Ralph score 를 hero 에 overlay. Criteria / trajectory / transcript preview 는 Phase 2 의 per-simulation detail 까지 mock 유지.
+- **정적 호스팅** — 나머지 9-screen 번들은 `./web/` 의 `StaticFiles` 마운트로 서빙; 키보드 ← → 화살표, localStorage persistence, Home → Setup → Live → Results happy-path 클릭 경로 모두 PR #8 static mode 와 동일 동작.
+
+### 아직 mock 인 것
+
+- Home, Avatar 상세, Create, Setup, Live, Settings, Cloud — 모두 디자인 placeholder 렌더. Library 카드 클릭은 mock Paul Graham detail 로 가지 **않음** (Phase 1 에서 해당 hotspot 비활성화 — real-card→mock-detail 의 jarring transition 방지).
+- **Create / Simulate write path 없음** — 새 아바타 생성·시뮬레이션 실행은 여전히 TUI (`/persona-studio:studio` 메뉴 1-3)에서.
+- **웹 백엔드에서 LLM 호출 없음** — Phase 3 에서 hybrid `claude -p` subprocess + Anthropic SDK 레이어 추가 → Live view 가 실제 turn output 으로 애니메이션.
+
+### 마이그레이션 로드맵
+
+1. **Phase 1 (이번 릴리즈)** — read-only Library + Results.
+2. **Phase 2** — persona detail + Create/import write path, `persona_studio.cli extract` 연결.
+3. **Phase 3** — SSE + hybrid LLM 백엔드 기반 라이브 시뮬레이션 (subprocess 기본, API key 있으면 SDK). Critical path.
+4. **Phase 4** — team-mode pane + realtime user interruption (stretch; sequential 로 충분할 수도).
 
 > `web/` 번들은 [Claude Design](https://claude.ai/design) 핸드오프. 원본 design README + chat transcript 는 작성자 의도 보존을 위해 `web/docs/` 에 보존. 라이선스 주: design 은 ELv2 를 권장했지만 이 레포는 MIT 유지 — 레포 루트 `LICENSE` 참조.
 

--- a/README.md
+++ b/README.md
@@ -316,32 +316,45 @@ Disable the whole layer for pure-brainstorm sessions via the `/persona-studio:st
 
 <br/>
 
-## Browser prototype (experimental)
+## Browser prototype (experimental · Phase 1 of web migration)
 
-Persona Studio has been a CLI plugin from day one, but a **clickable browser prototype** of the proposed web UI now lives in [`web/`](web/) — 9 screens (Home, Library, Avatar detail, Create, Setup, Live simulation, Results, Settings, Cloud · soon), built as a single HTML page that loads JSX files at runtime. **No build step required**.
+Persona Studio has been a CLI plugin from day one, but the [`web/`](web/) bundle — 9 screens of a clickable web UI — is in active migration toward becoming the primary runtime. **Phase 1 is now live**: two screens (Library, Results) are wired to real data from your project; the other 7 remain mock pending Phases 2-4.
+
+### Install the web extra (one-time)
 
 ```bash
-cd web/
-# Option 1 — any static server
-python3 -m http.server 7777
-# Option 2 — npx serve
-npx --yes serve -l 7777 .
-# then open http://localhost:7777/hifi-v2.html
+.venv/bin/pip install -e '.[web]'
 ```
 
-What it does today:
+Adds `fastapi`, `uvicorn`, `pyyaml`, and `httpx`. Kept opt-in so users who only use the TUI don't pay the install footprint.
 
-- **Fully clickable flow** — use the nav pills or ← / → arrows to walk through the 9 screens; click hotspots on each screen to move forward on the "happy path" (Home → Setup → Live → Results).
-- **Mock data only** — avatars, simulations, and transcripts shown are design placeholders. This prototype does not yet call the Python grounding or simulation pipeline under `src/persona_studio/`.
-- **Guest mode indicator** — the chrome shows "GUEST MODE · LOCAL ONLY" to signal the future behavior; today there is no persistence beyond the nav selection in `localStorage`.
+### Launch
 
-What it does NOT do yet:
+```bash
+python -m persona_studio.web
+# or via the TUI: /persona-studio:studio → "Open in browser (experimental)"
+```
 
-- No real Ralph simulation (the Live view is animated with scripted turns, not actual LLM output).
-- No write to `data/people/` or `simulations/`.
-- No auth / account / Cloud features — those screens are intentionally hidden and labelled "Cloud · soon".
+Bound to `http://127.0.0.1:7777` — localhost-only, no LAN exposure. Opens the default browser automatically; use `--no-browser` for headless.
 
-Want to help wire the prototype to the real backend? The next phase would be a Streamlit or FastAPI+React frontend that calls `persona_studio.grounding.audit`, `verify_claims`, and a new SSE/WebSocket endpoint for streaming live simulation turns. See the ROADMAP.
+### What's live (Phase 1)
+
+- **Library screen** — fetches `GET /api/personas`, shows the real persona library from both project-local (`./personas/*.md`) and global (`$HOME/.persona-studio/personas/*.md`) scopes with project-priority dedup. Falls through to the mock 7-persona cast if the server is unreachable.
+- **Results screen** — fetches `GET /api/simulations`, overlays the newest past simulation's topic and Ralph score onto the hero. Criteria / trajectory / transcript preview stay mock until Phase 2 ships per-simulation detail.
+- **Static hosting** — the rest of the 9-screen bundle served from `./web/` via a `StaticFiles` mount at `/`; keyboard ← → arrows, localStorage persistence, and the Home → Setup → Live → Results happy-path click route all behave exactly as in PR #8's static mode.
+
+### What's still mock
+
+- Home, Avatar detail, Create, Setup, Live, Settings, Cloud — all render the design's placeholder content. Clicking a Library card does NOT open the mock Paul Graham detail (Phase 1 disables that hotspot to avoid the jarring real-card → mock-detail transition).
+- **No Create / Simulate write path yet** — starting a new avatar or running a simulation must still happen from the TUI (`/persona-studio:studio` menu items 1-3).
+- **No LLM calls from the web backend** — Phase 3 will add a hybrid `claude -p` subprocess + Anthropic SDK layer so Live view animates against real turn output.
+
+### Migration roadmap
+
+1. **Phase 1 (this release)** — read-only Library + Results.
+2. **Phase 2** — persona detail + Create/import write paths wired to `persona_studio.cli extract`.
+3. **Phase 3** — live simulation via SSE + hybrid LLM backend (subprocess default, API key → SDK). The critical path.
+4. **Phase 4** — team-mode panes + realtime user interruption (stretch; sequential mode may be enough).
 
 > The `web/` bundle is a [Claude Design](https://claude.ai/design) handoff. Original design README + chat transcripts are preserved under `web/docs/` for authorial intent. License note: the design recommended ELv2, but this repo stays MIT — see `LICENSE` at the repo root.
 

--- a/commands/studio.md
+++ b/commands/studio.md
@@ -64,8 +64,9 @@ Use `AskUserQuestion` with this question, repeated until the user picks `Exit`:
   3. `Meeting simulation (facilitated)` — "A facilitator-led meeting with an agenda"
   4. `List avatars` — "Summary of saved personas"
   5. `Refine an avatar` — "Update specific sections of one persona"
-  6. `Toggle factual grounding` — "Turn grounding ON/OFF for this session (default: ON). Brainstorming sessions may want it OFF to welcome divergent claims."
-  7. `Exit` — "Exit the studio"
+  6. `Open in browser (experimental)` — "Launch the web UI at http://localhost:7777. Library + past Results show live data; Create/Simulate still use this menu."
+  7. `Toggle factual grounding` — "Turn grounding ON/OFF for this session (default: ON). Brainstorming sessions may want it OFF to welcome divergent claims."
+  8. `Exit` — "Exit the studio"
 
 Route to the matching sub-flow below. After each sub-flow returns, come back to
 this menu instead of ending the session.
@@ -183,6 +184,45 @@ State lives in a single JSON file at the project root: `data/grounding-session.j
       GROUNDING_ENABLED=true
   fi
   ```
+
+## Route G — Open in browser (experimental)
+
+Phase 1 of the web migration: boot a local FastAPI server and open the
+browser to the 9-screen prototype. The Library and Results screens show
+real data from the current project; the other 7 screens remain mock and
+write-path operations (Create, Simulate) still flow through this TUI.
+
+Ensure the optional `[web]` dependencies are installed (idempotent):
+
+```bash
+.venv/bin/pip install -e '.[web]' > /dev/null 2>&1 || true
+```
+
+Start the server via `run_in_background=true` Bash so this command can
+return to the menu while the server keeps running. The launcher already
+opens the user's default browser:
+
+```bash
+.venv/bin/python -m persona_studio.web --port 7777
+```
+
+Print the URL and a one-line stop-hint, then return to the main menu:
+
+```
+Opened: http://127.0.0.1:7777/hifi-v2.html
+Stop the server when you're done: press Ctrl-C in the shell that started it, or `lsof -ti:7777 | xargs kill`.
+```
+
+**What works in Phase 1**: Library screen (live personas from
+`./personas/` + `$HOME/.persona-studio/personas/`), Results screen
+(newest past simulation overlaid on the hero; mock criteria/trajectory
+for rest), 9-screen navigation, keyboard ← → arrows, localStorage
+persistence.
+
+**What doesn't work yet**: clicking a Library card doesn't open a detail
+(Phase 2 — the mock Paul Graham detail hotspot is disabled). Create /
+Setup / Live / Settings screens render but are mock (Phase 2/3/4). Any
+actual simulation must still be started from this TUI.
 
 ## Non-negotiable rules
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,12 @@ dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
 ]
+web = [
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.30",
+    "pyyaml>=6.0",
+    "httpx>=0.27",  # FastAPI TestClient dep
+]
 
 [project.scripts]
 persona-studio = "persona_studio.cli:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ persona-studio = "persona_studio.cli:app"
 testpaths = ["tests"]
 addopts = "-q"
 pythonpath = ["src"]
+markers = [
+    "slow: subprocess / integration tests — seconds, not ms. Still run by default; tag exists so `pytest -m 'not slow'` can skip them in tight dev loops.",
+]
 
 [tool.coverage.run]
 source = ["src/persona_studio"]

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -115,9 +115,14 @@ def setup_plan(
     ))
     steps.append(Step(
         name="pip_install",
-        description="Install persona-studio and dev extras",
+        description="Install persona-studio with dev + web extras",
         action=lambda: _run(
-            [str(py), "-m", "pip", "install", "--quiet", "-e", ".[dev]"],
+            # web extras (fastapi, uvicorn, pyyaml, httpx) cover the Phase 1
+            # browser UI launched via `python -m persona_studio.web`. Keeping
+            # them opt-in at the pyproject level, but the default bootstrap
+            # installs both so users don't hit ImportError on first Open in
+            # browser click.
+            [str(py), "-m", "pip", "install", "--quiet", "-e", ".[dev,web]"],
             cwd=repo_root,
         ),
     ))

--- a/src/persona_studio/web/__init__.py
+++ b/src/persona_studio/web/__init__.py
@@ -1,0 +1,7 @@
+"""Phase 1 web runtime for persona-studio.
+
+FastAPI-backed local server that serves the `web/` browser prototype and
+exposes read-only REST endpoints over the project's persona library and
+past simulation transcripts. No LLM calls, no write paths, no MCP
+dependencies — that isolation is what makes Phase 1 small and reviewable.
+"""

--- a/src/persona_studio/web/__main__.py
+++ b/src/persona_studio/web/__main__.py
@@ -41,7 +41,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if not args.no_browser:
-        url = f"http://{args.host}:{args.port}/hifi-v2.html"
+        # Open the production shell at `/`. StaticFiles(html=True) resolves
+        # a bare `/` to `index.html`, which renders one screen at a time
+        # via hash routing without hifi-v2's prototype chrome. The
+        # design-review wrapper stays accessible at /hifi-v2.html for
+        # anyone who wants to see the 9-pill navigator.
+        url = f"http://{args.host}:{args.port}/"
         # open() blocks until a browser is selected, but with new=2 it
         # opens in a new tab and returns quickly on macOS/Linux. If the
         # call fails entirely (no DISPLAY, no default browser), ignore —

--- a/src/persona_studio/web/__main__.py
+++ b/src/persona_studio/web/__main__.py
@@ -1,0 +1,64 @@
+"""CLI entrypoint: ``python -m persona_studio.web``.
+
+Starts a local uvicorn instance bound to ``127.0.0.1:7777`` by default
+and opens the user's browser to the hi-fi prototype. The slash-command
+menu item "Open in browser (experimental)" (``commands/studio.md`` Route
+G) invokes this module.
+
+Flags:
+    --port INT           bind port (default 7777)
+    --host STR           bind host (default 127.0.0.1)
+    --no-browser         do not call webbrowser.open on startup
+                         (tests and headless runs)
+"""
+from __future__ import annotations
+
+import argparse
+import webbrowser
+
+import uvicorn
+
+from persona_studio.web.server import create_app
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m persona_studio.web",
+        description="Persona Studio — local web runtime (Phase 1, read-only).",
+    )
+    parser.add_argument("--port", type=int, default=7777, help="bind port (default 7777)")
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help="bind host (default 127.0.0.1 — localhost-only)",
+    )
+    parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="skip webbrowser.open on startup (tests, headless environments)",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.no_browser:
+        url = f"http://{args.host}:{args.port}/hifi-v2.html"
+        # open() blocks until a browser is selected, but with new=2 it
+        # opens in a new tab and returns quickly on macOS/Linux. If the
+        # call fails entirely (no DISPLAY, no default browser), ignore —
+        # the server still runs, and user can navigate manually.
+        try:
+            webbrowser.open(url, new=2)
+        except Exception:
+            pass
+
+    uvicorn.run(
+        create_app(),
+        host=args.host,
+        port=args.port,
+        log_level="info",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/persona_studio/web/personas.py
+++ b/src/persona_studio/web/personas.py
@@ -1,0 +1,123 @@
+"""Read-only persona library listing for the Phase 1 web API.
+
+Ports the dual-scope + project-priority-dedup algorithm described in
+``commands/studio.md`` Route D (lines 116-129) to Python. Does NOT reuse
+``grounding.retriever.find_persona_data_dir`` — that function resolves a
+single persona's data directory, not the library. This is a distinct
+traversal.
+
+The returned records are shaped for the web UI's Library screen
+(``web/hifi-atoms.jsx`` PEOPLE array fields). Real persona files have a
+heterogeneous frontmatter subset; this module maps what exists and
+supplies defensible fallbacks for what doesn't.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
+_BACKGROUND_RE = re.compile(
+    r"^#\s*Background\s*\n+([^\n]+)", re.MULTILINE
+)
+
+
+def list_personas() -> list[dict]:
+    """Return the combined persona library from project-local + global scopes."""
+    project_dir = Path.cwd() / "personas"
+    global_dir: Path | None = None
+    home = os.environ.get("HOME")
+    if home:
+        global_dir = Path(home) / ".persona-studio" / "personas"
+
+    records: list[dict] = []
+    seen_stems: set[str] = set()
+
+    for path in _glob_sorted(project_dir):
+        stem = path.stem
+        if stem in seen_stems:
+            continue
+        seen_stems.add(stem)
+        records.append(_build_record(path, scope="project"))
+
+    if global_dir is not None:
+        for path in _glob_sorted(global_dir):
+            stem = path.stem
+            if stem in seen_stems:
+                continue
+            seen_stems.add(stem)
+            records.append(_build_record(path, scope="global"))
+
+    return records
+
+
+def _glob_sorted(directory: Path) -> Iterable[Path]:
+    if not directory.exists() or not directory.is_dir():
+        return []
+    return sorted(directory.glob("*.md"))
+
+
+def _build_record(path: Path, *, scope: str) -> dict:
+    frontmatter, body = _split_frontmatter(path)
+    name = frontmatter.get("name") or path.stem
+    return {
+        "name": str(name),
+        "scope": scope,
+        "mode": _normalize_mode(frontmatter.get("mode")),
+        "role": _resolve_role(frontmatter, body),
+        "born": frontmatter.get("born_year"),
+        "hue": _hue_for(str(name)),
+    }
+
+
+def _split_frontmatter(path: Path) -> tuple[dict, str]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}, ""
+
+    match = _FRONTMATTER_RE.match(raw)
+    if match is None:
+        return {}, raw
+
+    fm_text, body = match.group(1), match.group(2)
+    try:
+        data = yaml.safe_load(fm_text)
+    except yaml.YAMLError:
+        return {}, body
+
+    if not isinstance(data, dict):
+        return {}, body
+    return data, body
+
+
+def _normalize_mode(value: object) -> str:
+    if isinstance(value, str) and value.strip().lower() == "private":
+        return "private"
+    return "public"
+
+
+def _resolve_role(frontmatter: dict, body: str) -> str:
+    primary = frontmatter.get("primary_role")
+    if isinstance(primary, str) and primary.strip():
+        return primary.strip()
+
+    match = _BACKGROUND_RE.search(body)
+    if match:
+        return match.group(1).strip()
+    return ""
+
+
+def _hue_for(name: str) -> int:
+    """Deterministic hue in [0, 360) derived from name.
+
+    Keeps avatar tint stable across reloads. MD5 is used as a
+    well-distributed hash, not for security.
+    """
+    digest = hashlib.md5(name.encode("utf-8")).hexdigest()
+    return int(digest[:8], 16) % 360

--- a/src/persona_studio/web/server.py
+++ b/src/persona_studio/web/server.py
@@ -1,0 +1,52 @@
+"""FastAPI application factory for the Phase 1 web runtime.
+
+Exposes two read-only routes and a static mount:
+
+- ``GET /api/personas`` — delegates to :func:`.personas.list_personas`.
+- ``GET /api/simulations`` — delegates to :func:`.simulations.list_simulations`.
+- ``GET /*`` (any static path) — serves files from ``<cwd>/web/`` so the
+  browser prototype loads via ``GET /hifi-v2.html``.
+
+The application is built via :func:`create_app` (factory pattern) so
+each test gets a fresh instance. This matters because the underlying
+listing helpers read the current working directory, and pytest fixtures
+use ``monkeypatch.chdir(tmp_path)`` to isolate per-test filesystem state.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
+
+from persona_studio.web.personas import list_personas
+from persona_studio.web.simulations import list_simulations
+
+
+def create_app() -> FastAPI:
+    """Build and return a FastAPI instance for the Phase 1 web runtime."""
+    app = FastAPI(
+        title="Persona Studio — Web",
+        version="0.1.0",
+        docs_url=None,
+        redoc_url=None,
+    )
+
+    @app.get("/api/personas")
+    def _get_personas() -> JSONResponse:
+        return JSONResponse(content=list_personas())
+
+    @app.get("/api/simulations")
+    def _get_simulations() -> JSONResponse:
+        return JSONResponse(content=list_simulations())
+
+    web_dir = Path.cwd() / "web"
+    if web_dir.exists():
+        app.mount(
+            "/",
+            StaticFiles(directory=str(web_dir), html=True),
+            name="web",
+        )
+
+    return app

--- a/src/persona_studio/web/simulations.py
+++ b/src/persona_studio/web/simulations.py
@@ -1,0 +1,137 @@
+"""Read-only past-simulation listing for the Phase 1 web API.
+
+Walks ``./simulations/**/*.md`` and returns transcript metadata records
+for the Results screen. The parse here is intentionally a small
+frontmatter-only implementation — it does NOT reuse
+``grounding.audit._parse_topic`` or ``_collect_avatar_quotes`` (both
+underscore-private) nor ``audit_transcript()`` (mutates files).
+
+Per-simulation score, when present, is averaged from the final column of
+the inline ``## Factual Grounding`` markdown table that
+``persona_studio.grounding.audit.render_audit_section`` emits. When the
+section is missing or malformed, ``score`` is ``None``.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import re
+from pathlib import Path
+
+import yaml
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
+_GROUNDING_SECTION_RE = re.compile(
+    r"##\s*Factual Grounding\s*\n(.*?)(?=\n##\s|\Z)", re.DOTALL
+)
+# Empty string sorts smallest → with reverse=True, undated simulations
+# land at the end (behind every dated one).
+_MISSING_SORT_KEY = ""
+
+
+def list_simulations() -> list[dict]:
+    """Return simulation records newest-first."""
+    root = Path.cwd() / "simulations"
+    if not root.exists() or not root.is_dir():
+        return []
+
+    records: list[dict] = []
+    for path in sorted(root.rglob("*.md")):
+        record = _parse_transcript(path, root)
+        if record is not None:
+            records.append(record)
+
+    records.sort(
+        key=lambda r: r.get("generated") or _MISSING_SORT_KEY, reverse=True
+    )
+    return records
+
+
+def _parse_transcript(path: Path, root: Path) -> dict | None:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    frontmatter, body = _split_frontmatter(raw)
+    if not frontmatter:
+        return None
+
+    return {
+        "id": path.relative_to(root).as_posix(),
+        "kind": _coerce_str(frontmatter.get("kind"), default=""),
+        "topic": _coerce_str(frontmatter.get("topic"), default=""),
+        "participants": _coerce_list(frontmatter.get("participants")),
+        "generated": _coerce_generated(frontmatter.get("generated")),
+        "score": _extract_average_score(body),
+    }
+
+
+def _split_frontmatter(raw: str) -> tuple[dict, str]:
+    match = _FRONTMATTER_RE.match(raw)
+    if match is None:
+        return {}, raw
+
+    fm_text, body = match.group(1), match.group(2)
+    try:
+        data = yaml.safe_load(fm_text)
+    except yaml.YAMLError:
+        return {}, body
+
+    if not isinstance(data, dict):
+        return {}, body
+    return data, body
+
+
+def _coerce_str(value: object, *, default: str) -> str:
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return default
+    return str(value)
+
+
+def _coerce_list(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(v) for v in value]
+    return []
+
+
+def _coerce_generated(value: object) -> str | None:
+    """Keep frontmatter timestamp as a string.
+
+    YAML 1.1's ``safe_load`` auto-parses ISO 8601 timestamps into
+    ``datetime`` objects. We restore the canonical ``isoformat()`` shape
+    (with the ``T`` separator) so round-tripping through the API
+    matches what the frontmatter file actually contained. Falls back to
+    ``str(value)`` for anything non-datetime and non-string.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (_dt.datetime, _dt.date)):
+        return value.isoformat()
+    return str(value)
+
+
+def _extract_average_score(body: str) -> float | None:
+    """Average the last-column (Score) values from a Factual Grounding table."""
+    section = _GROUNDING_SECTION_RE.search(body)
+    if section is None:
+        return None
+
+    scores: list[float] = []
+    for line in section.group(1).splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if not cells:
+            continue
+        try:
+            scores.append(float(cells[-1]))
+        except ValueError:
+            continue
+
+    if not scores:
+        return None
+    return sum(scores) / len(scores)

--- a/tests/web/test_api_personas.py
+++ b/tests/web/test_api_personas.py
@@ -1,0 +1,250 @@
+"""TDD Cycle 1–3: list_personas() + frontmatter tolerance.
+
+Per the Phase 1 plan, `list_personas()` globs both project-local
+`./personas/*.md` and global `$HOME/.persona-studio/personas/*.md`,
+dedupes by filename stem with project-local winning on collision, and
+returns records shaped for the web UI with defensible fallbacks.
+
+Route D in commands/studio.md (lines 116-129) is the canonical
+algorithm — this module is that prose ported to Python.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _write_persona(dir_: Path, stem: str, frontmatter: str, body: str = "") -> None:
+    dir_.mkdir(parents=True, exist_ok=True)
+    (dir_ / f"{stem}.md").write_text(
+        f"---\n{frontmatter}\n---\n{body}", encoding="utf-8"
+    )
+
+
+class TestListPersonasDualScope:
+    def test_project_and_global_both_appear(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Personas from both scopes appear in the combined result."""
+        from persona_studio.web.personas import list_personas
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "fake_home"))
+
+        _write_persona(tmp_path / "personas", "alice", "name: alice", "# Background\nAlice is local.")
+        _write_persona(
+            tmp_path / "fake_home" / ".persona-studio" / "personas",
+            "bob",
+            "name: bob",
+            "# Background\nBob is global.",
+        )
+
+        result = list_personas()
+        names = {p["name"] for p in result}
+        scopes = {p["name"]: p["scope"] for p in result}
+
+        assert names == {"alice", "bob"}
+        assert scopes["alice"] == "project"
+        assert scopes["bob"] == "global"
+
+    def test_project_priority_on_name_collision(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same filename stem in both scopes → project wins, global hidden."""
+        from persona_studio.web.personas import list_personas
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "fake_home"))
+
+        _write_persona(
+            tmp_path / "personas", "eve",
+            "name: eve\nprimary_role: project-eve",
+        )
+        _write_persona(
+            tmp_path / "fake_home" / ".persona-studio" / "personas", "eve",
+            "name: eve\nprimary_role: global-eve",
+        )
+
+        result = list_personas()
+        eves = [p for p in result if p["name"] == "eve"]
+
+        assert len(eves) == 1, "dedup failed: duplicate eve entries"
+        assert eves[0]["scope"] == "project"
+        assert eves[0]["role"] == "project-eve"
+
+    def test_empty_both_scopes_returns_empty_list(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No personas in either scope → [], not raise."""
+        from persona_studio.web.personas import list_personas
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "fake_home"))
+
+        result = list_personas()
+        assert result == []
+
+    def test_missing_directories_tolerated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Neither ./personas/ nor global ~/.persona-studio/personas/ exists."""
+        from persona_studio.web.personas import list_personas
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "nowhere"))
+        # Do NOT create any dirs.
+
+        result = list_personas()
+        assert result == []
+
+
+class TestFrontmatterTolerance:
+    def test_missing_frontmatter_no_background_uses_filename_defaults(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Persona file with neither frontmatter nor Background → empty role."""
+        from persona_studio.web.personas import list_personas
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "fake_home"))
+
+        (tmp_path / "personas").mkdir()
+        (tmp_path / "personas" / "charlie.md").write_text(
+            "Just a body, no frontmatter, no Background section.\n",
+            encoding="utf-8",
+        )
+
+        result = list_personas()
+        charlie = next(p for p in result if p["name"] == "charlie")
+        assert charlie["scope"] == "project"
+        assert charlie["role"] == ""
+        assert charlie["mode"] == "public"
+
+    def test_missing_frontmatter_with_background_uses_body(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No frontmatter but Background section exists → role from body."""
+        from persona_studio.web.personas import list_personas
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "fake_home"))
+
+        (tmp_path / "personas").mkdir()
+        (tmp_path / "personas" / "charlie.md").write_text(
+            "# Background\nJust a body, no frontmatter.\n", encoding="utf-8"
+        )
+
+        result = list_personas()
+        charlie = next(p for p in result if p["name"] == "charlie")
+        assert charlie["role"] == "Just a body, no frontmatter."
+
+    def test_malformed_yaml_does_not_raise(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Broken YAML frontmatter → no 500, frontmatter-field defaults apply.
+
+        The spec path for role is ``primary_role`` > ``# Background`` first line
+        > ``""``. A broken YAML frontmatter invalidates the first clause only;
+        the Background body parse still runs independently. This test locks
+        the NO-RAISE invariant plus the default ``mode`` fallback — those are
+        the real concerns behind "malformed YAML" tolerance. The Background
+        fallback for ``role`` is verified separately in
+        ``test_missing_frontmatter_with_background_uses_body``.
+        """
+        from persona_studio.web.personas import list_personas
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "fake_home"))
+
+        (tmp_path / "personas").mkdir()
+        # Open bracket never closed; no Background so role resolves to "".
+        (tmp_path / "personas" / "broken.md").write_text(
+            "---\nname: [\n---\ntext without a Background heading\n",
+            encoding="utf-8",
+        )
+
+        result = list_personas()  # must not raise
+        broken = next(p for p in result if p["name"] == "broken")
+        assert broken["role"] == ""
+        assert broken["mode"] == "public"
+
+    def test_primary_role_populates_role_field(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If frontmatter has `primary_role`, surface as `role`."""
+        from persona_studio.web.personas import list_personas
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "fake_home"))
+
+        _write_persona(
+            tmp_path / "personas", "dhh",
+            "name: dhh\nprimary_role: Rails creator",
+        )
+
+        result = list_personas()
+        dhh = next(p for p in result if p["name"] == "dhh")
+        assert dhh["role"] == "Rails creator"
+
+    def test_background_first_line_used_when_no_primary_role(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fall back to first line of # Background section for role."""
+        from persona_studio.web.personas import list_personas
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "fake_home"))
+
+        _write_persona(
+            tmp_path / "personas", "nn",
+            "name: nn",
+            "# Background\nFirst-line description of NN.\nSecond line should be ignored.",
+        )
+
+        result = list_personas()
+        nn = next(p for p in result if p["name"] == "nn")
+        assert nn["role"] == "First-line description of NN."
+
+    def test_hue_is_deterministic(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """hue must be stable across reloads — same name → same hue."""
+        from persona_studio.web.personas import list_personas
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "fake_home"))
+
+        _write_persona(tmp_path / "personas", "stable", "name: stable")
+
+        r1 = list_personas()
+        r2 = list_personas()
+        assert r1[0]["hue"] == r2[0]["hue"]
+        assert 0 <= r1[0]["hue"] < 360
+
+    def test_mode_defaults_to_public(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If frontmatter doesn't set mode, default to 'public'."""
+        from persona_studio.web.personas import list_personas
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "fake_home"))
+
+        _write_persona(tmp_path / "personas", "nomode", "name: nomode")
+
+        result = list_personas()
+        assert result[0]["mode"] == "public"
+
+    def test_mode_private_preserved(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persona_studio.web.personas import list_personas
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "fake_home"))
+
+        _write_persona(tmp_path / "personas", "priv", "name: priv\nmode: private")
+
+        result = list_personas()
+        assert result[0]["mode"] == "private"

--- a/tests/web/test_api_simulations.py
+++ b/tests/web/test_api_simulations.py
@@ -1,0 +1,265 @@
+"""TDD Unit 2: list_simulations() helper.
+
+Walks ``./simulations/**/*.md``, parses frontmatter plus the optional
+``## Factual Grounding`` table, returns records newest-first. Tolerates
+missing directory and malformed transcripts.
+
+Per the Phase 1 plan, this intentionally does NOT reuse
+``grounding.audit._parse_topic`` / ``_collect_avatar_quotes``. Those are
+underscore-private, and ``audit_transcript()`` mutates files. A
+frontmatter-only parser inlined here stays read-only.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+
+def _write_sim(
+    dir_: Path,
+    filename: str,
+    *,
+    kind: str = "debate",
+    topic: str = "Sample topic",
+    participants: list[str] | None = None,
+    generated: str = "2026-04-23T10:00:00+00:00",
+    body: str = "",
+    grounding_table: str = "",
+) -> None:
+    dir_.mkdir(parents=True, exist_ok=True)
+    parts = participants or ["alice", "bob"]
+    fm = dedent(
+        f"""\
+        ---
+        kind: {kind}
+        topic: {topic}
+        participants: [{", ".join(parts)}]
+        generated: {generated}
+        ---
+        """
+    )
+    (dir_ / filename).write_text(fm + body + grounding_table, encoding="utf-8")
+
+
+class TestListSimulationsBasic:
+    def test_returns_empty_when_simulations_dir_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persona_studio.web.simulations import list_simulations
+
+        monkeypatch.chdir(tmp_path)
+        # Do NOT create simulations/.
+        assert list_simulations() == []
+
+    def test_returns_empty_when_simulations_dir_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persona_studio.web.simulations import list_simulations
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "simulations").mkdir()
+        assert list_simulations() == []
+
+    def test_parses_frontmatter_fields(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persona_studio.web.simulations import list_simulations
+
+        monkeypatch.chdir(tmp_path)
+        _write_sim(
+            tmp_path / "simulations",
+            "s1.md",
+            kind="debate",
+            topic="Are design docs a waste of time?",
+            participants=["sample_private", "paul_graham"],
+            generated="2026-04-21T17:15:00+00:00",
+        )
+
+        result = list_simulations()
+        assert len(result) == 1
+        sim = result[0]
+        assert sim["kind"] == "debate"
+        assert sim["topic"] == "Are design docs a waste of time?"
+        assert sim["participants"] == ["sample_private", "paul_graham"]
+        assert sim["generated"] == "2026-04-21T17:15:00+00:00"
+
+    def test_id_is_path_relative_to_simulations(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """id should be a stable identifier derived from the file path."""
+        from persona_studio.web.simulations import list_simulations
+
+        monkeypatch.chdir(tmp_path)
+        _write_sim(tmp_path / "simulations" / "topic-slug", "2026-04-21_debate.md")
+
+        result = list_simulations()
+        assert len(result) == 1
+        # Path relative to simulations/ as identifier
+        assert result[0]["id"] == "topic-slug/2026-04-21_debate.md"
+
+    def test_walks_subdirectories_recursively(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """simulations/<topic-slug>/<ts>.md structure is the canonical layout."""
+        from persona_studio.web.simulations import list_simulations
+
+        monkeypatch.chdir(tmp_path)
+        _write_sim(tmp_path / "simulations" / "topic-a", "s1.md", topic="A")
+        _write_sim(tmp_path / "simulations" / "topic-b", "s2.md", topic="B")
+        _write_sim(tmp_path / "simulations" / "topic-a" / "iter-1", "s3.md", topic="A-iter1")
+
+        result = list_simulations()
+        topics = {s["topic"] for s in result}
+        assert topics == {"A", "B", "A-iter1"}
+
+
+class TestListSimulationsOrdering:
+    def test_returns_newest_first(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persona_studio.web.simulations import list_simulations
+
+        monkeypatch.chdir(tmp_path)
+        sim_dir = tmp_path / "simulations"
+        _write_sim(sim_dir, "old.md", topic="Old", generated="2026-01-01T00:00:00+00:00")
+        _write_sim(sim_dir, "new.md", topic="New", generated="2026-04-23T00:00:00+00:00")
+        _write_sim(sim_dir, "mid.md", topic="Mid", generated="2026-03-15T00:00:00+00:00")
+
+        result = list_simulations()
+        topics_in_order = [s["topic"] for s in result]
+        assert topics_in_order == ["New", "Mid", "Old"]
+
+    def test_missing_generated_field_sorts_last(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Transcripts without a generated timestamp sort after dated ones."""
+        from persona_studio.web.simulations import list_simulations
+
+        monkeypatch.chdir(tmp_path)
+        sim_dir = tmp_path / "simulations"
+        _write_sim(sim_dir, "dated.md", generated="2026-04-23T00:00:00+00:00")
+        # A transcript with no `generated:` field (intentionally missing)
+        (sim_dir / "no_date.md").write_text(
+            "---\nkind: debate\ntopic: Undated\nparticipants: [x]\n---\n",
+            encoding="utf-8",
+        )
+        result = list_simulations()
+        assert len(result) == 2
+        assert result[0]["topic"] != "Undated"  # dated wins
+
+
+class TestListSimulationsScoring:
+    """Parse the ## Factual Grounding table when present; otherwise score=None."""
+
+    def test_no_factual_grounding_section_score_is_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persona_studio.web.simulations import list_simulations
+
+        monkeypatch.chdir(tmp_path)
+        _write_sim(tmp_path / "simulations", "s.md", body="# Transcript\n...\n")
+
+        result = list_simulations()
+        assert result[0]["score"] is None
+
+    def test_factual_grounding_average_across_avatars(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persona_studio.web.simulations import list_simulations
+
+        monkeypatch.chdir(tmp_path)
+        table = dedent(
+            """
+
+            ## Factual Grounding
+
+            | Avatar | Total | Supported | Unsupported | Unverifiable | External-verified | External-unverified | Score |
+            | --- | --- | --- | --- | --- | --- | --- | --- |
+            | paul_graham | 6 | 0 | 0 | 4 | 2 | 0 | 3.33 |
+            | sample_private | 5 | 5 | 0 | 0 | 0 | 0 | 10.00 |
+            """
+        )
+        _write_sim(tmp_path / "simulations", "s.md", grounding_table=table)
+
+        result = list_simulations()
+        # Average of 3.33 and 10.00 = 6.665 — implementation must round or truncate; accept either.
+        assert 6.5 <= result[0]["score"] <= 6.7
+
+    def test_factual_grounding_single_avatar_score(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persona_studio.web.simulations import list_simulations
+
+        monkeypatch.chdir(tmp_path)
+        table = dedent(
+            """
+
+            ## Factual Grounding
+
+            | Avatar | Total | Supported | Unsupported | Unverifiable | External-verified | External-unverified | Score |
+            | --- | --- | --- | --- | --- | --- | --- | --- |
+            | alice | 3 | 3 | 0 | 0 | 0 | 0 | 10.00 |
+            """
+        )
+        _write_sim(tmp_path / "simulations", "s.md", grounding_table=table)
+
+        result = list_simulations()
+        assert result[0]["score"] == 10.0
+
+    def test_malformed_grounding_table_score_is_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Broken table rows → don't raise, score=None."""
+        from persona_studio.web.simulations import list_simulations
+
+        monkeypatch.chdir(tmp_path)
+        bad = dedent(
+            """
+
+            ## Factual Grounding
+
+            something went wrong, no table here
+            """
+        )
+        _write_sim(tmp_path / "simulations", "s.md", grounding_table=bad)
+
+        result = list_simulations()
+        assert result[0]["score"] is None
+
+
+class TestListSimulationsTolerance:
+    def test_unreadable_file_skipped_not_raise(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A transcript with no frontmatter at all should not crash the list."""
+        from persona_studio.web.simulations import list_simulations
+
+        monkeypatch.chdir(tmp_path)
+        sim_dir = tmp_path / "simulations"
+        sim_dir.mkdir()
+        (sim_dir / "no_frontmatter.md").write_text(
+            "Just prose, no frontmatter.\n", encoding="utf-8"
+        )
+        _write_sim(sim_dir, "good.md", topic="valid")
+
+        result = list_simulations()
+        topics = {s["topic"] for s in result}
+        assert "valid" in topics
+        # no_frontmatter.md either skipped or included with filename-stem fallback —
+        # either is acceptable; what matters is no exception.
+
+    def test_malformed_yaml_frontmatter_does_not_raise(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persona_studio.web.simulations import list_simulations
+
+        monkeypatch.chdir(tmp_path)
+        sim_dir = tmp_path / "simulations"
+        sim_dir.mkdir()
+        (sim_dir / "broken.md").write_text(
+            "---\nkind: [\n---\nBody\n", encoding="utf-8"
+        )
+        # Must not raise; result may or may not include broken.md.
+        list_simulations()

--- a/tests/web/test_main_entrypoint.py
+++ b/tests/web/test_main_entrypoint.py
@@ -1,0 +1,148 @@
+"""TDD Unit 5: entrypoint boot via `python -m persona_studio.web`.
+
+End-to-end boot test: spawn the module as a subprocess, poll the HTTP
+endpoint until it responds, assert 200 + expected routes. Slower than
+the in-process TestClient tests (≈1-2 s each) but verifies the whole
+uvicorn + FastAPI + argparse chain the same way a user's shell would.
+"""
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+
+def _find_free_port() -> int:
+    """Return an ephemeral port the OS confirms is unused right now."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@contextmanager
+def _server(port: int, cwd: Path) -> Iterator[subprocess.Popen]:
+    """Spawn the entrypoint and tear it down cleanly after the test."""
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "persona_studio.web",
+            "--port",
+            str(port),
+            "--host",
+            "127.0.0.1",
+            "--no-browser",
+        ],
+        cwd=str(cwd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={**os.environ, "PYTHONUNBUFFERED": "1"},
+        # New process group so Ctrl-C semantics work the same as a user shell.
+        start_new_session=True,
+    )
+    try:
+        _wait_for_ready(port, proc, timeout=8.0)
+        yield proc
+    finally:
+        # Teardown: SIGTERM the process group, drain output.
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+
+def _wait_for_ready(port: int, proc: subprocess.Popen, timeout: float) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            stdout = proc.stdout.read().decode("utf-8", errors="replace") if proc.stdout else ""
+            stderr = proc.stderr.read().decode("utf-8", errors="replace") if proc.stderr else ""
+            raise RuntimeError(
+                f"server exited early (code {proc.returncode})\n"
+                f"STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+            )
+        try:
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=0.5)
+            conn.request("GET", "/api/personas")
+            resp = conn.getresponse()
+            if resp.status == 200:
+                resp.read()
+                return
+        except (ConnectionRefusedError, TimeoutError, OSError):
+            pass
+        time.sleep(0.1)
+    raise TimeoutError(f"server did not become ready on port {port} within {timeout}s")
+
+
+@pytest.fixture
+def repo_root() -> Path:
+    """The persona-studio repo root — has web/ and personas/ at known paths."""
+    return Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.slow
+class TestEntrypointBoot:
+    def test_boots_and_serves_api_personas(self, repo_root: Path) -> None:
+        port = _find_free_port()
+        with _server(port, cwd=repo_root):
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+            conn.request("GET", "/api/personas")
+            resp = conn.getresponse()
+            assert resp.status == 200
+            body = resp.read().decode("utf-8")
+            data = json.loads(body)
+            assert isinstance(data, list)
+            # Repo ships 4 public samples — sanity check at least one.
+            names = {p["name"] for p in data}
+            assert len(names) >= 1, f"expected at least one persona, got {data!r}"
+
+    def test_serves_hifi_v2_html(self, repo_root: Path) -> None:
+        port = _find_free_port()
+        with _server(port, cwd=repo_root):
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+            conn.request("GET", "/hifi-v2.html")
+            resp = conn.getresponse()
+            assert resp.status == 200
+            assert "text/html" in resp.getheader("content-type", "")
+
+    def test_serves_api_simulations(self, repo_root: Path) -> None:
+        port = _find_free_port()
+        with _server(port, cwd=repo_root):
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+            conn.request("GET", "/api/simulations")
+            resp = conn.getresponse()
+            assert resp.status == 200
+            data = json.loads(resp.read().decode("utf-8"))
+            assert isinstance(data, list)
+
+
+class TestArgparseShape:
+    """The entrypoint accepts --port, --host, --no-browser (plan contract)."""
+
+    def test_no_browser_flag_does_not_open_browser(self, repo_root: Path) -> None:
+        """--no-browser must suppress webbrowser.open; without it we'd pop up a window during the test."""
+        port = _find_free_port()
+        with _server(port, cwd=repo_root) as proc:
+            # If the test got here without webbrowser complaints (and the
+            # browser didn't actually open, which we can't assert directly),
+            # the flag is respected. Absent this test the fixture would
+            # blindly open the user's default browser mid-test run — a
+            # regression guard for future flag renames.
+            assert proc.poll() is None  # still running

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -1,0 +1,143 @@
+"""TDD Unit 3-5: FastAPI server + REST endpoints.
+
+Phase 1's server exposes two read-only routes:
+
+- ``GET /api/personas`` — from ``persona_studio.web.personas.list_personas``.
+- ``GET /api/simulations`` — from ``persona_studio.web.simulations.list_simulations``.
+
+Plus a static mount at ``/`` serving the ``web/`` directory so the
+browser prototype loads at ``GET /hifi-v2.html``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def app():
+    """Build the FastAPI app fresh per test to avoid CWD leaking between tests."""
+    from persona_studio.web.server import create_app
+
+    return create_app()
+
+
+@pytest.fixture
+def client(app):
+    from fastapi.testclient import TestClient
+
+    return TestClient(app)
+
+
+class TestApiPersonas:
+    def test_get_personas_returns_json_list(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persona_studio.web.server import create_app
+        from fastapi.testclient import TestClient
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "fake_home"))
+
+        (tmp_path / "personas").mkdir()
+        (tmp_path / "personas" / "alice.md").write_text(
+            "---\nname: alice\n---\n# Background\nAlice.\n", encoding="utf-8"
+        )
+
+        client = TestClient(create_app())
+        response = client.get("/api/personas")
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert any(p["name"] == "alice" for p in data)
+
+    def test_get_personas_empty_library_returns_empty_list(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persona_studio.web.server import create_app
+        from fastapi.testclient import TestClient
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "fake_home"))
+
+        client = TestClient(create_app())
+        response = client.get("/api/personas")
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+class TestApiSimulations:
+    def test_get_simulations_returns_json_list(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persona_studio.web.server import create_app
+        from fastapi.testclient import TestClient
+
+        monkeypatch.chdir(tmp_path)
+        sim_dir = tmp_path / "simulations"
+        sim_dir.mkdir()
+        (sim_dir / "s.md").write_text(
+            "---\nkind: debate\ntopic: X\nparticipants: [a]\n"
+            "generated: 2026-04-23T10:00:00+00:00\n---\nbody\n",
+            encoding="utf-8",
+        )
+
+        client = TestClient(create_app())
+        response = client.get("/api/simulations")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["topic"] == "X"
+
+    def test_get_simulations_missing_dir_returns_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persona_studio.web.server import create_app
+        from fastapi.testclient import TestClient
+
+        monkeypatch.chdir(tmp_path)
+        client = TestClient(create_app())
+        response = client.get("/api/simulations")
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+class TestStaticMount:
+    def test_serves_hifi_v2_html(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The static mount at / serves files from web/.
+
+        We run from the actual repo cwd (not tmp_path) because the static
+        mount points at ``<cwd>/web/`` and we need the real bundle.
+        """
+        from persona_studio.web.server import create_app
+        from fastapi.testclient import TestClient
+
+        # cwd stays at the repo root so the StaticFiles mount finds web/
+        client = TestClient(create_app())
+        response = client.get("/hifi-v2.html")
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+        assert "Persona Studio" in response.text
+
+    def test_serves_hifi_library_jsx(self) -> None:
+        from persona_studio.web.server import create_app
+        from fastapi.testclient import TestClient
+
+        client = TestClient(create_app())
+        response = client.get("/hifi-library.jsx")
+        assert response.status_code == 200
+
+
+class TestCreateApp:
+    def test_create_app_returns_distinct_instances(self) -> None:
+        """create_app() should return a fresh FastAPI instance per call.
+
+        This matters for tests that need to reset state; reusing a global
+        app would cause CWD-dependent fixtures to leak.
+        """
+        from persona_studio.web.server import create_app
+
+        a = create_app()
+        b = create_app()
+        assert a is not b

--- a/tests/web/test_web_prototype.py
+++ b/tests/web/test_web_prototype.py
@@ -245,3 +245,45 @@ def test_library_detail_hotspot_disabled_in_phase_1() -> None:
         "Library→Detail hotspot is still active — Phase 1 must disable it "
         "(UX regression: clicking a real persona card lands on mock PG detail)"
     )
+
+
+_ACTIVE_HIFI_V2_JSX = [
+    "hifi-home.jsx",
+    "hifi-library.jsx",
+    "hifi-v2-screens.jsx",
+    "hifi-live-animated.jsx",
+    "hifi-live.jsx",
+    "hifi-results.jsx",
+]
+
+
+def test_designer_handoff_notes_removed_from_active_screens() -> None:
+    """Designer-to-engineer handwritten margin notes (``<Note>`` elements
+    carrying commentary like "one statement. one breath of air. like
+    apple.com" or "portraits as big as the names") must NOT ship in the
+    active hifi-v2 flow.
+
+    These were handoff artifacts from claude.ai/design explaining design
+    intent to the implementing engineer. They look like unfinished
+    scaffolding to end users and must not appear in production UI.
+
+    Wireframes (``wireframes-screens.jsx``) are intentionally excluded —
+    that file is a historical exploration artifact kept for reference,
+    not reachable from ``hifi-v2.html``.
+    """
+    offenders: list[str] = []
+    for filename in _ACTIVE_HIFI_V2_JSX:
+        path = WEB / filename
+        if not path.exists():
+            continue
+        content = path.read_text(encoding="utf-8")
+        # Count both <Note ...> and <Note>; a false positive on a
+        # variable named "Notes" is unlikely here — JSX component
+        # usage starts with a capital N followed by word-boundary.
+        hits = re.findall(r"<Note[\s>]", content)
+        if hits:
+            offenders.append(f"{filename}: {len(hits)} <Note> tag(s)")
+    assert not offenders, (
+        "Designer handoff notes still present in active hifi-v2 screens:\n  "
+        + "\n  ".join(offenders)
+    )

--- a/tests/web/test_web_prototype.py
+++ b/tests/web/test_web_prototype.py
@@ -202,3 +202,46 @@ def test_auth_screens_removed_from_flow_but_kept_in_source() -> None:
     assert (WEB / "hifi-auth-screens.jsx").is_file(), (
         "hifi-auth-screens.jsx source removed — should stay as dormant scaffolding"
     )
+
+
+# --- Phase 1 fetch-wiring regression guards -----------------------------------
+
+
+def test_hifi_library_fetches_api_personas() -> None:
+    """LibraryA must fetch real personas from /api/personas (Phase 1 wiring)."""
+    content = (WEB / "hifi-library.jsx").read_text(encoding="utf-8")
+    assert "fetch('/api/personas')" in content, (
+        "hifi-library.jsx no longer calls fetch('/api/personas') — Phase 1 wiring regressed"
+    )
+    # Must still tolerate offline: the useEffect should keep the PEOPLE
+    # fallback intact (i.e. the `P` local from window.HF still appears).
+    assert " P.map" not in content or "(people ?? P).map" in content or "(people || P).map" in content, (
+        "LibraryA should render from fetched `people` with fallback to mock `P`"
+    )
+
+
+def test_hifi_results_fetches_api_simulations() -> None:
+    """ResultsA must fetch real past simulations from /api/simulations."""
+    content = (WEB / "hifi-results.jsx").read_text(encoding="utf-8")
+    assert "fetch('/api/simulations')" in content, (
+        "hifi-results.jsx no longer calls fetch('/api/simulations') — Phase 1 wiring regressed"
+    )
+
+
+def test_library_detail_hotspot_disabled_in_phase_1() -> None:
+    """Clicking a real persona card must not land on the mock Paul Graham
+    detail screen. Phase 1 disables the Library→Detail hotspot; Phase 2
+    ships a real detail page."""
+    content = (WEB / "hifi-v2.html").read_text(encoding="utf-8")
+    # Find the HOTSPOTS.library block and assert no uncommented `to: 'detail'`
+    lib_block_match = re.search(
+        r"library:\s*\[(.*?)\]", content, re.DOTALL
+    )
+    assert lib_block_match, "HOTSPOTS.library block missing"
+    lib_block = lib_block_match.group(1)
+    # Strip // line comments before checking
+    stripped = re.sub(r"//[^\n]*", "", lib_block)
+    assert "to: 'detail'" not in stripped, (
+        "Library→Detail hotspot is still active — Phase 1 must disable it "
+        "(UX regression: clicking a real persona card lands on mock PG detail)"
+    )

--- a/tests/web/test_web_prototype.py
+++ b/tests/web/test_web_prototype.py
@@ -257,6 +257,87 @@ _ACTIVE_HIFI_V2_JSX = [
 ]
 
 
+# --- Production shell (index.html) --------------------------------------------
+#
+# `hifi-v2.html` is a DESIGN-REVIEW wrapper with prototype chrome (HI-FI v2
+# badge, 9-pill screen navigation, fake Mac browser frame around the actual
+# app). Users running `python -m persona_studio.web` should land on the REAL
+# app — no prototype scaffolding. These tests lock in the difference.
+
+
+def test_index_html_exists_as_production_shell() -> None:
+    """Production entry at web/index.html — served at / via StaticFiles html=True."""
+    assert (WEB / "index.html").is_file(), (
+        "web/index.html missing — this is the production shell that renders "
+        "one screen at a time via hash routing, without hifi-v2's prototype chrome"
+    )
+
+
+def test_index_html_has_no_prototype_chrome_markers() -> None:
+    """index.html must NOT contain the hifi-v2 wrapper scaffolding."""
+    content = (WEB / "index.html").read_text(encoding="utf-8")
+    forbidden = [
+        "HI-FI v2 · CLICKABLE",      # top badge
+        "OSS · ELv2",                 # license chip (design-review only)
+        "GUEST MODE · LOCAL ONLY",    # status pill
+        "const SCREENS = [",          # 9-pill nav definition
+        "HAPPY PATH",                 # flow-map footer
+        "navpill",                    # prototype nav pill class
+    ]
+    offenders = [marker for marker in forbidden if marker in content]
+    assert not offenders, (
+        "index.html contains hifi-v2 prototype chrome markers; this should be "
+        "a clean production shell. Found: " + ", ".join(offenders)
+    )
+
+
+def test_index_html_uses_hash_routing() -> None:
+    """Navigation between screens uses URL hash so no SPA framework / build is needed."""
+    content = (WEB / "index.html").read_text(encoding="utf-8")
+    # Either hashchange event listener or a window.location.hash read must exist
+    has_hash_read = "location.hash" in content or "window.location.hash" in content
+    has_hash_listener = "hashchange" in content
+    assert has_hash_read and has_hash_listener, (
+        "index.html must implement hash-based routing: read window.location.hash "
+        "to pick the initial screen + listen to 'hashchange' to re-render"
+    )
+
+
+def test_index_html_strips_fake_browser_chrome() -> None:
+    """The fake Mac <Browser> chrome inside each screen must be overridden.
+
+    Each screen component wraps itself in <Browser url="localhost:7777">
+    (defined in hifi-atoms.jsx) which renders a fake red/yellow/green traffic
+    lights + URL bar. In a real browser that's double chrome. index.html
+    monkey-patches window.HF.Browser to a passthrough so screens render
+    cleanly at full viewport height.
+    """
+    content = (WEB / "index.html").read_text(encoding="utf-8")
+    # The override should mention HF.Browser on the left-hand side of an
+    # assignment. Regex captures `window.HF.Browser =` or `HF.Browser =`.
+    assert re.search(r"(?:window\.)?HF\.Browser\s*=", content), (
+        "index.html must replace window.HF.Browser with a passthrough "
+        "wrapper to strip the fake Mac-style browser chrome from each screen"
+    )
+
+
+def test_main_entrypoint_opens_index_not_hifi_v2() -> None:
+    """`python -m persona_studio.web` should default to the production shell."""
+    src_main = REPO / "src" / "persona_studio" / "web" / "__main__.py"
+    content = src_main.read_text(encoding="utf-8")
+    # Strip comments so mentions like "# design-review at /hifi-v2.html" in
+    # a docblock don't false-trigger. We check actual code lines.
+    code_only = "\n".join(
+        line for line in content.splitlines() if not line.strip().startswith("#")
+    )
+    # The URL f-string that gets passed to webbrowser.open should NOT point
+    # at hifi-v2.html. It should hit / (StaticFiles html=True → index.html).
+    assert "/hifi-v2.html" not in code_only, (
+        "__main__.py still opens /hifi-v2.html by default — should now land "
+        "on / (production shell via index.html)"
+    )
+
+
 def test_designer_handoff_notes_removed_from_active_screens() -> None:
     """Designer-to-engineer handwritten margin notes (``<Note>`` elements
     carrying commentary like "one statement. one breath of air. like

--- a/web/hifi-home.jsx
+++ b/web/hifi-home.jsx
@@ -81,11 +81,7 @@
             </div>
           </div>
         </div>
-
-        <Note top={140} right={64} rot={4} w={170} arrow>
-          one statement.<br/>one breath of air.<br/>like apple.com
-        </Note>
-      </Browser>
+</Browser>
     );
   }
 
@@ -157,10 +153,7 @@
             </div>
           </div>
         </div>
-        <Note top={44} right={28} rot={-3} w={140}>
-          real faces in<br/>real light.<br/>feels warm.
-        </Note>
-      </Browser>
+</Browser>
     );
   }
 
@@ -227,10 +220,7 @@
             </div>
           </div>
         </div>
-        <Note top={60} right={40} rot={3} w={150} arrow>
-          dark variant.<br/>engineers will<br/>live in ⌘K.
-        </Note>
-      </Browser>
+</Browser>
     );
   }
 

--- a/web/hifi-library.jsx
+++ b/web/hifi-library.jsx
@@ -272,10 +272,7 @@
           </div>
           {importOpen && <ImportModal onClose={() => setImportOpen(false)}/>}
         </div>
-        <Note top={70} right={40} rot={3} w={140} arrow>
-          portraits as<br/>big as the names.<br/>people first.
-        </Note>
-      </Browser>
+</Browser>
     );
   }
 
@@ -314,10 +311,7 @@
             <Kalam size={14} color={T.mute}>or drag a folder here to build one automatically</Kalam>
           </div>
         </div>
-        <Note top={50} right={40} rot={-3} w={150}>
-          editorial / museum.<br/>risky. memorable.
-        </Note>
-      </Browser>
+</Browser>
     );
   }
 

--- a/web/hifi-library.jsx
+++ b/web/hifi-library.jsx
@@ -2,7 +2,7 @@
 
 (function(){
   const { tokens: T, PEOPLE: P, InitialsAv: PhotoAv, AppNav, Browser, Note, Kalam, Mono, Display, Btn, Eyebrow, hueBg, hueSoft, hueDeep } = window.HF;
-  const { useState } = React;
+  const { useState, useEffect } = React;
 
   // ── Import modal ──────────────────────────────────────────────────────────
   // Three ingestion paths: URL (blogs, feeds), File (txt/md/pdf/chat export),
@@ -207,6 +207,18 @@
   // A · EDITORIAL GRID — feels like a masthead of contributors
   function LibraryA(){
     const [importOpen, setImportOpen] = useState(false);
+    // Phase 1 wiring: fetch real personas from the local backend. On
+    // failure (server not running, fetch blocked, etc.) we fall through
+    // to `P` (window.HF.PEOPLE mock) so the screen still renders —
+    // offline viewers and the static prototype preview keep working.
+    const [people, setPeople] = useState(null);
+    useEffect(() => {
+      fetch('/api/personas')
+        .then(r => r.ok ? r.json() : Promise.reject(r.status))
+        .then(data => Array.isArray(data) ? setPeople(data) : setPeople([]))
+        .catch(() => setPeople(null));
+    }, []);
+    const list = (people !== null && people.length > 0) ? people : P;
     return (
       <Browser>
         <AppNav active="library"/>
@@ -229,8 +241,8 @@
           </div>
 
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 20 }}>
-            {P.map((p, i) => (
-              <div key={p.id} style={{ background: '#fff', borderRadius: 18, overflow: 'hidden', border: `1px solid ${T.hair}` }}>
+            {list.map((p, i) => (
+              <div key={p.id || p.name} style={{ background: '#fff', borderRadius: 18, overflow: 'hidden', border: `1px solid ${T.hair}` }}>
                 {/* Portrait header */}
                 <div style={{ position: 'relative', height: 220, background: `linear-gradient(180deg, ${hueSoft(p.hue)} 0%, ${hueBg(p.hue)}33 100%)`, display: 'flex', alignItems: 'flex-end', justifyContent: 'center', paddingBottom: 16 }}>
                   <PhotoAv p={p} size={130}/>
@@ -244,7 +256,7 @@
                   <div style={{ fontFamily: T.fDisplay, fontSize: 22, fontWeight: 400, letterSpacing: -0.5, lineHeight: 1.1 }}>{p.name}</div>
                   <div style={{ fontSize: 12, color: T.mute, marginTop: 4 }}>{p.role}</div>
                   <div style={{ marginTop: 14, paddingTop: 14, borderTop: `1px solid ${T.hair}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                    <Mono size={10}>b.{p.born} · {p.corpus}</Mono>
+                    <Mono size={10}>{p.born ? `b.${p.born}` : ''}{p.born && p.corpus ? ' · ' : ''}{p.corpus || ''}</Mono>
                     <div style={{ fontSize: 13, color: T.accent }}>→</div>
                   </div>
                 </div>

--- a/web/hifi-live.jsx
+++ b/web/hifi-live.jsx
@@ -105,10 +105,7 @@
             <div><Mono size={10}>MODEL</Mono> <Mono size={11} color="#fff">sonnet-4.5</Mono></div>
           </div>
         </div>
-        <Note top={18} right={40} rot={2} w={150} arrow>
-          closest to tmux.<br/>still legible on<br/>a laptop screen.
-        </Note>
-      </Browser>
+</Browser>
     );
   }
 
@@ -201,10 +198,7 @@
             </div>
           </div>
         </div>
-        <Note top={90} right={410} rot={-3} w={140} arrow>
-          spatial metaphor.<br/>you feel who's<br/>talking to whom.
-        </Note>
-      </Browser>
+</Browser>
     );
   }
 
@@ -287,10 +281,7 @@
             </div>
           </div>
         </div>
-        <Note top={120} right={28} rot={3} w={150}>
-          readable,<br/>quotable.<br/>feels editorial.
-        </Note>
-      </Browser>
+</Browser>
     );
   }
 

--- a/web/hifi-results.jsx
+++ b/web/hifi-results.jsx
@@ -173,10 +173,7 @@
             </div>
           </div>
         </div>
-        <Note top={80} right={40} rot={3} w={140}>
-          score ring →<br/>celebratory, like<br/>closing rings.
-        </Note>
-      </Browser>
+</Browser>
     );
   }
 
@@ -243,10 +240,7 @@
             </div>
           </div>
         </div>
-        <Note top={80} right={40} rot={-3} w={130}>
-          reads like a<br/>New Yorker profile<br/>of the argument.
-        </Note>
-      </Browser>
+</Browser>
     );
   }
 
@@ -314,10 +308,7 @@
             </div>
           </div>
         </div>
-        <Note top={40} right={30} rot={2} w={150} arrow>
-          the "climb" is<br/>the story. frame<br/>it that way.
-        </Note>
-      </Browser>
+</Browser>
     );
   }
 

--- a/web/hifi-results.jsx
+++ b/web/hifi-results.jsx
@@ -2,6 +2,7 @@
 
 (function(){
   const { tokens: T, PEOPLE: P, InitialsAv: PhotoAv, AppNav, Browser, Note, Kalam, Mono, RalphRing, Btn, Eyebrow, hueBg, hueSoft, hueDeep } = window.HF;
+  const { useState, useEffect } = React;
 
   // Ralph trajectory — shows iteration-over-iteration improvement
   const RalphTrajectory = ({ scores = [5.2, 6.4, 8.1], target = 7, width = 420, height = 140 }) => {
@@ -61,32 +62,55 @@
 
   // A · SCORECARD HERO — celebrate the result
   function ResultsA(){
-    const criteria = [
+    // Phase 1 wiring: fetch the list of past simulations and overlay
+    // the newest one's topic + score onto the hero. The criteria /
+    // trajectory / transcript preview below stay mock for this phase —
+    // per-simulation detail needs /api/simulations/{id} which lands in
+    // Phase 2. On empty library or fetch failure we fall through to
+    // the original "Mobile vs web first" mock so offline viewers still
+    // see a complete-looking screen.
+    const [latest, setLatest] = useState(null);  // null = not-yet-fetched
+    useEffect(() => {
+      fetch('/api/simulations')
+        .then(r => r.ok ? r.json() : Promise.reject(r.status))
+        .then(data => setLatest(Array.isArray(data) && data.length > 0 ? data[0] : null))
+        .catch(() => setLatest(null));
+    }, []);
+
+    const mockCriteria = [
       { label: 'Clarity',          score: 8.4, target: 7 },
       { label: 'Disagreement',     score: 8.9, target: 7 },
       { label: 'Evidence cited',   score: 7.6, target: 7 },
       { label: 'Resolution',       score: 7.2, target: 7 },
       { label: 'Voice fidelity',   score: 8.8, target: 7 },
     ];
+    const criteria = mockCriteria;  // real criteria arrive in Phase 2
+
+    const title = latest?.topic ?? 'Mobile vs web first';
+    const subtitle = latest ? '' : 'in 2026?';
+    const heroScore = (latest && typeof latest.score === 'number') ? latest.score : 8.1;
+    const heroEyebrow = latest
+      ? `● ${String(latest.kind || 'simulation').toUpperCase()} · ${latest.participants?.length || 0} VOICES`
+      : '● RALPH PASSED · ITER 3 OF 3';
+
     return (
       <Browser url="localhost:7777/sim/20260421T1404.../results">
         <AppNav active="results"/>
         <div style={{ flex: 1, overflow: 'auto', padding: '48px 80px' }}>
           <div style={{ display: 'flex', alignItems: 'baseline', gap: 16, marginBottom: 6 }}>
-            <Mono color={T.mute}>← simulation · 20260421T1404</Mono>
+            <Mono color={T.mute}>← simulation · {latest?.id || '20260421T1404'}</Mono>
           </div>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 220px', gap: 48, alignItems: 'flex-end', marginBottom: 40 }}>
             <div>
-              <Eyebrow color={T.cool}>● RALPH PASSED · ITER 3 OF 3</Eyebrow>
+              <Eyebrow color={T.cool}>{heroEyebrow}</Eyebrow>
               <div style={{ fontFamily: T.fDisplay, fontWeight: 400, fontSize: 56, letterSpacing: -1.8, lineHeight: 1.05, marginTop: 14 }}>
-                Mobile vs web first<br/>
-                <span style={{ fontStyle: 'italic', fontWeight: 300 }}>in 2026?</span>
+                {title}{subtitle && <><br/><span style={{ fontStyle: 'italic', fontWeight: 300 }}>{subtitle}</span></>}
               </div>
               <div style={{ fontSize: 15, color: T.mute, marginTop: 14, maxWidth: 560, lineHeight: 1.5 }}>
                 Three rounds. One conclusion: start with the web because distribution compounds and friction is lowest — unless your specific user's touchpoint is mobile-only.
               </div>
             </div>
-            <RalphRing score={8.1} target={7} size={180}/>
+            <RalphRing score={heroScore} target={7} size={180}/>
           </div>
 
           <div style={{ display: 'grid', gridTemplateColumns: '1.4fr 1fr', gap: 24, marginBottom: 40 }}>

--- a/web/hifi-v2-screens.jsx
+++ b/web/hifi-v2-screens.jsx
@@ -120,9 +120,7 @@
               <span style={{ color: T.accent, fontSize: 16 }}>⚠</span>
               <div>Celebrity avatars never impersonate. You'll review and approve the generated profile before it can be used.</div>
             </div>
-
-            <Note top={40} right={-60} rot={-2} w={150}>upload experience<br/>is the new<br/>iTunes CD-rip.</Note>
-          </div>
+</div>
         </div>
       </Browser>
     );

--- a/web/hifi-v2.html
+++ b/web/hifi-v2.html
@@ -91,7 +91,11 @@
       library: [
         { top: 0, left: 0, w: '100%', h: 56, to: '__nav', title: 'Top nav' }, // handled by nav bar below
         { top: 160, right: 80, w: 140, h: 40, to: 'create', title: '+ New avatar' },
-        { top: 240, left: 72, w: 240, h: 340, to: 'detail', title: 'Open Paul Graham' },
+        // Phase 1: Library→Detail hotspot disabled — clicking a real persona
+        // card would land on the mock Paul Graham detail screen, which is
+        // jarring once /api/personas serves live data. Phase 2 will ship a
+        // real detail page keyed off /api/personas/{name} and re-enable this.
+        // { top: 240, left: 72, w: 240, h: 340, to: 'detail', title: 'Open Paul Graham' },
       ],
       detail:  [
         { top: 500, left: 72, w: 300, h: 50, to: 'setup', title: 'Start simulation →' },

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>Persona Studio</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,500;1,9..144,300;1,9..144,400&family=Kalam:wght@300;400;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+<style>
+  html, body { margin: 0; padding: 0; background: #fbfaf7; font-family: 'Inter', -apple-system, system-ui, sans-serif; -webkit-font-smoothing: antialiased; min-height: 100vh; height: 100%; }
+  #root { height: 100vh; }
+  * { box-sizing: border-box; }
+  @keyframes blink { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0; } }
+  @keyframes ring { 0% { transform: scale(1); opacity: .8; } 100% { transform: scale(1.3); opacity: 0; } }
+  @keyframes fadeUp { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+  .screen { animation: fadeUp .25s cubic-bezier(.2,.7,.3,1); height: 100%; }
+</style>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+</head>
+<body>
+<div id="root"></div>
+
+<script type="text/babel" src="hifi-atoms.jsx"></script>
+<script type="text/babel" src="hifi-home.jsx"></script>
+<script type="text/babel" src="hifi-library.jsx"></script>
+<script type="text/babel" src="hifi-live.jsx"></script>
+<script type="text/babel" src="hifi-results.jsx"></script>
+<script type="text/babel" src="hifi-v2-screens.jsx"></script>
+<script type="text/babel" src="hifi-live-animated.jsx"></script>
+<script type="text/babel" src="hifi-auth-screens.jsx"></script>
+
+<script type="text/babel">
+  // Production shell — renders one screen at a time via hash routing.
+  // No prototype chrome (no HI-FI badge, no 9-pill nav, no "happy path"
+  // footer). Each screen's fake Mac-window <Browser> wrapper is also
+  // stripped via a window.HF.Browser monkey-patch so the UI occupies the
+  // full viewport like a real app.
+  const { useState, useEffect } = React;
+
+  // Replace the prototype Browser chrome with a passthrough container.
+  // Screens still call <Browser url="…" dark={…}>...</Browser>; the url
+  // prop is ignored because the real browser's address bar shows it.
+  window.HF.Browser = ({ children, dark = false }) => (
+    <div style={{
+      height: '100%',
+      background: dark ? window.HF.tokens.ink : window.HF.tokens.paper,
+      display: 'flex',
+      flexDirection: 'column',
+      overflow: 'hidden',
+      fontFamily: window.HF.tokens.fSans,
+      color: dark ? '#fff' : window.HF.tokens.ink,
+    }}>
+      {children}
+    </div>
+  );
+
+  // Route → screen component. Sets of screens the app actually exposes:
+  // the AppNav inside each screen has Home / Library / New / Simulate /
+  // Results tabs, so those five are first-class routes. Detail / Settings
+  // / Cloud are reachable from hotspots or Settings nav once Phase 2+
+  // wire them up; Phase 1 keeps them routable but mock.
+  const ROUTES = {
+    home:     () => <window.HF_Home.HomeA/>,
+    library:  () => <window.HF_Library.LibraryA/>,
+    detail:   () => <window.HF_V2.DetailScreen onNav={navigate}/>,
+    create:   () => <window.HF_V2.CreateScreen onNav={navigate}/>,
+    new:      () => <window.HF_V2.CreateScreen onNav={navigate}/>,  // alias
+    setup:    () => <window.HF_V2.SetupScreen onNav={navigate}/>,
+    simulate: () => <window.HF_V2.SetupScreen onNav={navigate}/>,   // alias
+    live:     () => <window.HF_LiveAnimated.LiveBAnimated/>,
+    results:  () => <window.HF_Results.ResultsA/>,
+    settings: () => <window.HF_Auth.SettingsScreen onNav={navigate}/>,
+  };
+  const DEFAULT_ROUTE = 'home';
+
+  function navigate(route) {
+    // Programmatic navigation: update hash, which fires 'hashchange' and
+    // re-renders. Used by screen onNav props (e.g. CreateScreen "next" CTA).
+    window.location.hash = route;
+  }
+
+  function readHash() {
+    const raw = (window.location.hash || '').replace(/^#\/?/, '');
+    return ROUTES[raw] ? raw : DEFAULT_ROUTE;
+  }
+
+  function App() {
+    const [route, setRoute] = useState(readHash);
+    useEffect(() => {
+      const onHash = () => setRoute(readHash());
+      window.addEventListener('hashchange', onHash);
+      return () => window.removeEventListener('hashchange', onHash);
+    }, []);
+    const render = ROUTES[route] || ROUTES[DEFAULT_ROUTE];
+    return <div className="screen" key={route}>{render()}</div>;
+  }
+
+  ReactDOM.createRoot(document.getElementById('root')).render(<App/>);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Phase 1 of the 4-phase **terminal → browser** migration approved in [plan file](/Users/jhbaek/.claude/plans/fuzzy-cuddling-reddy.md) and refined via Ultraplan. This PR boots a local FastAPI server, serves the existing `web/` prototype, and wires the **two read-only screens** (Library, Results) to real data from the user's persona library and past simulation transcripts.

Everything else — new persona creation, live simulation, team mode — still flows through the existing slash commands. The TUI stays default; users opt into the browser UI via a new menu item.

## TDD discipline

Per user directive (2026-04-23) and the refined plan: **non-negotiable TDD**. Every commit is a red→green pair, tests authored and demonstrably failing BEFORE the implementation. Six commits in this PR, each a complete logical unit:

| # | Commit | Tests | What's red→green |
|---|---|---|---|
| 1 | `feat(web): list_personas helper` | 12 | dual-scope glob, project-priority dedup, frontmatter tolerance, deterministic hue |
| 2 | `feat(web): list_simulations helper` | 13 | recursive walk, frontmatter parse, newest-first ordering, score averaging, undated-sort-last |
| 3 | `feat(web): FastAPI server + /api routes` | 7 | GET /api/personas, GET /api/simulations, static mount at /, create_app() factory |
| 4 | `feat(web): module entrypoint` | 4 | `python -m persona_studio.web --port --host --no-browser`, subprocess boot smoke |
| 5 | `feat(web): JSX fetch wiring` | +3 static | hifi-library.jsx fetches /api/personas, hifi-results.jsx fetches /api/simulations, library→detail hotspot disabled |
| 6 | `docs(web): Route G + README rewrite` | — | slash menu, bootstrap, docs |

Full project suite: **312 passed** (started at 305).

## What the user will see

After `.venv/bin/pip install -e '.[web]'`:

```bash
python -m persona_studio.web
# or: /persona-studio:studio → "Open in browser (experimental)"
```

Opens http://127.0.0.1:7777/hifi-v2.html. Library screen shows real personas from both project-local and global scopes. Results screen shows the newest past simulation with its Ralph score overlaid on the hero. All other 7 screens render their mock content.

## Key architecture decisions

1. **`create_app()` factory, not a module-level singleton** — the listing helpers read `Path.cwd()` and pytest's `monkeypatch.chdir()` fixtures need a fresh app per test. A cached global would snapshot the wrong directory.

2. **Static fallback preserved in JSX** — `LibraryA` and `ResultsA` both fall through to `window.HF.PEOPLE` / mock criteria when `fetch()` fails or returns empty. Offline viewers and the pre-PR-8 static mode keep working.

3. **No /api/personas/{name} detail endpoint** — clicking a Library card would have landed on the mock Paul Graham detail (a jarring regression). Phase 1 disables that hotspot; Phase 2 ships the real detail page.

4. **Phase 1 stays read-only** — zero write paths, zero LLM calls, zero MCP dependencies. That boundary is what makes this PR reviewable without a threat model review.

5. **127.0.0.1 bind** — no LAN exposure even if private personas are in the local library.

## Key corrections from the Ultraplan refinement

Three draft errors the approved plan caught:

1. `grounding.retriever.find_persona_data_dir` resolves a **single** persona's data dir, not the library. The dual-scope listing logic lives in `commands/studio.md` Route D prose; this PR ports it to Python.
2. `grounding.audit._parse_topic` / `_collect_avatar_quotes` are underscore-private and `audit_transcript()` mutates files. Phase 1 needed its own frontmatter-only parser (read-only).
3. Persona frontmatter is non-uniform across the 4 shipped samples. The response layer supplies defensible fallbacks for every UI-expected field.

Also one UX regression the draft missed: Library card → mock Detail hotspot. Disabled in Phase 1; documented for Phase 2.

## Out of scope (Phases 2-4)

- No persona detail route (`GET /api/personas/{name}`) — Phase 2.
- No Create write path (`POST /api/personas/import`, file upload) — Phase 2.
- No LLM call layer, no live simulation, no SSE — Phase 3.
- No team mode, no WebSocket, no realtime user interruption — Phase 4.
- No auth, no settings write API — the "Guest Mode · Local Only" chrome stays literally true.

## Test plan

- [x] 312/312 tests pass (static + in-process TestClient + subprocess boot)
- [x] `python -m persona_studio.web --port 7781 --no-browser` starts successfully
- [x] `curl http://127.0.0.1:7781/api/personas` returns real data from both scopes
- [x] `curl http://127.0.0.1:7781/api/simulations` returns past transcript metadata
- [x] `curl http://127.0.0.1:7781/hifi-v2.html` serves the static HTML
- [x] Dual-scope project-priority verified with a collision fixture
- [x] Empty `simulations/` directory returns 200 []
- [x] Malformed YAML frontmatter returns 200 with filename-stem fallback
- [x] `pytest -m 'not slow'` excludes subprocess boot tests for tight dev loops
- [x] Stop-hook defense: staged 4 explicit paths in final commit, verified `diff --cached --stat`

## Follow-up

The Phase-2-4 scope is already mapped in the plan. Next PR candidate: the `GET /api/personas/{name}` detail route plus persona refresh write path — enough to make the Avatar detail + Refine screens work on real data.